### PR TITLE
Allow for template sources in the HDF5 file

### DIFF
--- a/src/py4vasp/_raw/access.py
+++ b/src/py4vasp/_raw/access.py
@@ -10,6 +10,7 @@ import h5py
 from py4vasp import exception, raw
 from py4vasp._raw.definition import DEFAULT_FILE, DEFAULT_SOURCE, schema
 from py4vasp._raw.schema import Length, Link, Sequence, error_message
+from py4vasp._util import convert
 
 
 @contextlib.contextmanager
@@ -120,11 +121,7 @@ class _State:
             raise exception.OutdatedVaspVersion(message)
 
     def _get_datasets(self, h5f, data):
-        valid_indices = (
-            self._get_dataset(h5f, data.valid_indices)
-            if isinstance(data, Sequence)
-            else None
-        )
+        valid_indices = self._get_valid_indices(h5f, data)
         result = {
             field.name: self._get_dataset(h5f, getattr(data, field.name), valid_indices)
             for field in dataclasses.fields(data)
@@ -133,6 +130,15 @@ class _State:
         if valid_indices is not None:
             result["valid_indices"] = valid_indices
         return result
+
+    def _get_valid_indices(self, h5f, data):
+        if not isinstance(data, Sequence):
+            return None
+        valid_indices = self._get_dataset(h5f, data.valid_indices)
+        if valid_indices.ndim == 0:
+            return range(valid_indices)
+        else:
+            return valid_indices
 
     def _get_dataset(self, h5f, key, valid_indices=None):
         if key is None:
@@ -143,13 +149,17 @@ class _State:
             dataset = h5f.get(key.dataset)
             return len(dataset) if dataset else None
         if key.format(0) == key or valid_indices is None:
-            return self._parse_dataset(h5f.get(key))
-        # convert to Fortran index
-        get_dataset = lambda i: h5f.get(key.format(i + 1))
-        return [self._parse_dataset(get_dataset(i)) for i in range(valid_indices)]
+            return self._parse_dataset(h5f, key)
+        return [self._parse_dataset(h5f, key, index) for index in valid_indices]
 
-    def _parse_dataset(self, dataset):
-        result = raw.VaspData(dataset)
+    def _parse_dataset(self, h5f, key, index=None):
+        if index is not None:
+            if isinstance(index, int):
+                index = index + 1  # convert to Fortran index
+            else:
+                index = convert.text_to_string(index)
+            key = key.format(index)
+        result = raw.VaspData(h5f.get(key))
         if _is_scalar(result):
             result = result[()]
         return result

--- a/src/py4vasp/_raw/access.py
+++ b/src/py4vasp/_raw/access.py
@@ -9,7 +9,7 @@ import h5py
 
 from py4vasp import exception, raw
 from py4vasp._raw.definition import DEFAULT_FILE, DEFAULT_SOURCE, schema
-from py4vasp._raw.schema import Length, Link, Sequence, error_message
+from py4vasp._raw.schema import Length, Link, Mapping, error_message
 from py4vasp._util import convert
 
 
@@ -132,13 +132,13 @@ class _State:
         return result
 
     def _get_valid_indices(self, h5f, data):
-        if not isinstance(data, Sequence):
+        if not isinstance(data, Mapping):
             return None
         valid_indices = self._get_dataset(h5f, data.valid_indices)
         if valid_indices.ndim == 0:
             return range(valid_indices)
         else:
-            return valid_indices
+            return tuple(convert.text_to_string(index) for index in valid_indices)
 
     def _get_dataset(self, h5f, key, valid_indices=None):
         if key is None:
@@ -156,8 +156,6 @@ class _State:
         if index is not None:
             if isinstance(index, int):
                 index = index + 1  # convert to Fortran index
-            else:
-                index = convert.text_to_string(index)
             key = key.format(index)
         result = raw.VaspData(h5f.get(key))
         if _is_scalar(result):

--- a/src/py4vasp/_raw/schema.py
+++ b/src/py4vasp/_raw/schema.py
@@ -177,7 +177,7 @@ class Sequence(abc.Sequence):
             for key, value in dataclasses.asdict(self).items()
             if key != "valid_indices"
         }
