### PR TITLE
Fix nglview dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2987,4 +2987,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "2e635ad1eca25e96438ffb1088c3e69b9a5df4e483973b86367ec5a0c9f6633d"
+content-hash = "368415b8aa3008b564725eeeee7c8f1d7cf34c8aebc18d0b7517a07e5ded0a09"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ numpy = ">=1.23.0"
 h5py = ">=3.7.0"
 pandas = ">=1.4.3"
 nglview = ">=3.0.3"
+# nglview is not compatible with recent ipywidgets, so we need to set the constraint here
+# this should be removed again, once this is fixed in nglview and the broken version of
+# nglview should be excluded
+ipywidgets = "^7.7"
 ase = ">=3.22.1"
 mdtraj = ">=1.9.6"
 mrcfile = ">=1.3.0"


### PR DESCRIPTION
nglview does not work with recent ipywidget versions. Until nglview releases an update to address this, we exclude newer version of ipywidgets to avoid a broken nglview installation.