### PR TITLE
Fixes for workshop (#133)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py4vasp"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = [
     "Martin Schlipf <martin.schlipf@gmail.com>",

--- a/src/py4vasp/__init__.py
+++ b/src/py4vasp/__init__.py
@@ -1,4 +1,5 @@
 from .calculation import Calculation
 from py4vasp._third_party.interactive import set_error_handling
 
+__version__ = "0.3.1"
 set_error_handling("Minimal")

--- a/src/py4vasp/data/dielectric_tensor.py
+++ b/src/py4vasp/data/dielectric_tensor.py
@@ -34,7 +34,8 @@ class DielectricTensor(_base.DataBase):
     def _to_string(self):
         data = self._to_dict()
         return f"""
-MACROSCOPIC STATIC DIELECTRIC TENSOR {_description(data["method"])}
+Macroscopic static dielectric tensor (dimensionless)
+  {_description(data["method"])}
 ------------------------------------------------------
 {_dielectric_tensor_string(data["clamped_ion"], "clamped-ion")}
 {_dielectric_tensor_string(data["relaxed_ion"], "relaxed-ion")}
@@ -55,11 +56,11 @@ def _dielectric_tensor_string(tensor, label):
 
 def _description(method):
     if method == "dft":
-        return "(including local field effects in DFT)"
+        return "including local field effects in DFT"
     elif method == "rpa":
-        return "(including local field effects in RPA (Hartree))"
+        return "including local field effects in RPA (Hartree)"
     elif method == "scf":
-        return "(including local field effects)"
+        return "including local field effects"
     elif method == "nscf":
-        return "(excluding local field effects)"
+        return "excluding local field effects"
     assert False  # unknown method

--- a/src/py4vasp/raw/file.py
+++ b/src/py4vasp/raw/file.py
@@ -348,14 +348,15 @@ class File(AbstractContextManager):
 
     def _read_dielectric_function(self):
         self._raise_error_if_closed()
-        group = f"results/linear_response"
+        group = "results/linear_response"
+        suffix = "_dielectric_function"
         if group not in self._h5f:
             return None
         return RawDielectricFunction(
-            energies=self._h5f[f"{group}/energies_dielectric_function"],
-            density_density=self._h5f[f"{group}/density_density_dielectric_function"],
-            current_current=self._h5f[f"{group}/current_current_dielectric_function"],
-            ion=self._h5f[f"{group}/ion_dielectric_function"],
+            energies=self._h5f[f"{group}/energies{suffix}"],
+            density_density=self._safe_get_key(f"{group}/density_density{suffix}"),
+            current_current=self._safe_get_key(f"{group}/current_current{suffix}"),
+            ion=self._safe_get_key(f"{group}/ion{suffix}"),
         )
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,12 @@ class RawDataFactory:
 
     @staticmethod
     def dielectric_function(selection):
-        return _dielectric_function()
+        if selection == "electron":
+            return _electron_dielectric_function()
+        elif selection == "ion":
+            return _ion_dielectric_function()
+        else:
+            raise exception.NotImplemented()
 
     @staticmethod
     def dielectric_tensor(selection):
@@ -181,14 +186,24 @@ def _number_components(selection):
         raise exception.NotImplemented()
 
 
-def _dielectric_function():
-    shape = (3, axes, axes, number_points, complex_)
+def _electron_dielectric_function():
+    shape = (2, axes, axes, number_points, complex_)
     data = np.linspace(0, 1, np.prod(shape)).reshape(shape)
     return raw.RawDielectricFunction(
         energies=np.linspace(0, 1, number_points),
         density_density=data[0],
         current_current=data[1],
-        ion=data[2],
+        ion=None,
+    )
+
+
+def _ion_dielectric_function():
+    shape = (axes, axes, number_points, complex_)
+    return raw.RawDielectricFunction(
+        energies=np.linspace(0, 1, number_points),
+        density_density=None,
+        current_current=None,
+        ion=np.linspace(0, 1, np.prod(shape)).reshape(shape),
     )
 
 

--- a/tests/data/test_dielectric_tensor.py
+++ b/tests/data/test_dielectric_tensor.py
@@ -86,7 +86,8 @@ def test_print_dft_tensor(nscf_tensor, format_):
 
 def check_print_dielectric_tensor(actual, expected_description):
     reference = f"""
-MACROSCOPIC STATIC DIELECTRIC TENSOR ({expected_description})
+Macroscopic static dielectric tensor (dimensionless)
+  {expected_description}
 ------------------------------------------------------
                       clamped-ion
           0.000000     1.000000     2.000000

--- a/tests/data/test_repr.py
+++ b/tests/data/test_repr.py
@@ -8,7 +8,7 @@ def test_repr(raw_data):
     tests = {
         Band: "multiple",
         Density: "Fe3O4 collinear",
-        DielectricFunction: None,
+        DielectricFunction: "electron",
         DielectricTensor: "dft",
         Dos: "Fe3O4",
         ElasticModulus: None,

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,20 @@
+import pathlib
+import py4vasp
+
+
+def test_version():
+    version = get_version_from_toml_file()
+    assert version == py4vasp.__version__
+
+
+def get_version_from_toml_file():
+    root_dir = pathlib.Path(__file__).parent.parent
+    with open(root_dir / "pyproject.toml") as toml_file:
+        return version_from_lines(toml_file)
+
+
+def version_from_lines(toml_file):
+    for line in toml_file:
+        parts = line.split("=")
+        if parts[0].strip() == "version":
+            return parts[1].strip().strip('"')


### PR DESCRIPTION
* Read only the parts of dielectric function that are actually written
* Fix dielectric function for ionic and electronic part
* Avoid Latex in figure caption
* Write that dielectric tensor is dimensionless
* Expose version tag via py4vasp.__version__