-        return dataclasses.replace(self, valid_indices=1, **elements)
+        return dataclasses.replace(self, valid_indices=[index], **elements)
 
 
 def _parse_version(version):

--- a/src/py4vasp/_raw/schema.py
+++ b/src/py4vasp/_raw/schema.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import textwrap
+from collections import abc
 
 import numpy as np
 
@@ -157,6 +158,22 @@ class Link:
 class Length:
     dataset: str
     __str__ = lambda self: f"length({self.dataset})"
+
+
+@dataclasses.dataclass
+class Sequence(abc.Sequence):
+    size: int
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, index):
+        elements = {
+            key: value[index] if isinstance(value, list) else value
+            for key, value in dataclasses.asdict(self).items()
+            if key != "size"
+        }
+        return dataclasses.replace(self, size=1, **elements)
 
 
 def _parse_version(version):

--- a/src/py4vasp/_raw/schema.py
+++ b/src/py4vasp/_raw/schema.py
@@ -174,11 +174,18 @@ class Mapping(abc.Mapping):
         index = self.valid_indices.index(key)
         elements = {
             key: value[index] if isinstance(value, list) else value
-            for key, value in dataclasses.asdict(self).items()
+            for key, value in self._as_dict().items()
             if key != "valid_indices"
         }
         return dataclasses.replace(self, valid_indices=[key], **elements)
 
+    def _as_dict(self):
+        # shallow copy of dataclass to dictionary
+        return {
+            field.name: getattr(self, field.name)
+            for field in dataclasses.fields(self)
+            if getattr(self, field.name) is not None
+        }
 
 def _parse_version(version):
     return f"""version:

--- a/src/py4vasp/_raw/schema.py
+++ b/src/py4vasp/_raw/schema.py
@@ -161,23 +161,23 @@ class Length:
 
 
 @dataclasses.dataclass
-class Sequence(abc.Sequence):
-    valid_indices: int or Sequence
+class Mapping(abc.Mapping):
+    valid_indices: Sequence
 
     def __len__(self):
-        valid_indices = np.array(self.valid_indices)
-        if valid_indices.ndim == 0:
-            return valid_indices
-        else:
-            return len(valid_indices)
+        return len(self.valid_indices)
 
-    def __getitem__(self, index):
+    def __iter__(self):
+        return iter(self.valid_indices)
+
+    def __getitem__(self, key):
+        index = self.valid_indices.index(key)
         elements = {
             key: value[index] if isinstance(value, list) else value
             for key, value in dataclasses.asdict(self).items()
             if key != "valid_indices"
         }
-        return dataclasses.replace(self, valid_indices=[index], **elements)
+        return dataclasses.replace(self, valid_indices=[key], **elements)
 
 
 def _parse_version(version):

--- a/src/py4vasp/_raw/schema.py
+++ b/src/py4vasp/_raw/schema.py
@@ -187,6 +187,7 @@ class Mapping(abc.Mapping):
             if getattr(self, field.name) is not None
         }
 
+
 def _parse_version(version):
     return f"""version:
     major: {version.major}

--- a/src/py4vasp/_raw/schema.py
+++ b/src/py4vasp/_raw/schema.py
@@ -162,18 +162,22 @@ class Length:
 
 @dataclasses.dataclass
 class Sequence(abc.Sequence):
-    size: int
+    valid_indices: int or Sequence
 
     def __len__(self):
-        return self.size
+        valid_indices = np.array(self.valid_indices)
+        if valid_indices.ndim == 0:
+            return valid_indices
+        else:
+            return len(valid_indices)
 
     def __getitem__(self, index):
         elements = {
             key: value[index] if isinstance(value, list) else value
             for key, value in dataclasses.asdict(self).items()
-            if key != "size"
+            if key != "valid_indices"
         }
-        return dataclasses.replace(self, size=1, **elements)
+        return dataclasses.replace(self, valid_indices=1, **elements)
 
 
 def _parse_version(version):

--- a/tests/raw/conftest.py
+++ b/tests/raw/conftest.py
@@ -33,6 +33,9 @@ def complex_schema():
     sequence = Sequence(
         valid_indices="foo_sequence", common="common_data", variable="variable_data{}"
     )
