### PR TITLE
Fix broken tests

### DIFF
--- a/tests/raw/test_access.py
+++ b/tests/raw/test_access.py
@@ -55,7 +55,7 @@ def mock_read_result(key):
 def check_data(actual, key):
     mock = mock_read_result(key)
     if mock.ndim == 0:
-        mock.__array__.assert_called_once_with()
+        mock.__array__.assert_called_once()
         assert actual == EXAMPLE_SCALAR
     else:
         assert isinstance(actual, raw.VaspData)

--- a/tests/raw/test_data.py
+++ b/tests/raw/test_data.py
@@ -142,7 +142,7 @@ def test_scalar_data():
     reference = 1
     mock = MagicMock()
     mock.ndim = 0
-    mock.__array__ = lambda: np.array(reference)
+    mock.__array__ = lambda *args, **kwargs: np.array(reference)
     vasp = VaspData(mock)
     assert vasp == reference
     assert np.array(vasp) == reference


### PR DESCRIPTION
It seems that np.array may pass on copy=True argument so that the check assert_called_once_with fails