### PR TITLE
Update pyproject.toml - add mdtraj dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ mrcfile = ">=1.3.0"
 plotly = ">=5.9.0"
 kaleido = ">=0.2.1,<0.2.1.post1 || >0.2.1.post1"
 ipython = ">=8.12"
+mdtraj = ">=1.9.9"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.1.2"


### PR DESCRIPTION
Hi folks, 

I recently installed py4vasp and it was missing 'mdtraj' package:

`File ~/.local/lib/python3.10/site-packages/py4vasp/_data/structure.py:8
      5 from dataclasses import dataclass
      7 import ase.io
----> 8 import mdtraj
      9 import numpy as np
     10 from IPython.lib.pretty import pretty

ModuleNotFoundError: No module named 'mdtraj'`

It should be listed in py4vasp's dependencies, right? Version 1.9.9 worked fine for me, so I put '>=1.9.9' version specifier into the PR. Feel free to edit the PR if you think an older version would be better.

Cheers,
Jan