+    list_ = Sequence(
+        valid_indices="list_sequence", common="common", variable="variable_data_{}"
+    )
     first = Complex(
         Link("optional_argument", "default"),
         Link("with_link", "default"),
@@ -42,7 +45,7 @@ def complex_schema():
     second = Complex(
         Link("optional_argument", name),
         Link("with_link", "default"),
-        Link("sequence", "default"),
+        Link("sequence", "my_list"),
     )
     schema = Schema(VERSION)
     schema.add(Simple, file=filename, **as_dict(simple))
@@ -52,6 +55,7 @@ def complex_schema():
     schema.add(WithLink, required=version, **as_dict(pointer))
     schema.add(WithLength, alias="alias_name", **as_dict(length))
     schema.add(Sequence, **as_dict(sequence))
+    schema.add(Sequence, name="my_list", **as_dict(list_))
     schema.add(Complex, **as_dict(first))
     schema.add(Complex, name=name, **as_dict(second))
     other_file_source = Source(simple, file=filename)
@@ -63,7 +67,7 @@ def complex_schema():
         "optional_argument": {"default": Source(both), name: Source(only_mandatory)},
         "with_link": {"default": Source(pointer, required=version)},
         "with_length": {"default": Source(length), "alias_name": alias_source},
-        "sequence": {"default": Source(sequence)},
+        "sequence": {"default": Source(sequence), "my_list": Source(list_)},
         "complex": {"default": Source(first), name: Source(second)},
     }
     return schema, reference

