### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ will test whether everything worked
 ~~~shell
 conda create --name py4vasp-env python=3.8
 git clone git@github.com:vasp-dev/py4vasp.git
+conda activate py4vasp-env
 pip install poetry
 poetry install
 conda install -c conda-forge mdtraj

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git clone git@github.com:vasp-dev/py4vasp.git
 conda activate py4vasp-env
 pip install poetry
 poetry install
-conda install -c conda-forge mdtraj
+conda install conda-forge::mdtraj
 poetry run pytest
 ~~~
 Note that this will install py4vasp into the conda environment. This isolates the code

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git clone git@github.com:vasp-dev/py4vasp.git
 conda activate py4vasp-env
 pip install poetry
 poetry install
-conda install conda-forge::mdtraj
+conda install -c conda-forge mdtraj
 poetry run pytest
 ~~~
 Note that this will install py4vasp into the conda environment. This isolates the code


### PR DESCRIPTION
To install everything the created conda environment, the conda environment needs to be activated. I have added `conda activate py4vasp-env` line in the installation step.

I faced error while installing `mdtraj` using `conda install -c conda-forge mdtraj`. However, it is resolved by using `conda install conda-forge::mdtraj` which I think is the new way of getting `mdtraj` from conda-forge. I have updated the command to install mdtraj.