--- a/tests/raw/conftest.py
+++ b/tests/raw/conftest.py
@@ -6,8 +6,8 @@ import pytest
 from util import (
     VERSION,
     Complex,
+    Mapping,
     OptionalArgument,
-    Sequence,
     Simple,
     WithLength,
     WithLink,
@@ -30,22 +30,22 @@ def complex_schema():
     pointer = WithLink("baz_dataset", Link("simple", "default"))
     version = raw.Version(1, 2, 3)
     length = WithLength(Length("dataset"))
-    sequence = Sequence(
-        valid_indices="foo_sequence", common="common_data", variable="variable_data{}"
+    mapping = Mapping(
+        valid_indices="foo_mapping", common="common_data", variable="variable_data{}"
     )
-    list_ = Sequence(
-        valid_indices="list_sequence", common="common", variable="variable_data_{}"
+    list_ = Mapping(
+        valid_indices="list_mapping", common="common", variable="variable_data_{}"
     )
     first = Complex(
         Link("optional_argument", "default"),
         Link("with_link", "default"),
-        Link("sequence", "default"),
+        Link("mapping", "default"),
         Link("with_length", "default"),
     )
     second = Complex(
         Link("optional_argument", name),
         Link("with_link", "default"),
-        Link("sequence", "my_list"),
+        Link("mapping", "my_list"),
     )
     schema = Schema(VERSION)
     schema.add(Simple, file=filename, **as_dict(simple))
@@ -54,8 +54,8 @@ def complex_schema():
     schema.add(OptionalArgument, **as_dict(both))
     schema.add(WithLink, required=version, **as_dict(pointer))
     schema.add(WithLength, alias="alias_name", **as_dict(length))
-    schema.add(Sequence, **as_dict(sequence))
-    schema.add(Sequence, name="my_list", **as_dict(list_))
+    schema.add(Mapping, **as_dict(mapping))
+    schema.add(Mapping, name="my_list", **as_dict(list_))
     schema.add(Complex, **as_dict(first))
     schema.add(Complex, name=name, **as_dict(second))
     other_file_source = Source(simple, file=filename)
@@ -67,7 +67,7 @@ def complex_schema():
         "optional_argument": {"default": Source(both), name: Source(only_mandatory)},
         "with_link": {"default": Source(pointer, required=version)},
         "with_length": {"default": Source(length), "alias_name": alias_source},
-        "sequence": {"default": Source(sequence), "my_list": Source(list_)},
+        "mapping": {"default": Source(mapping), "my_list": Source(list_)},
         "complex": {"default": Source(first), name: Source(second)},
     }
     return schema, reference

--- a/tests/raw/conftest.py
+++ b/tests/raw/conftest.py
@@ -29,7 +29,7 @@ def complex_schema():
     version = raw.Version(1, 2, 3)
     length = WithLength(Length("dataset"))
     sequence = Sequence(
-        size="foo_sequence", common="common_data", variable="variable_data{}"
+        valid_indices="foo_sequence", common="common_data", variable="variable_data{}"
     )
     first = Complex(
         Link("optional_argument", "default"),
@@ -52,7 +52,10 @@ def complex_schema():
     other_file_source = Source(simple, file=filename)
     data_factory_source = Source(None, file=filename, data_factory=make_data)
     schema.add(
-        Sequence, size=sequence.size, common=sequence.common, variable=sequence.variable
+        Sequence,
+        valid_indices=sequence.valid_indices,
+        common=sequence.common,
+        variable=sequence.variable,
     )
     schema.add(
         Complex,

--- a/tests/raw/test_access.py
+++ b/tests/raw/test_access.py
@@ -107,10 +107,10 @@ def test_access_sequence(mock_access):
     mock_file, sources = mock_access
     source = sources[quantity]["default"]
     with raw.access(quantity) as sequence:
-        assert sequence.size == len(sequence) == EXAMPLE_SCALAR
+        assert sequence.valid_indices == len(sequence) == EXAMPLE_SCALAR
         check_single_file_access(mock_file, DEFAULT_FILE, source)
         for i, element in enumerate(sequence):
-            assert element.size == len(element) == 1
+            assert element.valid_indices == len(element) == 1
             check_data(element.common, source.data.common)
             variable = source.data.variable.format(i + 1)  # convert to Fortran index
             check_data(element.variable, variable)

--- a/tests/raw/test_schema.py
+++ b/tests/raw/test_schema.py
@@ -1,7 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import pytest
-from util import VERSION, OptionalArgument, Sequence, Simple, WithLength, WithLink
+from util import VERSION, Mapping, OptionalArgument, Simple, WithLength, WithLink
 
 from py4vasp import exception, raw
 from py4vasp._raw.schema import Length, Link, Schema, Source
@@ -107,16 +107,16 @@ def test_custom_data_source():
     assert remove_version(schema.sources) == reference
 
 
-def test_sequence():
-    sequence = Sequence("valid_indices", "common_data", "variable_data{}")
+def test_mapping():
+    mapping = Mapping("valid_indices", "common_data", "variable_data{}")
     schema = Schema(VERSION)
     schema.add(
-        Sequence,
-        valid_indices=sequence.valid_indices,
-        common=sequence.common,
-        variable=sequence.variable,
+        Mapping,
+        valid_indices=mapping.valid_indices,
+        common=mapping.common,
+        variable=mapping.variable,
     )
-    reference = {"sequence": {"default": Source(sequence)}}
+    reference = {"mapping": {"default": Source(mapping)}}
     assert remove_version(schema.sources) == reference
 
 
@@ -172,13 +172,13 @@ with_length:
         num_data: length(dataset)
     alias_name: *with_length-default
 
-sequence:
-    default:  &sequence-default
-        valid_indices: foo_sequence
+mapping:
+    default:  &mapping-default
+        valid_indices: foo_mapping
         common: common_data
         variable: variable_data{}
-    my_list:  &sequence-my_list
-        valid_indices: list_sequence
+    my_list:  &mapping-my_list
+        valid_indices: list_mapping
         common: common
         variable: variable_data_{}
 
@@ -186,12 +186,12 @@ complex:
     default:  &complex-default
         opt: *optional_argument-default
         link: *with_link-default
-        sequence: *sequence-default
+        mapping: *mapping-default
         length: *with_length-default
     mandatory:  &complex-mandatory
         opt: *optional_argument-mandatory
         link: *with_link-default
-        sequence: *sequence-my_list
+        mapping: *mapping-my_list
 """
     assert str(schema) == reference
 

--- a/tests/raw/test_schema.py
+++ b/tests/raw/test_schema.py
@@ -108,10 +108,13 @@ def test_custom_data_source():
 
 
 def test_sequence():
-    sequence = Sequence("size", "common_data", "variable_data{}")
+    sequence = Sequence("valid_indices", "common_data", "variable_data{}")
     schema = Schema(VERSION)
     schema.add(
-        Sequence, size=sequence.size, common=sequence.common, variable=sequence.variable
+        Sequence,
+        valid_indices=sequence.valid_indices,
+        common=sequence.common,
+        variable=sequence.variable,
     )
     reference = {"sequence": {"default": Source(sequence)}}
     assert remove_version(schema.sources) == reference
@@ -171,7 +174,7 @@ with_length:
 
 sequence:
     default:  &sequence-default
-        size: foo_sequence
+        valid_indices: foo_sequence
         common: common_data
         variable: variable_data{}
 

--- a/tests/raw/test_schema.py
+++ b/tests/raw/test_schema.py
@@ -177,6 +177,10 @@ sequence:
         valid_indices: foo_sequence
         common: common_data
         variable: variable_data{}
+    my_list:  &sequence-my_list
+        valid_indices: list_sequence
+        common: common
+        variable: variable_data_{}
 
 complex:
     default:  &complex-default
@@ -187,7 +191,7 @@ complex:
     mandatory:  &complex-mandatory
         opt: *optional_argument-mandatory
         link: *with_link-default
-        sequence: *sequence-default
+        sequence: *sequence-my_list
 """
     assert str(schema) == reference
 

--- a/tests/raw/test_schema.py
+++ b/tests/raw/test_schema.py
@@ -1,7 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import pytest
-from util import VERSION, OptionalArgument, Simple, WithLength, WithLink
+from util import VERSION, OptionalArgument, Sequence, Simple, WithLength, WithLink
 
 from py4vasp import exception, raw
 from py4vasp._raw.schema import Length, Link, Schema, Source
@@ -107,6 +107,16 @@ def test_custom_data_source():
     assert remove_version(schema.sources) == reference
 
 
+def test_sequence():
+    sequence = Sequence("size", "common_data", "variable_data{}")
+    schema = Schema(VERSION)
+    schema.add(
+        Sequence, size=sequence.size, common=sequence.common, variable=sequence.variable
+    )
+    reference = {"sequence": {"default": Source(sequence)}}
+    assert remove_version(schema.sources) == reference
+
+
 def remove_version(sources):
     version = sources.pop("version")
     assert version == {"default": Source(VERSION)}
@@ -159,14 +169,22 @@ with_length:
         num_data: length(dataset)
     alias_name: *with_length-default
 
+sequence:
+    default:  &sequence-default
+        size: foo_sequence
+        common: common_data
+        variable: variable_data{}
+
 complex:
     default:  &complex-default
         opt: *optional_argument-default
         link: *with_link-default
+        sequence: *sequence-default
         length: *with_length-default
     mandatory:  &complex-mandatory
         opt: *optional_argument-mandatory
         link: *with_link-default
+        sequence: *sequence-default
 """
     assert str(schema) == reference
 

--- a/tests/raw/util.py
+++ b/tests/raw/util.py
@@ -32,7 +32,7 @@ class WithLength:
 
 
 @dataclasses.dataclass
-class Sequence(schema.Sequence):
+class Mapping(schema.Mapping):
     common: str
     variable: str
 
@@ -41,5 +41,5 @@ class Sequence(schema.Sequence):
 class Complex:
     opt: OptionalArgument
     link: WithLink
-    sequence: Sequence
+    mapping: Mapping
     length: WithLength = None

--- a/tests/raw/util.py
+++ b/tests/raw/util.py
@@ -3,6 +3,7 @@
 import dataclasses
 
 from py4vasp import raw
+from py4vasp._raw import schema
 
 VERSION = raw.Version("major_dataset", "minor_dataset", "patch_dataset")
 
@@ -31,7 +32,14 @@ class WithLength:
 
 
 @dataclasses.dataclass
+class Sequence(schema.Sequence):
+    common: str
+    variable: str
+
+
+@dataclasses.dataclass
 class Complex:
     opt: OptionalArgument
     link: WithLink
+    sequence: Sequence
     length: WithLength = None


### PR DESCRIPTION
I included this from #174 and extended it to not only allow for integer sizes but also for lists of strings.