### PR TITLE
Feat: Contour plot theming and Visualizer refactoring

### DIFF
--- a/src/py4vasp/_calculation/current_density.py
+++ b/src/py4vasp/_calculation/current_density.py
@@ -99,8 +99,8 @@ current density:
         grid_scalar = np.linalg.norm(grid_vector, axis=-1)
 
         # set up Visualizer
-        visualizer = Visualizer(self._structure, {}, (lambda _: label))
-        return visualizer.to_contour(grid_scalar, a, b, c, normal, supercell)
+        visualizer = Visualizer(self._structure, (lambda _: label))
+        return visualizer.to_contour_from_data(grid_scalar, a, b, c, normal, supercell, isolevels=False)
 
     @base.data_access
     @documentation.format(plane=slicing.PLANE, parameters=_COMMON_PARAMETERS)
@@ -143,5 +143,5 @@ current density:
         sel_data = np.moveaxis(data, -1, 0)
 
         # set up Visualizer
-        visualizer = Visualizer(self._structure, {}, (lambda _: label))
-        return visualizer.to_quiver(sel_data, a, b, c, normal, supercell)
+        visualizer = Visualizer(self._structure, (lambda _: label))
+        return visualizer.to_quiver_from_data(sel_data, a, b, c, normal, supercell)

--- a/src/py4vasp/_calculation/current_density.py
+++ b/src/py4vasp/_calculation/current_density.py
@@ -7,7 +7,7 @@ from py4vasp import exception
 from py4vasp._calculation import _stoichiometry, base, structure
 from py4vasp._third_party import graph
 from py4vasp._util import documentation, import_, slicing
-from py4vasp._util.density import Visualizer
+from py4vasp._util.density import SliceArguments, Visualizer
 
 pretty = import_.optional("IPython.lib.pretty")
 
@@ -99,9 +99,11 @@ current density:
         grid_scalar = np.linalg.norm(grid_vector, axis=-1)
 
         # set up Visualizer
-        visualizer = Visualizer(self._structure, (lambda _: label))
-        return visualizer.to_contour_from_data(
-            grid_scalar, a, b, c, normal, supercell, isolevels=False
+        visualizer = Visualizer(self._structure)
+        return visualizer.to_contour(
+            {label: grid_scalar},
+            SliceArguments(a, b, c, normal, supercell),
+            isolevels=False,
         )
 
     @base.data_access
@@ -145,5 +147,7 @@ current density:
         sel_data = np.moveaxis(data, -1, 0)
 
         # set up Visualizer
-        visualizer = Visualizer(self._structure, (lambda _: label))
-        return visualizer.to_quiver_from_data(sel_data, a, b, c, normal, supercell)
+        visualizer = Visualizer(self._structure)
+        return visualizer.to_quiver(
+            {label: sel_data}, SliceArguments(a, b, c, normal, supercell)
+        )

--- a/src/py4vasp/_calculation/current_density.py
+++ b/src/py4vasp/_calculation/current_density.py
@@ -100,7 +100,9 @@ current density:
 
         # set up Visualizer
         visualizer = Visualizer(self._structure, (lambda _: label))
-        return visualizer.to_contour_from_data(grid_scalar, a, b, c, normal, supercell, isolevels=False)
+        return visualizer.to_contour_from_data(
+            grid_scalar, a, b, c, normal, supercell, isolevels=False
+        )
 
     @base.data_access
     @documentation.format(plane=slicing.PLANE, parameters=_COMMON_PARAMETERS)

--- a/src/py4vasp/_calculation/current_density.py
+++ b/src/py4vasp/_calculation/current_density.py
@@ -7,6 +7,7 @@ from py4vasp import exception
 from py4vasp._calculation import _stoichiometry, base, structure
 from py4vasp._third_party import graph
 from py4vasp._util import documentation, import_, slicing
+from py4vasp._util.density import Visualizer
 
 pretty = import_.optional("IPython.lib.pretty")
 
@@ -94,15 +95,12 @@ current density:
 
         >>> calculation.current_density.to_contour(a=0.3, normal="x")
         """
-        cut, fraction = slicing.get_cut(a, b, c)
-        plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
         label, grid_vector = self._read_current_density(selection)
         grid_scalar = np.linalg.norm(grid_vector, axis=-1)
-        grid_scalar = slicing.grid_scalar(grid_scalar, plane, fraction)
-        contour_plot = graph.Contour(grid_scalar, plane, label)
-        if supercell is not None:
-            contour_plot.supercell = np.ones(2, dtype=np.int_) * supercell
-        return graph.Graph([contour_plot])
+
+        # set up Visualizer
+        visualizer = Visualizer(self._structure, {}, (lambda _: label))
+        return visualizer.to_contour(grid_scalar, a, b, c, normal, supercell)
 
     @base.data_access
     @documentation.format(plane=slicing.PLANE, parameters=_COMMON_PARAMETERS)
@@ -140,11 +138,10 @@ current density:
 
         >>> calculation.current_density.to_quiver(a=0.3, normal="x")
         """
-        cut, fraction = slicing.get_cut(a, b, c)
-        plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
+        # set up data
         label, data = self._read_current_density(selection)
-        sliced_data = slicing.grid_vector(np.moveaxis(data, -1, 0), plane, fraction)
-        quiver_plot = graph.Contour(sliced_data, plane, label)
-        if supercell is not None:
-            quiver_plot.supercell = np.ones(2, dtype=np.int_) * supercell
-        return graph.Graph([quiver_plot])
+        sel_data = np.moveaxis(data, -1, 0)
+
+        # set up Visualizer
+        visualizer = Visualizer(self._structure, {}, (lambda _: label))
+        return visualizer.to_quiver(sel_data, a, b, c, normal, supercell)

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -362,7 +362,9 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
             self._structure,
             (lambda sel: (self._label(selector.label(sel)) or "charge")),
         )
-        contour = visualizer.to_contour_from_mapping(selector, selections, a, b, c, normal, supercell)
+        contour = visualizer.to_contour_from_mapping(
+            selector, selections, a, b, c, normal, supercell
+        )
         return contour
 
     @base.data_access

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -225,19 +225,23 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
         # build selector
         map_ = self._create_map()
         selector = index.Selector({0: map_}, self._raw_data.charge)
-        
+
         # define selections
         selection = selection or _INTERNAL
         tree = select.Tree.from_selection(selection)
         selections = list(self._filter_noncollinear_magnetization_from_selections(tree))
 
         # set up visualizer
-        visualizer = Visualizer(self._structure, selector, (lambda sel: self._label(selector.label(sel))))
+        visualizer = Visualizer(
+            self._structure, selector, (lambda sel: self._label(selector.label(sel)))
+        )
         viewer = visualizer.to_view(selections, supercell=supercell)
 
         # adjust viewer
         for scalar, sel in zip(viewer.grid_scalars, selections):
-            isosurfaces = self._grid_quantity_properties(selector, sel, map_, user_options)
+            isosurfaces = self._grid_quantity_properties(
+                selector, sel, map_, user_options
+            )
             scalar.isosurfaces = isosurfaces
         return viewer
 
@@ -274,7 +278,7 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
     def _grid_quantity_properties(self, selector, selection, map_, user_options):
         component_label = selector.label(selection)
         component = map_.get(component_label, -1)
-        isosurfaces=self._isosurfaces(component, **user_options)
+        isosurfaces = self._isosurfaces(component, **user_options)
         return isosurfaces
 
     def _label(self, component_label):
@@ -352,9 +356,13 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
         selection = selection or _INTERNAL
         tree = select.Tree.from_selection(selection)
         selections = list(self._filter_noncollinear_magnetization_from_selections(tree))
-        
+
         # set up visualizer
-        visualizer = Visualizer(self._structure, selector, (lambda sel: (self._label(selector.label(sel)) or "charge")))
+        visualizer = Visualizer(
+            self._structure,
+            selector,
+            (lambda sel: (self._label(selector.label(sel)) or "charge")),
+        )
         contour = visualizer.to_contour(selections, a, b, c, normal, supercell)
         return contour
 
@@ -398,12 +406,18 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
         >>> calculation.density.to_quiver("kinetic_energy", a=0.3, normal="x")
         """
         # set up data
-        if self.is_collinear(): data = self._raw_data.charge[1].T
-        else: data = self.to_numpy()[1:]
+        if self.is_collinear():
+            data = self._raw_data.charge[1].T
+        else:
+            data = self.to_numpy()[1:]
 
         # set up visualizer
-        visualizer = Visualizer(self._structure, {}, (lambda _: self._selection or "magnetization"))
-        return visualizer.to_quiver(data, a=a, b=b, c=c, normal=normal, supercell=supercell)
+        visualizer = Visualizer(
+            self._structure, {}, (lambda _: self._selection or "magnetization")
+        )
+        return visualizer.to_quiver(
+            data, a=a, b=b, c=c, normal=normal, supercell=supercell
+        )
 
     @base.data_access
     def is_nonpolarized(self):

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -6,7 +6,7 @@ from py4vasp import _config, exception
 from py4vasp._calculation import _stoichiometry, base, structure
 from py4vasp._third_party import graph, view
 from py4vasp._util import documentation, import_, index, select, slicing
-from py4vasp._util.density import Visualizer
+from py4vasp._util.density import SliceArguments, Visualizer
 
 pretty = import_.optional("IPython.lib.pretty")
 
@@ -232,10 +232,12 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
         selections = list(self._filter_noncollinear_magnetization_from_selections(tree))
 
         # set up visualizer
-        visualizer = Visualizer(
-            self._structure, (lambda sel: self._label(selector.label(sel)))
-        )
-        viewer = visualizer.to_view(selector, selections, supercell=supercell)
+        visualizer = Visualizer(self._structure)
+        dataDict = {
+            self._label(selector.label(sel)): (selector[sel].T)[np.newaxis]
+            for sel in selections
+        }
+        viewer = visualizer.to_view(dataDict, supercell=supercell)
 
         # adjust viewer
         for scalar, sel in zip(viewer.grid_scalars, selections):
@@ -360,10 +362,13 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
         # set up visualizer
         visualizer = Visualizer(
             self._structure,
-            (lambda sel: (self._label(selector.label(sel)) or "charge")),
         )
-        contour = visualizer.to_contour_from_mapping(
-            selector, selections, a, b, c, normal, supercell
+        dataDict = {
+            (self._label(selector.label(sel)) or "charge"): selector[sel].T
+            for sel in selections
+        }
+        contour = visualizer.to_contour(
+            dataDict, SliceArguments(a, b, c, normal, supercell)
         )
         return contour
 
@@ -413,11 +418,10 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
             data = self.to_numpy()[1:]
 
         # set up visualizer
-        visualizer = Visualizer(
-            self._structure, (lambda _: self._selection or "magnetization")
-        )
-        return visualizer.to_quiver_from_data(
-            data, a=a, b=b, c=c, normal=normal, supercell=supercell
+        visualizer = Visualizer(self._structure)
+        dataDict = {(self._selection or "magnetization"): data}
+        return visualizer.to_quiver(
+            dataDict, SliceArguments(a, b, c, normal, supercell)
         )
 
     @base.data_access

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -233,9 +233,9 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
 
         # set up visualizer
         visualizer = Visualizer(
-            self._structure, selector, (lambda sel: self._label(selector.label(sel)))
+            self._structure, (lambda sel: self._label(selector.label(sel)))
         )
-        viewer = visualizer.to_view(selections, supercell=supercell)
+        viewer = visualizer.to_view(selector, selections, supercell=supercell)
 
         # adjust viewer
         for scalar, sel in zip(viewer.grid_scalars, selections):
@@ -360,10 +360,9 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
         # set up visualizer
         visualizer = Visualizer(
             self._structure,
-            selector,
             (lambda sel: (self._label(selector.label(sel)) or "charge")),
         )
-        contour = visualizer.to_contour(selections, a, b, c, normal, supercell)
+        contour = visualizer.to_contour_from_mapping(selector, selections, a, b, c, normal, supercell)
         return contour
 
     @base.data_access
@@ -413,9 +412,9 @@ class Density(base.Refinery, structure.Mixin, view.Mixin):
 
         # set up visualizer
         visualizer = Visualizer(
-            self._structure, {}, (lambda _: self._selection or "magnetization")
+            self._structure, (lambda _: self._selection or "magnetization")
         )
-        return visualizer.to_quiver(
+        return visualizer.to_quiver_from_data(
             data, a=a, b=b, c=c, normal=normal, supercell=supercell
         )
 

--- a/src/py4vasp/_calculation/exciton_density.py
+++ b/src/py4vasp/_calculation/exciton_density.py
@@ -107,9 +107,7 @@ class ExcitonDensity(base.Refinery, structure.Mixin, view.Mixin):
         tree = select.Tree.from_selection(selection)
 
         # set up Visualizer
-        visualizer = Visualizer(
-            self._structure, (lambda sel: selector.label(sel))
-        )
+        visualizer = Visualizer(self._structure, (lambda sel: selector.label(sel)))
         viewer = visualizer.to_view(selector, tree.selections(), supercell=supercell)
 
         # adjust viewer

--- a/src/py4vasp/_calculation/exciton_density.py
+++ b/src/py4vasp/_calculation/exciton_density.py
@@ -107,8 +107,12 @@ class ExcitonDensity(base.Refinery, structure.Mixin, view.Mixin):
         tree = select.Tree.from_selection(selection)
 
         # set up Visualizer
-        visualizer = Visualizer(self._structure, (lambda sel: selector.label(sel)))
-        viewer = visualizer.to_view(selector, tree.selections(), supercell=supercell)
+        visualizer = Visualizer(self._structure)
+        dataDict = {
+            selector.label(sel): (selector[sel].T)[np.newaxis]
+            for sel in tree.selections()
+        }
+        viewer = visualizer.to_view(dataDict, supercell=supercell)
 
         # adjust viewer
         if center:

--- a/src/py4vasp/_calculation/exciton_density.py
+++ b/src/py4vasp/_calculation/exciton_density.py
@@ -108,9 +108,9 @@ class ExcitonDensity(base.Refinery, structure.Mixin, view.Mixin):
 
         # set up Visualizer
         visualizer = Visualizer(
-            self._structure, selector, (lambda sel: selector.label(sel))
+            self._structure, (lambda sel: selector.label(sel))
         )
-        viewer = visualizer.to_view(tree.selections(), supercell=supercell)
+        viewer = visualizer.to_view(selector, tree.selections(), supercell=supercell)
 
         # adjust viewer
         if center:

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -132,10 +132,7 @@ class Contour(trace.Trace):
         ]
         dx = np.linalg.norm(meshes_raw[0][1])
         dy = np.linalg.norm(meshes_raw[1][1])
-        meshes = [
-            v[::subsample]
-            for v, subsample in zip(meshes_raw, subsamples)
-        ]
+        meshes = [v[::subsample] for v, subsample in zip(meshes_raw, subsamples)]
         subsampled_data = data[:: subsamples[0], :: subsamples[1]]
         if self.scale_arrows is None:
             # arrows may be at most as long as the shorter lattice vector

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -104,7 +104,8 @@ class Contour(trace.Trace):
             autocontour=True,
             colorscale=self._get_color_scale(z),
             colorbar=self._get_color_bar(),
-            zmin=zmin, zmax=zmax,
+            zmin=zmin,
+            zmax=zmax,
             contours={"showlabels": self.show_contour_values},
         )
 
@@ -118,7 +119,8 @@ class Contour(trace.Trace):
             name=self.label,
             colorscale=self._get_color_scale(z),
             colorbar=self._get_color_bar(),
-            zmin=zmin, zmax=zmax,
+            zmin=zmin,
+            zmax=zmax,
         )
 
     def _interpolate_data_if_necessary(self, lattice, data):
@@ -231,44 +233,43 @@ class Contour(trace.Trace):
         if (self.color_scheme == "signed") or (
             self.color_scheme == "auto" and (zmin < 0 and zmax > 0)
         ):
-            selected_color_scheme = (
-                [
-                    [0, color_lower],
-                    [0.5, color_center],
-                    [1, color_upper],
-                ]
-            )
+            selected_color_scheme = [
+                [0, color_lower],
+                [0.5, color_center],
+                [1, color_upper],
+            ]
         elif (self.color_scheme == "positive") or (
             self.color_scheme == "auto" and (zmin >= 0)
         ):
-            selected_color_scheme = (
-                [[0, color_center], [1, color_upper]]
-            )
+            selected_color_scheme = [[0, color_center], [1, color_upper]]
         elif (self.color_scheme == "negative") or (
             self.color_scheme == "auto" and (zmax <= 0)
         ):
-            selected_color_scheme = (
-                [[0, color_lower], [1, color_center]]
-            )
+            selected_color_scheme = [[0, color_lower], [1, color_center]]
         # Defaulting to color map if not yet set
         if selected_color_scheme is None:
             selected_color_scheme = [
-                    [0, color_lower],
-                    [0.5, color_center],
-                    [1, color_upper],
-                ]
+                [0, color_lower],
+                [0.5, color_center],
+                [1, color_upper],
+            ]
 
         return selected_color_scheme
 
     def _get_color_range(self, z: np.ndarray) -> tuple:
-        if self.color_limits is None: return (np.min(z), np.max(z))
+        if self.color_limits is None:
+            return (np.min(z), np.max(z))
         else:
             assert len(self.color_limits) == 2
             zmin, zmax = self.color_limits
-            if zmin is None and zmax is not None: return (np.min(z), zmax)
-            elif zmin is not None and zmax is None: return (zmin, np.max(z))
-            elif zmin is None and zmax is None: return(np.min(z), np.max(z))
-            else: return (zmin, zmax)
+            if zmin is None and zmax is not None:
+                return (np.min(z), zmax)
+            elif zmin is not None and zmax is None:
+                return (zmin, np.max(z))
+            elif zmin is None and zmax is None:
+                return (np.min(z), np.max(z))
+            else:
+                return (zmin, zmax)
 
     def _get_color_bar(self):
         if (self.colorbar_label is not None) and (self.colorbar_label):

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -253,7 +253,7 @@ class Contour(trace.Trace):
         return (
             x,
             y,
-            (self._extend_data_contour(data) if self.traces_as_periodic else data),
+            self._extend_data_contour(data),
         )
 
     def _make_mesh(self, lattice, num_point, index):

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -66,6 +66,14 @@ class Contour(trace.Trace):
     - (float, float): Sets minimum and maximum of the color scale."""
     contrast_mode: bool = False
     "If True, enables high contrast mode, which affects the colors of the plot."
+    traces_as_periodic: bool = False
+    """If True, traces (contour and quiver) are shifted so that quiver and heatmap 'cell' 
+    centers align with the positions they were computed at. Periodic images will be drawn
+    so that the supercell still appears completely covered on all sides.
+
+    If False, traces (contour and quiver) are shifted so that the heatmap cells visually
+    align with the supercell instead. No periodic images are required, but the visual
+    presentation might be misleading."""
     supercell: np.array = (1, 1)
     "Multiple of each lattice vector to be drawn."
     show_cell: bool = True
@@ -135,13 +143,22 @@ class Contour(trace.Trace):
         # remember that b and a axis are swapped
         vectors = reversed(lattice)
         meshes_raw = [
-            np.linspace(np.zeros(2), vector, num_points, endpoint=False)
+            np.linspace(
+                np.zeros(2),
+                vector,
+                num_points + (1 if self.traces_as_periodic else 0),
+                endpoint=self.traces_as_periodic,
+            )
             for vector, num_points in zip(vectors, data.shape)
         ]
         dx = np.linalg.norm(meshes_raw[0][1])
         dy = np.linalg.norm(meshes_raw[1][1])
         meshes = [v[::subsample] for v, subsample in zip(meshes_raw, subsamples)]
-        subsampled_data = data[:: subsamples[0], :: subsamples[1]]
+        subsampled_data = (
+            self._subsample_data_quiver(data, subsamples)
+            if self.traces_as_periodic
+            else data[:: subsamples[0], :: subsamples[1]]
+        )
         if self.scale_arrows is None:
             # arrows may be at most as long as the shorter lattice vector
             max_length = min(np.linalg.norm(meshes[0][1]), np.linalg.norm(meshes[1][1]))
@@ -153,10 +170,42 @@ class Contour(trace.Trace):
         u = scale * subsampled_data[:, :, 0].flatten()
         v = scale * subsampled_data[:, :, 1].flatten()
         fig = ff.create_quiver(
-            x - 0.5 * u + 0.5 * dy, y - 0.5 * v + 0.5 * dx, u, v, scale=1
+            x - 0.5 * u + ((0.5 * dy) if not (self.traces_as_periodic) else 0.0),
+            y - 0.5 * v + ((0.5 * dx) if not (self.traces_as_periodic) else 0.0),
+            u,
+            v,
+            scale=1,
         )
         fig.data[0].line.color = _config.VASP_COLORS["dark"]
         return fig.data[0]
+
+    def _subsample_data_quiver(self, data, subsamples):
+        xdim, ydim, _ = data.shape
+
+        # Create index arrays with "wrapped" boundaries
+        x_indices = (
+            np.arange(0, xdim + (1 if self.traces_as_periodic else 0), subsamples[0])
+            % xdim
+        )
+        y_indices = (
+            np.arange(0, ydim + (1 if self.traces_as_periodic else 0), subsamples[1])
+            % ydim
+        )
+
+        # Access data using advanced indexing
+        subsampled_data = data[np.ix_(x_indices, y_indices)]
+        return subsampled_data
+
+    def _extend_data_contour(self, data):
+        xdim, ydim = data.shape
+
+        # Create index arrays with "wrapped" boundaries
+        x_indices = np.arange(0, xdim + (1 if self.traces_as_periodic else 0)) % xdim
+        y_indices = np.arange(0, ydim + (1 if self.traces_as_periodic else 0)) % ydim
+
+        # Access data using advanced indexing
+        subsampled_data = data[np.ix_(x_indices, y_indices)]
+        return subsampled_data
 
     def _limit_number_of_arrows(self, data_size):
         subsamples = [1, 1]
@@ -186,7 +235,11 @@ class Contour(trace.Trace):
         x_in, y_in = (line_mesh_a[:, np.newaxis] + line_mesh_b[np.newaxis, :]).T
         x_in = x_in.flatten()
         y_in = y_in.flatten()
-        z_in = data.flatten()
+        z_in = (
+            self._extend_data_contour(data).flatten()
+            if self.traces_as_periodic
+            else data.flatten()
+        )
         x_out, y_out = np.meshgrid(
             np.linspace(x_in.min(), x_in.max(), shape[0]),
             np.linspace(y_in.min(), y_in.max(), shape[1]),
@@ -197,14 +250,24 @@ class Contour(trace.Trace):
     def _use_data_without_interpolation(self, lattice, data):
         x = self._make_mesh(lattice, data.shape[1], 0)
         y = self._make_mesh(lattice, data.shape[0], 1)
-        return x, y, data
+        return (
+            x,
+            y,
+            (self._extend_data_contour(data) if self.traces_as_periodic else data),
+        )
 
     def _make_mesh(self, lattice, num_point, index):
         vector = index if self._interpolation_required() else (index, index)
-        return (
-            np.linspace(0, lattice[vector], num_point, endpoint=False)
-            + 0.5 * lattice[vector] / num_point
+
+        mesh = np.linspace(
+            0,
+            lattice[vector],
+            num_point + (1 if self.traces_as_periodic else 0),
+            endpoint=self.traces_as_periodic,
         )
+        if not self.traces_as_periodic:
+            mesh = mesh + (0.5 * lattice[vector] / num_point)
+        return mesh
 
     def _options(self):
         return {

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -130,7 +130,9 @@ class Contour(trace.Trace):
         x, y = np.array([sum(points) for points in itertools.product(*meshes)]).T
         u = scale * subsampled_data[:, :, 0].flatten()
         v = scale * subsampled_data[:, :, 1].flatten()
-        fig = ff.create_quiver(x - 0.5 * u, y - 0.5 * v, u, v, scale=1)
+        dx = np.linalg.norm(meshes[0][1])
+        dy = np.linalg.norm(meshes[1][1])
+        fig = ff.create_quiver(x - 0.5 * u + 0.5 * dx, y - 0.5 * v + 0.5 * dy, u, v, scale=1)
         fig.data[0].line.color = _config.VASP_COLORS["dark"]
         return fig.data[0]
 

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -126,9 +126,15 @@ class Contour(trace.Trace):
         subsamples = self._limit_number_of_arrows(data.size)
         # remember that b and a axis are swapped
         vectors = reversed(lattice)
+        meshes_raw = [
+            np.linspace(np.zeros(2), vector, num_points, endpoint=False)
+            for vector, num_points in zip(vectors, data.shape)
+        ]
+        dx = np.linalg.norm(meshes_raw[0][1])
+        dy = np.linalg.norm(meshes_raw[1][1])
         meshes = [
-            np.linspace(np.zeros(2), vector, num_points, endpoint=False)[::subsample]
-            for vector, num_points, subsample in zip(vectors, data.shape, subsamples)
+            v[::subsample]
+            for v, subsample in zip(meshes_raw, subsamples)
         ]
         subsampled_data = data[:: subsamples[0], :: subsamples[1]]
         if self.scale_arrows is None:
@@ -141,10 +147,8 @@ class Contour(trace.Trace):
         x, y = np.array([sum(points) for points in itertools.product(*meshes)]).T
         u = scale * subsampled_data[:, :, 0].flatten()
         v = scale * subsampled_data[:, :, 1].flatten()
-        dx = np.linalg.norm(meshes[0][1])
-        dy = np.linalg.norm(meshes[1][1])
         fig = ff.create_quiver(
-            x - 0.5 * u + 0.5 * dx, y - 0.5 * v + 0.5 * dy, u, v, scale=1
+            x - 0.5 * u + 0.5 * dy, y - 0.5 * v + 0.5 * dx, u, v, scale=1
         )
         fig.data[0].line.color = _config.VASP_COLORS["dark"]
         return fig.data[0]

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -64,8 +64,6 @@ class Contour(trace.Trace):
     - (float, None): Sets the minimum of the color scale.
     - (None, float): Sets the maximum of the color scale.
     - (float, float): Sets minimum and maximum of the color scale."""
-    contrast_mode: bool = False
-    "If True, enables high contrast mode, which affects the colors of the plot."
     traces_as_periodic: bool = False
     """If True, traces (contour and quiver) are shifted so that quiver and heatmap 'cell' 
     centers align with the positions they were computed at. Periodic images will be drawn

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -1,0 +1,36 @@
+from py4vasp._util import slicing, index
+from py4vasp._calculation.structure import Structure
+from py4vasp._third_party.view import GridQuantity
+
+import numpy as np
+
+#Density, CurrentDensity, ExcitonDensity, [PartialDensity], (BField/MagneticField)
+class Visualizer:
+    def __init__(self, structure: Structure, selector: index.Selector):
+        self._selector = selector
+        self._structure = structure
+
+    def to_view(self, selections, supercell=1):
+        viewer = self._structure.plot(supercell)
+        viewer.grid_scalars = [
+            GridQuantity((self._selector[selection].T)[np.newaxis], label=self._selector.label(selection)) #user_options)
+            for selection in selections
+        ]
+        return viewer
+
+    # def to_contour(self, selections, a, b, c, supercell, normal):
+    #     cut, fraction = slicing.get_cut(a, b, c)
+    #     plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
+    #     contours = [
+    #         self._contour(selector, selection, plane, fraction, supercell)
+    #         for selection in selections
+    #     ]
+    #     return graph.Graph(contours)
+
+    # def to_quiver(self, selections, a, b,c, supercell, normal):
+    #     cut, fraction = slicing.get_cut(a, b, c)
+    #     plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
+    #     quiver_plots = [
+    #         self._quiver_plot(selector, selection, plane, fraction, supercell)
+    #         for selection in selections
+    #     ]

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -1,63 +1,66 @@
-from py4vasp._third_party import graph
-from py4vasp._util import slicing, index
-from py4vasp._calculation.structure import Structure
-from py4vasp._third_party.view import GridQuantity
-from py4vasp._third_party.graph import Contour
+from typing import Callable
 
 import numpy as np
 
-#Density, CurrentDensity, ExcitonDensity, [PartialDensity], (BField/MagneticField)
+from py4vasp._calculation.structure import Structure
+from py4vasp._third_party.graph import Contour, Graph
+from py4vasp._third_party.view import GridQuantity, View
+from py4vasp._util import index, slicing
+
+
 class Visualizer:
     def __init__(self, structure: Structure, selector: index.Selector):
         self._selector = selector
         self._structure = structure
 
-    def to_view(self, selections, supercell=1):
+    def to_view(self, selections, supercell=1) -> View:
         viewer = self._structure.plot(supercell)
         viewer.grid_scalars = [
-            GridQuantity((self._selector[selection].T)[np.newaxis], label=self._selector.label(selection)) #user_options)
+            GridQuantity(
+                (self._selector[selection].T)[np.newaxis],
+                label=self._selector.label(selection),
+            )
             for selection in selections
         ]
         return viewer
 
-    def to_contour(self, selections, a=None, b=None, c=None, normal=None, supercell=None):
+    def to_contour(
+        self, selections, a=None, b=None, c=None, normal=None, supercell=None
+    ) -> Graph:
+        return self._make_contour_graph(
+            selections, slicing.grid_scalar, a, b, c, supercell, normal
+        )
+
+    def to_quiver(
+        self, selections, a=None, b=None, c=None, supercell=None, normal=None
+    ) -> Graph:
+        return self._make_contour_graph(
+            selections, slicing.grid_vector, a, b, c, supercell, normal
+        )
+
+    def _make_contour_graph(
+        self,
+        selections,
+        data_slicer: Callable,
+        a=None,
+        b=None,
+        c=None,
+        supercell=None,
+        normal=None,
+    ) -> Graph:
         cut, fraction = slicing.get_cut(a, b, c)
         plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
 
         def _make_contour(selection):
             contour = Contour(
-                slicing.grid_scalar(self._selector[selection].T, plane, fraction), 
-                plane, 
-                label=self._selector.label(selection) or "", 
-                isolevels=True, 
+                data_slicer(self._selector[selection].T, plane, fraction),
+                plane,
+                label=self._selector.label(selection) or "",
+                isolevels=True,
             )
-            if supercell is not None: contour.supercell = np.ones(2, dtype=np.int_) * supercell
+            if supercell is not None:
+                contour.supercell = np.ones(2, dtype=np.int_) * supercell
             return contour
-        
-        contours = [
-            _make_contour(selection)
-            for selection in selections
-        ]
-        return graph.Graph(contours)
-    
-    
 
-    def to_quiver(self, selections, a=None, b=None, c=None, supercell=None, normal=None):
-        cut, fraction = slicing.get_cut(a, b, c)
-        plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
-
-        def _make_contour(selection):
-            contour = Contour(
-                slicing.grid_vector(self._selector[selection].T, plane, fraction), 
-                plane, 
-                label=self._selector.label(selection) or "", 
-                isolevels=True, 
-            )
-            if supercell is not None: contour.supercell = np.ones(2, dtype=np.int_) * supercell
-            return contour
-        
-        contours = [
-            _make_contour(selection)
-            for selection in selections
-        ]
-        return graph.Graph(contours)
+        contours = [_make_contour(selection) for selection in selections]
+        return Graph(contours)

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -1,24 +1,79 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+
 from dataclasses import dataclass
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional, Union
 
 import numpy as np
 
 from py4vasp._calculation.structure import Structure
 from py4vasp._third_party.graph import Contour, Graph
 from py4vasp._third_party.view import GridQuantity, View
-from py4vasp._util import index, slicing
+from py4vasp._util import documentation, index, slicing
 from py4vasp.exception import IncorrectUsage
+
+_DATA_DICT_PARAMETER = """\
+data_dict : dict[str, Any]
+    A dictionary containing labels as keys and the data as values (if required, already 
+    transposed and reshaped) for all selections, in the form of 
+    `{make_label(selection): get_data(selector, selection) for selection in selections}`.
+"""
+_SLICE_ARGS_PARAMETER = """\
+slice_args : SliceArguments
+    A wrapper around a, b, c, normal, and supercell that also allows to compute the
+    plane at the specified cut.
+"""
 
 
 @dataclass
 class SliceArguments:
+    """Helper dataclass for storing a, b, c (the specifications for slicing along which vector),
+    normal (how the plane should be aligned), and supercell (expanding the lattice).
+
+    Define like so:
+    >>> slice_args = SliceArguments(a=1.3)
+
+    Note that exactly one of a, b, c must be given and not None, otherwise,
+    py4vasp will raise an IncorrectUsage exception.
+    """
+
     a: Optional[float] = None
+    """You must select exactly one of a,b,c to specify which of the three lattice
+    vectors you want to remove to form a plane. The assigned value represents
+    the fractional length along this lattice vector, so `a = 0.3` will remove
+    the first lattice vector and then take the grid points at 30% of the length
+    of the first vector in the b-c plane. The fractional height uses periodic
+    boundary conditions."""
     b: Optional[float] = None
+    """You must select exactly one of a,b,c to specify which of the three lattice
+    vectors you want to remove to form a plane. The assigned value represents
+    the fractional length along this lattice vector, so `b = 0.3` will remove
+    the second lattice vector and then take the grid points at 30% of the length
+    of the second vector in the a-c plane. The fractional height uses periodic
+    boundary conditions."""
     c: Optional[float] = None
-    normal: Optional[float] = None
-    supercell: Optional[float] = None
+    """You must select exactly one of a,b,c to specify which of the three lattice
+    vectors you want to remove to form a plane. The assigned value represents
+    the fractional length along this lattice vector, so `c = 0.3` will remove
+    the third lattice vector and then take the grid points at 30% of the length
+    of the third vector in the a-b plane. The fractional height uses periodic
+    boundary conditions."""
+    normal: Optional[str] = None
+    """If not set or None, py4vasp will align the first remaining lattice vector with the
+    x-axis and the second one such that the angle between the lattice vectors
+    is preserved. You can set it to "x", "y", or "z"; then py4vasp will rotate
+    the plane in such a way that the normal direction aligns with the specified
+    Cartesian axis. This may look better if the normal direction is close to a
+    Cartesian axis. You may also set it to "auto" so that py4vasp chooses a
+    close Cartesian axis if it can find any."""
+    supercell: Optional[Union[int, tuple]] = None
+    """Stored here to replicate the lattice periodically a given number of times
+    when passed to Visualizer. If you provide two different numbers, the resulting 
+    cell will be the two remaining lattice vectors multiplied by the specific number."""
 
     def __post_init__(self):
+        """__post_init__ is a special @dataclass function, called automatically
+        after __init__. Here, we check if a, b, c are valid."""
         # Count how many of a, b, c are not None
         provided = [x is not None for x in (self.a, self.b, self.c)].count(True)
         if provided != 1:
@@ -26,7 +81,25 @@ class SliceArguments:
                 "Exactly one of a, b, or c must be provided (not None)."
             )
 
-    def slice_plane(self, lattice_vectors):
+    def slice_plane(self, lattice_vectors) -> tuple[slicing.Plane, float]:
+        """Cuts along a fraction of the selected vector (`a`, `b`, or `c`)
+        of the `lattice_vectors` argument, then defines the plane at that
+        fraction spanned by the remaining two lattice vectors and rotates
+        that plane according to `normal`.
+
+        Parameters
+        ----------
+        lattice_vectors : np.ndarray
+            A 3 × 3 array defining the three lattice vectors of the unit cell.
+
+        Returns
+        -------
+        tuple
+            slicing.Plane
+                A 2d representation of the plane with some information to transform data to it.
+            float
+                The fraction at which the plane is defined, in the direction of `a`, `b`, or `c`.
+        """
         cut, fraction = slicing.get_cut(self.a, self.b, self.c)
         plane = slicing.plane(lattice_vectors, cut, self.normal)
         return plane, fraction
@@ -36,33 +109,101 @@ class Visualizer:
     def __init__(self, structure: Structure):
         self._structure = structure
 
-    def to_view(self, dataDict: dict[str, Any], supercell=1) -> View:
+    @documentation.format(data_dict=_DATA_DICT_PARAMETER)
+    def to_view(
+        self, data_dict: dict[str, Any], supercell: Union[int, np.ndarray, None] = 1
+    ) -> View:
+        """Constructs a `View` object and manages setting of `grid_scalars`
+        with data and labels.
+
+        Parameters
+        ----------
+        {data_dict}
+
+        supercell : Union[int, np.ndarray, None]
+            Replicate the plot periodically a given number of times. If you
+            provide two different numbers, the resulting cell will be the two remaining
+            lattice vectors multiplied by the specific number.
+
+        Returns
+        -------
+        View
+            A visualization of the quantity within the crystal structure.
+        """
         viewer = self._structure.plot(supercell)
         viewer.grid_scalars = [
             GridQuantity(
                 data,
                 label=label if label else "",
             )
-            for label, data in dataDict.items()
+            for label, data in data_dict.items()
         ]
         return viewer
 
+    @documentation.format(
+        data_dict=_DATA_DICT_PARAMETER,
+        slice_args=_SLICE_ARGS_PARAMETER,
+    )
     def to_contour(
         self,
-        dataDict: dict[str, Any],
+        data_dict: dict[str, Any],
         slice_args: SliceArguments,
         isolevels: bool = True,
     ) -> Graph:
+        """Constructs a `Graph` object and manages slicing and constructing
+        the contours.
+
+        Parameters
+        ----------
+        {data_dict}
+
+        {slice_args}
+
+        isolevels : bool
+            Defines whether isolevels should be added or a heatmap is used.
+
+        Returns
+        -------
+        Graph
+            A contour plot in the plane spanned by the 2 remaining lattice vectors.
+        """
         plane, fraction = slice_args.slice_plane(self._structure.lattice_vectors())
         contours = [
             self._make_contour(
                 data, label, plane, fraction, slice_args.supercell, isolevels
             )
-            for label, data in dataDict.items()
+            for label, data in data_dict.items()
         ]
         return Graph(contours)
 
     def _make_contour(self, data, label, plane, fraction, supercell, isolevels):
+        """Helper function for creating and modifying a `Contour` object.
+
+        Parameters
+        ----------
+        data : Any
+            The unsliced data to be represented.
+
+        label : str
+            The label for the data.
+
+        plane : slicing.Plane
+            The plane along which to slice the data.
+
+        fraction : float
+            The fraction at which the slice is taken along the chosen lattice vector.
+
+        supercell : Union[int, np.ndarray, None]
+            The specification of the supercell for duplicating the lattice.
+
+        isolevels : bool
+            Defines whether isolevels should be added or a heatmap is used.
+
+        Returns
+        -------
+        Contour
+            Represents data on a 2d slice through the unit cell.
+        """
         contour = Contour(
             slicing.grid_scalar(data, plane, fraction),
             plane,
@@ -73,19 +214,61 @@ class Visualizer:
             contour.supercell = np.ones(2, dtype=np.int_) * supercell
         return contour
 
+    @documentation.format(
+        data_dict=_DATA_DICT_PARAMETER,
+        slice_args=_SLICE_ARGS_PARAMETER,
+    )
     def to_quiver(
         self,
-        dataDict,
+        data_dict: dict[str, Any],
         slice_args: SliceArguments,
     ) -> Graph:
+        """Constructs a `Graph` object and manages slicing and constructing
+        the quivers.
+
+        Parameters
+        ----------
+        {data_dict}
+
+        {slice_args}
+
+        Returns
+        -------
+        Graph
+            A quiver plot in the plane spanned by the 2 remaining lattice vectors.
+        """
         plane, fraction = slice_args.slice_plane(self._structure.lattice_vectors())
-        contours = [
+        quivers = [
             self._make_quiver(data, label, plane, fraction, slice_args.supercell)
-            for label, data in dataDict.items()
+            for label, data in data_dict.items()
         ]
-        return Graph(contours)
+        return Graph(quivers)
 
     def _make_quiver(self, sel, label, plane, fraction, supercell):
+        """Helper function for creating and modifying a `Contour` object for quivers.
+
+        Parameters
+        ----------
+        sel : Any
+            The unsliced data to be represented.
+
+        label : str
+            The label for the data.
+
+        plane : slicing.Plane
+            The plane along which to slice the data.
+
+        fraction : float
+            The fraction at which the slice is taken along the chosen lattice vector.
+
+        supercell : Union[int, np.ndarray, None]
+            The specification of the supercell for duplicating the lattice.
+
+        Returns
+        -------
+        Contour
+            Represents data on a 2d slice through the unit cell.
+        """
         if sel.ndim == 3 or len(sel) == 1:
             data = slicing.grid_scalar(sel, plane, fraction)
             data = np.array((np.zeros_like(data), data))

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -9,9 +9,7 @@ from py4vasp._util import index, slicing
 
 
 class Visualizer:
-    def __init__(
-        self, structure: Structure, label_function: Callable = None
-    ):
+    def __init__(self, structure: Structure, label_function: Callable = None):
         self._structure = structure
         self._label = label_function
 
@@ -27,16 +25,27 @@ class Visualizer:
         ]
         return viewer
 
-    
     def to_contour_from_mapping(
-        self, mapping, selections, a=None, b=None, c=None, normal=None, supercell=None, isolevels=True,
+        self,
+        mapping,
+        selections,
+        a=None,
+        b=None,
+        c=None,
+        normal=None,
+        supercell=None,
+        isolevels=True,
     ) -> Graph:
         if self._label is None:
             self._label = getattr(mapping, "label", (lambda _: ""))
         plane, fraction = self._slice_plane(a, b, c, normal)
-        contours = [self._make_contour(mapping[selection].T, selection, plane, fraction, supercell, isolevels) for selection in selections]
+        contours = [
+            self._make_contour(
+                mapping[selection].T, selection, plane, fraction, supercell, isolevels
+            )
+            for selection in selections
+        ]
         return Graph(contours)
-    
 
     def _make_contour(self, data, selection, plane, fraction, supercell, isolevels):
         contour = Contour(
@@ -48,24 +57,34 @@ class Visualizer:
         if supercell is not None:
             contour.supercell = np.ones(2, dtype=np.int_) * supercell
         return contour
-    
+
     def _slice_plane(self, a, b, c, normal):
         cut, fraction = slicing.get_cut(a, b, c)
         plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
         return plane, fraction
-    
+
     def to_contour_from_data(
-        self, data, a=None, b=None, c=None, normal=None, supercell=None, isolevels=True,
+        self,
+        data,
+        a=None,
+        b=None,
+        c=None,
+        normal=None,
+        supercell=None,
+        isolevels=True,
     ) -> Graph:
         if self._label is None:
-            self._label = (lambda _: "")
+            self._label = lambda _: ""
         plane, fraction = self._slice_plane(a, b, c, normal)
-        contours = [self._make_contour(data, None, plane, fraction, supercell, isolevels)]
+        contours = [
+            self._make_contour(data, None, plane, fraction, supercell, isolevels)
+        ]
         return Graph(contours)
 
     def to_quiver_from_mapping(
         self,
-        mapping, selections,
+        mapping,
+        selections,
         a=None,
         b=None,
         c=None,
@@ -75,9 +94,14 @@ class Visualizer:
         if self._label is None:
             self._label = getattr(mapping, "label", (lambda _: ""))
         plane, fraction = self._slice_plane(a, b, c, normal)
-        contours = [self._make_quiver(mapping[selection].T, selection, plane, fraction, supercell) for selection in selections]
+        contours = [
+            self._make_quiver(
+                mapping[selection].T, selection, plane, fraction, supercell
+            )
+            for selection in selections
+        ]
         return Graph(contours)
-    
+
     def _make_quiver(self, sel, selection, plane, fraction, supercell):
         if sel.ndim == 3 or len(sel) == 1:
             data = slicing.grid_scalar(sel, plane, fraction)
@@ -93,7 +117,7 @@ class Visualizer:
         if supercell is not None:
             contour.supercell = np.ones(2, dtype=np.int_) * supercell
         return contour
-    
+
     def to_quiver_from_data(
         self,
         data,
@@ -104,7 +128,7 @@ class Visualizer:
         supercell=None,
     ) -> Graph:
         if self._label is None:
-            self._label = (lambda _: "")
+            self._label = lambda _: ""
         plane, fraction = self._slice_plane(a, b, c, normal)
         contours = [self._make_quiver(data, None, plane, fraction, supercell)]
         return Graph(contours)

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -49,13 +49,16 @@ class Visualizer:
         return Graph(contours)
 
     def to_quiver(
-        self, selections, a=None, b=None, c=None, normal=None, supercell=None, 
+        self, selections_or_data, *, a=None, b=None, c=None, normal=None, supercell=None, 
     ) -> Graph:
         cut, fraction = slicing.get_cut(a, b, c)
         plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
 
         def _make_contour(selection):
-            sel = self._mapping[selection].T
+            if (isinstance(selection, tuple)):
+                sel = self._mapping[selection].T
+            else:
+                sel = selection
             if sel.ndim == 3 or len(sel) == 1:
                 data = slicing.grid_scalar(sel, plane, fraction)
                 data = np.array((np.zeros_like(data), data))
@@ -71,5 +74,8 @@ class Visualizer:
                 contour.supercell = np.ones(2, dtype=np.int_) * supercell
             return contour
 
-        contours = [_make_contour(selection) for selection in selections]
+        if (isinstance(selections_or_data, list)):
+            contours = [_make_contour(selection) for selection in selections_or_data]
+        else:
+            contours = [_make_contour(selections_or_data)]
         return Graph(contours)

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional
 
 import numpy as np
 
@@ -12,17 +12,19 @@ from py4vasp.exception import IncorrectUsage
 
 @dataclass
 class SliceArguments:
-    a: Optional[float]=None
-    b: Optional[float]=None
-    c: Optional[float]=None
-    normal: Optional[float]=None
-    supercell: Optional[float]=None
+    a: Optional[float] = None
+    b: Optional[float] = None
+    c: Optional[float] = None
+    normal: Optional[float] = None
+    supercell: Optional[float] = None
 
     def __post_init__(self):
         # Count how many of a, b, c are not None
         provided = [x is not None for x in (self.a, self.b, self.c)].count(True)
         if provided != 1:
-            raise IncorrectUsage("Exactly one of a, b, or c must be provided (not None).")
+            raise IncorrectUsage(
+                "Exactly one of a, b, or c must be provided (not None)."
+            )
 
     def slice_plane(self, lattice_vectors):
         cut, fraction = slicing.get_cut(self.a, self.b, self.c)
@@ -30,85 +32,60 @@ class SliceArguments:
         return plane, fraction
 
 
-
 class Visualizer:
-    def __init__(self, structure: Structure, label_function: Callable = None):
+    def __init__(self, structure: Structure):
         self._structure = structure
-        self._label = label_function
 
-    def to_view(self, mapping, selections, supercell=1) -> View:
-        if self._label is None:
-            self._label = getattr(mapping, "label", (lambda _: ""))
+    def to_view(self, dataDict: dict[str, Any], supercell=1) -> View:
         viewer = self._structure.plot(supercell)
         viewer.grid_scalars = [
             GridQuantity(
-                (mapping[selection].T)[np.newaxis], label=self._label(selection)
+                data,
+                label=label if label else "",
             )
-            for selection in selections
+            for label, data in dataDict.items()
         ]
         return viewer
 
-    def to_contour_from_mapping(
+    def to_contour(
         self,
-        mapping,
-        selections,
+        dataDict: dict[str, Any],
         slice_args: SliceArguments,
-        isolevels: bool=True,
+        isolevels: bool = True,
     ) -> Graph:
-        if self._label is None:
-            self._label = getattr(mapping, "label", (lambda _: ""))
         plane, fraction = slice_args.slice_plane(self._structure.lattice_vectors())
         contours = [
             self._make_contour(
-                mapping[selection].T, selection, plane, fraction, slice_args.supercell, isolevels
+                data, label, plane, fraction, slice_args.supercell, isolevels
             )
-            for selection in selections
+            for label, data in dataDict.items()
         ]
         return Graph(contours)
 
-    def _make_contour(self, data, selection, plane, fraction, supercell, isolevels):
+    def _make_contour(self, data, label, plane, fraction, supercell, isolevels):
         contour = Contour(
             slicing.grid_scalar(data, plane, fraction),
             plane,
-            label=self._label(selection),
+            label=label if label else "",
             isolevels=isolevels,
         )
         if supercell is not None:
             contour.supercell = np.ones(2, dtype=np.int_) * supercell
         return contour
 
-    def to_contour_from_data(
+    def to_quiver(
         self,
-        data,
+        dataDict,
         slice_args: SliceArguments,
-        isolevels: bool=True,
     ) -> Graph:
-        if self._label is None:
-            self._label = lambda _: ""
         plane, fraction = slice_args.slice_plane(self._structure.lattice_vectors())
         contours = [
-            self._make_contour(data, None, plane, fraction, slice_args.supercell, isolevels)
+            self._make_quiver(data, label, plane, fraction, slice_args.supercell)
+            for label, data in dataDict.items()
         ]
         return Graph(contours)
 
-    def to_quiver_from_mapping(
-        self,
-        mapping,
-        selections,
-        slice_args: SliceArguments,
-    ) -> Graph:
-        if self._label is None:
-            self._label = getattr(mapping, "label", (lambda _: ""))
-        plane, fraction = slice_args.slice_plane(self._structure.lattice_vectors())
-        contours = [
-            self._make_quiver(
-                mapping[selection].T, selection, plane, fraction, slice_args.supercell
-            )
-            for selection in selections
-        ]
-        return Graph(contours)
-
-    def _make_quiver(self, sel, selection, plane, fraction, supercell):
+    def _make_quiver(self, sel, label, plane, fraction, supercell):
         if sel.ndim == 3 or len(sel) == 1:
             data = slicing.grid_scalar(sel, plane, fraction)
             data = np.array((np.zeros_like(data), data))
@@ -117,20 +94,9 @@ class Visualizer:
         contour = Contour(
             data,
             plane,
-            label=self._label(selection),
+            label=label if label else "",
             isolevels=True,
         )
         if supercell is not None:
             contour.supercell = np.ones(2, dtype=np.int_) * supercell
         return contour
-
-    def to_quiver_from_data(
-        self,
-        data,
-        slice_args: SliceArguments,
-    ) -> Graph:
-        if self._label is None:
-            self._label = lambda _: ""
-        plane, fraction = slice_args.slice_plane(self._structure.lattice_vectors())
-        contours = [self._make_quiver(data, None, plane, fraction, slice_args.supercell)]
-        return Graph(contours)

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -9,7 +9,9 @@ from py4vasp._util import index, slicing
 
 
 class Visualizer:
-    def __init__(self, structure: Structure, mapping: Mapping, label_function: Callable=None):
+    def __init__(
+        self, structure: Structure, mapping: Mapping, label_function: Callable = None
+    ):
         self._mapping = mapping
         self._structure = structure
         if label_function is not None:
@@ -21,22 +23,25 @@ class Visualizer:
         viewer = self._structure.plot(supercell)
         viewer.grid_scalars = [
             GridQuantity(
-                (self._mapping[selection].T)[np.newaxis],
-                label=self._label(selection)
+                (self._mapping[selection].T)[np.newaxis], label=self._label(selection)
             )
             for selection in selections
         ]
         return viewer
 
     def to_contour(
-        self, selections, a=None, b=None, c=None, normal=None, supercell=None
+        self, selections_or_data, a=None, b=None, c=None, normal=None, supercell=None
     ) -> Graph:
         cut, fraction = slicing.get_cut(a, b, c)
         plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
 
         def _make_contour(selection):
+            if isinstance(selection, tuple):
+                data = self._mapping[selection].T
+            else:
+                data = selection
             contour = Contour(
-                slicing.grid_scalar(self._mapping[selection].T, plane, fraction),
+                slicing.grid_scalar(data, plane, fraction),
                 plane,
                 label=self._label(selection),
                 isolevels=True,
@@ -45,17 +50,26 @@ class Visualizer:
                 contour.supercell = np.ones(2, dtype=np.int_) * supercell
             return contour
 
-        contours = [_make_contour(selection) for selection in selections]
+        if isinstance(selections_or_data, list):
+            contours = [_make_contour(selection) for selection in selections_or_data]
+        else:
+            contours = [_make_contour(selections_or_data)]
         return Graph(contours)
 
     def to_quiver(
-        self, selections_or_data, *, a=None, b=None, c=None, normal=None, supercell=None, 
+        self,
+        selections_or_data,
+        a=None,
+        b=None,
+        c=None,
+        normal=None,
+        supercell=None,
     ) -> Graph:
         cut, fraction = slicing.get_cut(a, b, c)
         plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
 
         def _make_contour(selection):
-            if (isinstance(selection, tuple)):
+            if isinstance(selection, tuple):
                 sel = self._mapping[selection].T
             else:
                 sel = selection
@@ -74,7 +88,7 @@ class Visualizer:
                 contour.supercell = np.ones(2, dtype=np.int_) * supercell
             return contour
 
-        if (isinstance(selections_or_data, list)):
+        if isinstance(selections_or_data, list):
             contours = [_make_contour(selection) for selection in selections_or_data]
         else:
             contours = [_make_contour(selections_or_data)]

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Mapping
 
 import numpy as np
 
@@ -9,16 +9,20 @@ from py4vasp._util import index, slicing
 
 
 class Visualizer:
-    def __init__(self, structure: Structure, selector: index.Selector):
-        self._selector = selector
+    def __init__(self, structure: Structure, mapping: Mapping, label_function: Callable=None):
+        self._mapping = mapping
         self._structure = structure
+        if label_function is not None:
+            self._label = label_function
+        else:
+            self._label = getattr(mapping, "label", (lambda _: ""))
 
     def to_view(self, selections, supercell=1) -> View:
         viewer = self._structure.plot(supercell)
         viewer.grid_scalars = [
             GridQuantity(
-                (self._selector[selection].T)[np.newaxis],
-                label=self._selector.label(selection),
+                (self._mapping[selection].T)[np.newaxis],
+                label=self._label(selection)
             )
             for selection in selections
         ]
@@ -27,35 +31,40 @@ class Visualizer:
     def to_contour(
         self, selections, a=None, b=None, c=None, normal=None, supercell=None
     ) -> Graph:
-        return self._make_contour_graph(
-            selections, slicing.grid_scalar, a, b, c, supercell, normal
-        )
-
-    def to_quiver(
-        self, selections, a=None, b=None, c=None, supercell=None, normal=None
-    ) -> Graph:
-        return self._make_contour_graph(
-            selections, slicing.grid_vector, a, b, c, supercell, normal
-        )
-
-    def _make_contour_graph(
-        self,
-        selections,
-        data_slicer: Callable,
-        a=None,
-        b=None,
-        c=None,
-        supercell=None,
-        normal=None,
-    ) -> Graph:
         cut, fraction = slicing.get_cut(a, b, c)
         plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
 
         def _make_contour(selection):
             contour = Contour(
-                data_slicer(self._selector[selection].T, plane, fraction),
+                slicing.grid_scalar(self._mapping[selection].T, plane, fraction),
                 plane,
-                label=self._selector.label(selection) or "",
+                label=self._label(selection),
+                isolevels=True,
+            )
+            if supercell is not None:
+                contour.supercell = np.ones(2, dtype=np.int_) * supercell
+            return contour
+
+        contours = [_make_contour(selection) for selection in selections]
+        return Graph(contours)
+
+    def to_quiver(
+        self, selections, a=None, b=None, c=None, normal=None, supercell=None, 
+    ) -> Graph:
+        cut, fraction = slicing.get_cut(a, b, c)
+        plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
+
+        def _make_contour(selection):
+            sel = self._mapping[selection].T
+            if sel.ndim == 3 or len(sel) == 1:
+                data = slicing.grid_scalar(sel, plane, fraction)
+                data = np.array((np.zeros_like(data), data))
+            else:
+                data = slicing.grid_vector(sel, plane, fraction)
+            contour = Contour(
+                data,
+                plane,
+                label=self._label(selection),
                 isolevels=True,
             )
             if supercell is not None:

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -1,6 +1,8 @@
+from py4vasp._third_party import graph
 from py4vasp._util import slicing, index
 from py4vasp._calculation.structure import Structure
 from py4vasp._third_party.view import GridQuantity
+from py4vasp._third_party.graph import Contour
 
 import numpy as np
 
@@ -18,14 +20,22 @@ class Visualizer:
         ]
         return viewer
 
-    # def to_contour(self, selections, a, b, c, supercell, normal):
-    #     cut, fraction = slicing.get_cut(a, b, c)
-    #     plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
-    #     contours = [
-    #         self._contour(selector, selection, plane, fraction, supercell)
-    #         for selection in selections
-    #     ]
-    #     return graph.Graph(contours)
+    def to_contour(self, selections, a=None, b=None, c=None, normal=None, supercell=None):
+        cut, fraction = slicing.get_cut(a, b, c)
+        plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
+        if supercell is not None: supercell_arg = np.ones(2, dtype=np.int_) * supercell
+        else: supercell_arg = (1,1)
+        contours = [
+            Contour(
+                slicing.grid_scalar(self._selector[selection].T, plane, fraction), 
+                plane, 
+                label=self._selector.label(selection) or "charge", 
+                isolevels=True, 
+                supercell=supercell_arg
+            )
+            for selection in selections
+        ]
+        return graph.Graph(contours)
 
     # def to_quiver(self, selections, a, b,c, supercell, normal):
     #     cut, fraction = slicing.get_cut(a, b, c)

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -10,86 +10,101 @@ from py4vasp._util import index, slicing
 
 class Visualizer:
     def __init__(
-        self, structure: Structure, mapping: Mapping, label_function: Callable = None
+        self, structure: Structure, label_function: Callable = None
     ):
-        self._mapping = mapping
         self._structure = structure
-        if label_function is not None:
-            self._label = label_function
-        else:
-            self._label = getattr(mapping, "label", (lambda _: ""))
+        self._label = label_function
 
-    def to_view(self, selections, supercell=1) -> View:
+    def to_view(self, mapping, selections, supercell=1) -> View:
+        if self._label is None:
+            self._label = getattr(mapping, "label", (lambda _: ""))
         viewer = self._structure.plot(supercell)
         viewer.grid_scalars = [
             GridQuantity(
-                (self._mapping[selection].T)[np.newaxis], label=self._label(selection)
+                (mapping[selection].T)[np.newaxis], label=self._label(selection)
             )
             for selection in selections
         ]
         return viewer
 
-    def to_contour(
-        self, selections_or_data, a=None, b=None, c=None, normal=None, supercell=None
+    
+    def to_contour_from_mapping(
+        self, mapping, selections, a=None, b=None, c=None, normal=None, supercell=None, isolevels=True,
     ) -> Graph:
+        if self._label is None:
+            self._label = getattr(mapping, "label", (lambda _: ""))
+        plane, fraction = self._slice_plane(a, b, c, normal)
+        contours = [self._make_contour(mapping[selection].T, selection, plane, fraction, supercell, isolevels) for selection in selections]
+        return Graph(contours)
+    
+
+    def _make_contour(self, data, selection, plane, fraction, supercell, isolevels):
+        contour = Contour(
+            slicing.grid_scalar(data, plane, fraction),
+            plane,
+            label=self._label(selection),
+            isolevels=isolevels,
+        )
+        if supercell is not None:
+            contour.supercell = np.ones(2, dtype=np.int_) * supercell
+        return contour
+    
+    def _slice_plane(self, a, b, c, normal):
         cut, fraction = slicing.get_cut(a, b, c)
         plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
-
-        def _make_contour(selection):
-            if isinstance(selection, tuple):
-                data = self._mapping[selection].T
-            else:
-                data = selection
-            contour = Contour(
-                slicing.grid_scalar(data, plane, fraction),
-                plane,
-                label=self._label(selection),
-                isolevels=True,
-            )
-            if supercell is not None:
-                contour.supercell = np.ones(2, dtype=np.int_) * supercell
-            return contour
-
-        if isinstance(selections_or_data, list):
-            contours = [_make_contour(selection) for selection in selections_or_data]
-        else:
-            contours = [_make_contour(selections_or_data)]
+        return plane, fraction
+    
+    def to_contour_from_data(
+        self, data, a=None, b=None, c=None, normal=None, supercell=None, isolevels=True,
+    ) -> Graph:
+        if self._label is None:
+            self._label = (lambda _: "")
+        plane, fraction = self._slice_plane(a, b, c, normal)
+        contours = [self._make_contour(data, None, plane, fraction, supercell, isolevels)]
         return Graph(contours)
 
-    def to_quiver(
+    def to_quiver_from_mapping(
         self,
-        selections_or_data,
+        mapping, selections,
         a=None,
         b=None,
         c=None,
         normal=None,
         supercell=None,
     ) -> Graph:
-        cut, fraction = slicing.get_cut(a, b, c)
-        plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
-
-        def _make_contour(selection):
-            if isinstance(selection, tuple):
-                sel = self._mapping[selection].T
-            else:
-                sel = selection
-            if sel.ndim == 3 or len(sel) == 1:
-                data = slicing.grid_scalar(sel, plane, fraction)
-                data = np.array((np.zeros_like(data), data))
-            else:
-                data = slicing.grid_vector(sel, plane, fraction)
-            contour = Contour(
-                data,
-                plane,
-                label=self._label(selection),
-                isolevels=True,
-            )
-            if supercell is not None:
-                contour.supercell = np.ones(2, dtype=np.int_) * supercell
-            return contour
-
-        if isinstance(selections_or_data, list):
-            contours = [_make_contour(selection) for selection in selections_or_data]
+        if self._label is None:
+            self._label = getattr(mapping, "label", (lambda _: ""))
+        plane, fraction = self._slice_plane(a, b, c, normal)
+        contours = [self._make_quiver(mapping[selection].T, selection, plane, fraction, supercell) for selection in selections]
+        return Graph(contours)
+    
+    def _make_quiver(self, sel, selection, plane, fraction, supercell):
+        if sel.ndim == 3 or len(sel) == 1:
+            data = slicing.grid_scalar(sel, plane, fraction)
+            data = np.array((np.zeros_like(data), data))
         else:
-            contours = [_make_contour(selections_or_data)]
+            data = slicing.grid_vector(sel, plane, fraction)
+        contour = Contour(
+            data,
+            plane,
+            label=self._label(selection),
+            isolevels=True,
+        )
+        if supercell is not None:
+            contour.supercell = np.ones(2, dtype=np.int_) * supercell
+        return contour
+    
+    def to_quiver_from_data(
+        self,
+        data,
+        a=None,
+        b=None,
+        c=None,
+        normal=None,
+        supercell=None,
+    ) -> Graph:
+        if self._label is None:
+            self._label = (lambda _: "")
+        plane, fraction = self._slice_plane(a, b, c, normal)
+        contours = [self._make_quiver(data, None, plane, fraction, supercell)]
         return Graph(contours)

--- a/src/py4vasp/_util/density.py
+++ b/src/py4vasp/_util/density.py
@@ -23,24 +23,41 @@ class Visualizer:
     def to_contour(self, selections, a=None, b=None, c=None, normal=None, supercell=None):
         cut, fraction = slicing.get_cut(a, b, c)
         plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
-        if supercell is not None: supercell_arg = np.ones(2, dtype=np.int_) * supercell
-        else: supercell_arg = (1,1)
-        contours = [
-            Contour(
+
+        def _make_contour(selection):
+            contour = Contour(
                 slicing.grid_scalar(self._selector[selection].T, plane, fraction), 
                 plane, 
-                label=self._selector.label(selection) or "charge", 
+                label=self._selector.label(selection) or "", 
                 isolevels=True, 
-                supercell=supercell_arg
             )
+            if supercell is not None: contour.supercell = np.ones(2, dtype=np.int_) * supercell
+            return contour
+        
+        contours = [
+            _make_contour(selection)
             for selection in selections
         ]
         return graph.Graph(contours)
+    
+    
 
-    # def to_quiver(self, selections, a, b,c, supercell, normal):
-    #     cut, fraction = slicing.get_cut(a, b, c)
-    #     plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
-    #     quiver_plots = [
-    #         self._quiver_plot(selector, selection, plane, fraction, supercell)
-    #         for selection in selections
-    #     ]
+    def to_quiver(self, selections, a=None, b=None, c=None, supercell=None, normal=None):
+        cut, fraction = slicing.get_cut(a, b, c)
+        plane = slicing.plane(self._structure.lattice_vectors(), cut, normal)
+
+        def _make_contour(selection):
+            contour = Contour(
+                slicing.grid_vector(self._selector[selection].T, plane, fraction), 
+                plane, 
+                label=self._selector.label(selection) or "", 
+                isolevels=True, 
+            )
+            if supercell is not None: contour.supercell = np.ones(2, dtype=np.int_) * supercell
+            return contour
+        
+        contours = [
+            _make_contour(selection)
+            for selection in selections
+        ]
+        return graph.Graph(contours)

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -595,7 +595,9 @@ def test_legend_positioning(parabola, sine, Assert, not_core):
     graph = Graph([sine, parabola])
     fig = graph.to_plotly()
     assert len(fig.data) == 2
-    assert fig.layout.legend.x is None # actually at 1.02, but plotly does not expose this until set explicitly
+    assert (
+        fig.layout.legend.x is None
+    )  # actually at 1.02, but plotly does not expose this until set explicitly
 
 
 def test_contour_legend_with_colorbar(rectangle_contour, parabola, Assert, not_core):
@@ -606,6 +608,7 @@ def test_contour_legend_with_colorbar(rectangle_contour, parabola, Assert, not_c
     assert hasattr(fig.data[0].colorbar, "x")
     assert fig.data[0].colorbar.x == 1.02
     assert fig.layout.legend.x == pytest.approx(fig.data[0].colorbar.x + 0.18, abs=1e-6)
+
 
 def check_unit_cell(unit_cell, x, y, zero):
     assert unit_cell.type == "path"

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -126,8 +126,21 @@ def test_contour_color_scheme(color_scheme):
         isolevels=True,
     )
     assert color_scheme == contour.color_scheme
+    graph = Graph(contour)
+    fig = graph.to_plotly()
+    expected_colorscale = []
+    if (color_scheme == "auto") or (color_scheme == "positive"):
+        expected_colorscale = ((0, 'white'), (1, _config.VASP_COLORS["red"]))
+    elif (color_scheme == "negative"):
+        expected_colorscale = ((0, _config.VASP_COLORS["blue"]), (1, "white"))
+    elif (color_scheme == "signed"):
+        expected_colorscale = ((0, _config.VASP_COLORS["blue"]), (0.5, "white"), (1, _config.VASP_COLORS["red"]))
+    else: raise NotImplementedError(f"Color scheme {color_scheme} not implemented.")
+    assert fig.data[0].colorscale == expected_colorscale
+    
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("contrast_mode", [True, False])
 def test_contour_contrast_mode(contrast_mode):
     contour = Contour(
@@ -138,30 +151,46 @@ def test_contour_contrast_mode(contrast_mode):
         isolevels=True,
     )
     assert contrast_mode == contour.contrast_mode
+    graph = Graph(contour)
+    raise NotImplementedError("Contrast mode currently has no effect on plotting.")
 
 
-@pytest.mark.parametrize("color_diverging_around_zero", [True, False])
-def test_contour_color_diverging_setting(color_diverging_around_zero):
+@pytest.mark.parametrize("color_limits", [None, (None, None), (-9, None), (None, 9), (-11, 11)])
+def test_contour_color_limits(color_limits):
     contour = Contour(
-        data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
+        data=np.linspace(-10, 10, 20 * 18).reshape((20, 18)),
         lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
         label="rectangle contour",
-        color_diverging_around_zero=color_diverging_around_zero,
+        color_limits=color_limits,
         isolevels=True,
     )
-    assert color_diverging_around_zero == contour.color_diverging_around_zero
+    assert color_limits == contour.color_limits
+    graph = Graph(contour)
+    expected_zmin = -10
+    expected_zmax = 10
+    if (color_limits is not None):
+        _zmin, _zmax = color_limits
+        if _zmin is not None: expected_zmin = _zmin
+        if _zmax is not None: expected_zmax = _zmax
+    fig = graph.to_plotly()
+    assert fig.data[0].zmin == expected_zmin
+    assert fig.data[0].zmax == expected_zmax
 
 
 @pytest.mark.parametrize("units", ["", None, "px", "m/s"])
-def test_contour_units(units):
+def test_contour_colorbar_label(units):
     contour = Contour(
         data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
         lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
         label="rectangle contour",
-        units=units,
+        colorbar_label=units,
         isolevels=True,
     )
-    assert units == contour.units
+    assert units == contour.colorbar_label
+    graph = Graph(contour)
+    fig = graph.to_plotly()
+    if units != '': assert fig.data[0].colorbar.title.text == units 
+    else: assert fig.data[0].colorbar.title.text == None
 
 
 def test_basic_graph(parabola, Assert, not_core):
@@ -588,7 +617,7 @@ def test_contour_interpolate(tilted_contour, Assert, not_core):
     finite = np.isfinite(fig.data[0].z)
     assert np.isclose(np.average(fig.data[0].z[finite]), expected_average)
     assert len(fig.layout.shapes) == 0
-    expected_colorscale = px.colors.get_colorscale("turbid_r")
+    expected_colorscale = [[0, _config.VASP_COLORS["blue"]], [0.5, "white"], [1, _config.VASP_COLORS["red"]]]
     assert len(fig.data[0].colorscale) == len(expected_colorscale)
     for actual, expected in zip(fig.data[0].colorscale, expected_colorscale):
         Assert.allclose(actual[0], expected[0])

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -130,14 +130,18 @@ def test_contour_color_scheme(color_scheme):
     fig = graph.to_plotly()
     expected_colorscale = []
     if (color_scheme == "auto") or (color_scheme == "positive"):
-        expected_colorscale = ((0, 'white'), (1, _config.VASP_COLORS["red"]))
-    elif (color_scheme == "negative"):
+        expected_colorscale = ((0, "white"), (1, _config.VASP_COLORS["red"]))
+    elif color_scheme == "negative":
         expected_colorscale = ((0, _config.VASP_COLORS["blue"]), (1, "white"))
-    elif (color_scheme == "signed"):
-        expected_colorscale = ((0, _config.VASP_COLORS["blue"]), (0.5, "white"), (1, _config.VASP_COLORS["red"]))
-    else: raise NotImplementedError(f"Color scheme {color_scheme} not implemented.")
+    elif color_scheme == "signed":
+        expected_colorscale = (
+            (0, _config.VASP_COLORS["blue"]),
+            (0.5, "white"),
+            (1, _config.VASP_COLORS["red"]),
+        )
+    else:
+        raise NotImplementedError(f"Color scheme {color_scheme} not implemented.")
     assert fig.data[0].colorscale == expected_colorscale
-    
 
 
 @pytest.mark.xfail
@@ -155,7 +159,9 @@ def test_contour_contrast_mode(contrast_mode):
     raise NotImplementedError("Contrast mode currently has no effect on plotting.")
 
 
-@pytest.mark.parametrize("color_limits", [None, (None, None), (-9, None), (None, 9), (-11, 11)])
+@pytest.mark.parametrize(
+    "color_limits", [None, (None, None), (-9, None), (None, 9), (-11, 11)]
+)
 def test_contour_color_limits(color_limits):
     contour = Contour(
         data=np.linspace(-10, 10, 20 * 18).reshape((20, 18)),
@@ -168,10 +174,12 @@ def test_contour_color_limits(color_limits):
     graph = Graph(contour)
     expected_zmin = -10
     expected_zmax = 10
-    if (color_limits is not None):
+    if color_limits is not None:
         _zmin, _zmax = color_limits
-        if _zmin is not None: expected_zmin = _zmin
-        if _zmax is not None: expected_zmax = _zmax
+        if _zmin is not None:
+            expected_zmin = _zmin
+        if _zmax is not None:
+            expected_zmax = _zmax
     fig = graph.to_plotly()
     assert fig.data[0].zmin == expected_zmin
     assert fig.data[0].zmax == expected_zmax
@@ -189,8 +197,10 @@ def test_contour_colorbar_label(units):
     assert units == contour.colorbar_label
     graph = Graph(contour)
     fig = graph.to_plotly()
-    if units != '': assert fig.data[0].colorbar.title.text == units 
-    else: assert fig.data[0].colorbar.title.text == None
+    if units != "":
+        assert fig.data[0].colorbar.title.text == units
+    else:
+        assert fig.data[0].colorbar.title.text == None
 
 
 def test_basic_graph(parabola, Assert, not_core):
@@ -617,7 +627,11 @@ def test_contour_interpolate(tilted_contour, Assert, not_core):
     finite = np.isfinite(fig.data[0].z)
     assert np.isclose(np.average(fig.data[0].z[finite]), expected_average)
     assert len(fig.layout.shapes) == 0
-    expected_colorscale = [[0, _config.VASP_COLORS["blue"]], [0.5, "white"], [1, _config.VASP_COLORS["red"]]]
+    expected_colorscale = [
+        [0, _config.VASP_COLORS["blue"]],
+        [0.5, "white"],
+        [1, _config.VASP_COLORS["red"]],
+    ]
     assert len(fig.data[0].colorscale) == len(expected_colorscale)
     for actual, expected in zip(fig.data[0].colorscale, expected_colorscale):
         Assert.allclose(actual[0], expected[0])

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -115,6 +115,42 @@ def complex_quiver():
     )
 
 
+@pytest.mark.parametrize("color_scheme", ["auto", "signed", "positive", "negative"])
+def test_color_scheme(color_scheme):
+    contour = Contour(
+        data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
+        lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
+        label="rectangle contour",
+        color_scheme=color_scheme,
+        isolevels=True,
+    )
+    assert color_scheme == contour.color_scheme
+
+
+@pytest.mark.parametrize("contrast_mode", [True, False])
+def test_contrast_mode(contrast_mode):
+    contour = Contour(
+        data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
+        lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
+        label="rectangle contour",
+        contrast_mode=contrast_mode,
+        isolevels=True,
+    )
+    assert contrast_mode == contour.contrast_mode
+
+
+@pytest.mark.parametrize("color_diverging_around_zero", [True, False])
+def test_contrast_mode(color_diverging_around_zero):
+    contour = Contour(
+        data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
+        lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
+        label="rectangle contour",
+        color_diverging_around_zero=color_diverging_around_zero,
+        isolevels=True,
+    )
+    assert color_diverging_around_zero == contour.color_diverging_around_zero
+
+
 def test_basic_graph(parabola, Assert, not_core):
     graph = Graph(parabola)
     fig = graph.to_plotly()

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -81,7 +81,6 @@ def tilted_contour():
         label="tilted contour",
         supercell=(2, 1),
         show_cell=False,
-        contrast_mode=True,
     )
 
 

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -591,6 +591,22 @@ def test_contour_show_contour_values(rectangle_contour, show_contour_values, not
     assert fig.data[0].contours.showlabels == show_contour_values
 
 
+def test_legend_positioning(parabola, sine, Assert, not_core):
+    graph = Graph([sine, parabola])
+    fig = graph.to_plotly()
+    assert len(fig.data) == 2
+    assert fig.layout.legend.x is None # actually at 1.02, but plotly does not expose this until set explicitly
+
+
+def test_contour_legend_with_colorbar(rectangle_contour, parabola, Assert, not_core):
+    graph = Graph([rectangle_contour, parabola])
+    fig = graph.to_plotly()
+    assert len(fig.data) == 2
+    assert hasattr(fig.data[0], "colorbar") and fig.data[0].colorbar
+    assert hasattr(fig.data[0].colorbar, "x")
+    assert fig.data[0].colorbar.x == 1.02
+    assert fig.layout.legend.x == pytest.approx(fig.data[0].colorbar.x + 0.18, abs=1e-6)
+
 def check_unit_cell(unit_cell, x, y, zero):
     assert unit_cell.type == "path"
     assert unit_cell.path == f"M 0 0 L {x} {zero} L {x} {y} L {zero} {y} Z"

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -1,3 +1,6 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+
 from types import SimpleNamespace
 
 import numpy as np

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -1,0 +1,32 @@
+from py4vasp._util import density
+from py4vasp._util import index
+from py4vasp._calculation.structure import Structure
+
+import numpy as np
+
+import pytest
+
+
+def test_view(raw_data, Assert):
+    structure = Structure.from_data(raw_data.structure("Fe3O4"))
+    data3d = np.ones(shape=(3,4,5,10))
+    selector = index.Selector({3: {"spin up": 0, "spin down": 1}}, data3d)
+
+    visualizer = density.Visualizer(structure, selector)
+    view = visualizer.to_view([("spin up",), ("spin down",)])
+
+    Assert.same_structure_view(structure.to_view(), view)
+    Assert.allclose(view.grid_scalars[0].quantity, data3d.T[0])
+    Assert.allclose(view.grid_scalars[1].quantity, data3d.T[1])
+
+@pytest.mark.parametrize("supercell", [(2,3,2), 3, (2,5,1)])
+def test_view_supercell(raw_data, supercell, Assert):
+    structure = Structure.from_data(raw_data.structure("Fe3O4"))
+    data3d = np.ones(shape=(3,4,5))
+    selector = index.Selector({}, data3d)
+
+    visualizer = density.Visualizer(structure, selector)
+    view = visualizer.to_view([()], supercell=supercell)
+
+    Assert.same_structure_view(structure.to_view(supercell=supercell), view)
+    Assert.allclose(view.grid_scalars[0].quantity, data3d.T)

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import numpy as np
+from py4vasp.exception import IncorrectUsage
 import pytest
 
 from py4vasp import raw
@@ -120,23 +121,23 @@ def test_view_supercell(visualizer, supercell, Assert):
 
 
 @pytest.mark.parametrize(
-    "kwargs, index, position",
-    (({"a": 0.2}, 0, 1), ({"b": 0.5}, 1, 2), ({"c": 1.3}, 2, 1)),
+    "slice_args, index, position",
+    ((density.SliceArguments(a=0.2), 0, 1), (density.SliceArguments(b=0.5), 1, 2), (density.SliceArguments(c=1.3), 2, 1)),
 )
-def test_contour_from_mapping(visualizer, kwargs, index, position, Assert):
+def test_contour_from_mapping(visualizer, slice_args, index, position, Assert):
     graph = visualizer.to_contour_from_mapping(
-        visualizer.ref.selector, visualizer.ref.selections, **kwargs
+        visualizer.ref.selector, visualizer.ref.selections, slice_args
     )
     _check_contour(graph, visualizer, index, position, Assert)
 
 
 @pytest.mark.parametrize(
-    "kwargs, index, position",
-    (({"a": 0.2}, 0, 1), ({"b": 0.5}, 1, 2), ({"c": 1.3}, 2, 1)),
+    "slice_args, index, position",
+    ((density.SliceArguments(a=0.2), 0, 1), (density.SliceArguments(b=0.5), 1, 2), (density.SliceArguments(c=1.3), 2, 1)),
 )
-def test_contour_from_data(visualizer_selected, kwargs, index, position, Assert):
+def test_contour_from_data(visualizer_selected, slice_args, index, position, Assert):
     graph = visualizer_selected.to_contour_from_data(
-        visualizer_selected.ref.data3d[0], **kwargs
+        visualizer_selected.ref.data3d[0], slice_args
     )
     _check_contour(graph, visualizer_selected, index, position, Assert)
 
@@ -165,12 +166,11 @@ def _check_contour(graph, visualizer, index, position, Assert):
 
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_contour_from_mapping_supercell(visualizer, supercell, Assert):
-    kwargs, index = ({"c": 1.3}, 2)
+    slice_args, index = (density.SliceArguments(c=1.3, supercell=supercell), 2)
     graph = visualizer.to_contour_from_mapping(
         visualizer.ref.selector,
         visualizer.ref.selections,
-        supercell=supercell,
-        **kwargs,
+        slice_args=slice_args,
     )
     _check_contour_supercell(graph, visualizer, index, supercell, Assert)
 
@@ -191,25 +191,27 @@ def _check_contour_supercell(graph, visualizer, index, supercell, Assert):
 
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_contour_from_data_supercell(visualizer_selected, supercell, Assert):
-    kwargs, index = ({"c": 1.3}, 2)
+    slice_args, index = (density.SliceArguments(c=1.3, supercell=supercell), 2)
     graph = visualizer_selected.to_contour_from_data(
-        visualizer_selected.ref.data3d[0], supercell=supercell, **kwargs
+        visualizer_selected.ref.data3d[0], slice_args
     )
     _check_contour_supercell(graph, visualizer_selected, index, supercell, Assert)
 
 
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_contour_from_mapping_normal(visualizer, normal, Assert):
+    slice_args = density.SliceArguments(c=1.3, normal=normal)
     graph = visualizer.to_contour_from_mapping(
-        visualizer.ref.selector, visualizer.ref.selections, normal=normal, c=1.3
+        visualizer.ref.selector, visualizer.ref.selections, slice_args
     )
     _check_contour_normal(graph, visualizer, normal, Assert)
 
 
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_contour_from_data_normal(visualizer_selected, normal, Assert):
+    slice_args = density.SliceArguments(c=1.3, normal=normal)
     graph = visualizer_selected.to_contour_from_data(
-        visualizer_selected.ref.data3d[0], normal=normal, c=1.3
+        visualizer_selected.ref.data3d[0], slice_args
     )
     _check_contour_normal(graph, visualizer_selected, normal, Assert)
 
@@ -225,17 +227,17 @@ def _check_contour_normal(graph, visualizer, normal, Assert):
 
 
 def test_quiver_from_mapping(visualizer_quiver, Assert):
-    kwargs, index, position = ({"c": 1.3}, 2, 1)
+    slice_args, index, position = (density.SliceArguments(c=1.3), 2, 1)
     graph = visualizer_quiver.to_quiver_from_mapping(
-        visualizer_quiver.ref.selector, visualizer_quiver.ref.selections, **kwargs
+        visualizer_quiver.ref.selector, visualizer_quiver.ref.selections, slice_args
     )
     _check_quiver(graph, visualizer_quiver, position, index, Assert)
 
 
 def test_quiver_from_data(visualizer_quiver_selected, Assert):
-    kwargs, index, position = ({"c": 1.3}, 2, 1)
+    slice_args, index, position = (density.SliceArguments(c=1.3), 2, 1)
     graph = visualizer_quiver_selected.to_quiver_from_data(
-        visualizer_quiver_selected.ref.data3d[0], **kwargs
+        visualizer_quiver_selected.ref.data3d[0], slice_args
     )
     _check_quiver(graph, visualizer_quiver_selected, position, index, Assert)
 
@@ -264,21 +266,20 @@ def _check_quiver(graph, visualizer_quiver, position, index, Assert):
 
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_quiver_from_mapping_supercell(visualizer_quiver, supercell, Assert):
-    kwargs, index = ({"c": 1.3}, 2)
+    slice_args, index = (density.SliceArguments(c=1.3, supercell=supercell), 2)
     graph = visualizer_quiver.to_quiver_from_mapping(
         visualizer_quiver.ref.selector,
         visualizer_quiver.ref.selections,
-        supercell=supercell,
-        **kwargs,
+        slice_args,
     )
     _check_quiver_supercell(graph, visualizer_quiver, supercell, index, Assert)
 
 
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_quiver_from_data_supercell(visualizer_quiver_selected, supercell, Assert):
-    kwargs, index = ({"c": 1.3}, 2)
+    slice_args, index = (density.SliceArguments(c=1.3, supercell=supercell), 2)
     graph = visualizer_quiver_selected.to_quiver_from_data(
-        visualizer_quiver_selected.ref.data3d[0], supercell=supercell, **kwargs
+        visualizer_quiver_selected.ref.data3d[0], slice_args
     )
     _check_quiver_supercell(graph, visualizer_quiver_selected, supercell, index, Assert)
 
@@ -299,19 +300,20 @@ def _check_quiver_supercell(graph, visualizer_quiver, supercell, index, Assert):
 
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_quiver_from_mapping_normal(visualizer_quiver, normal, Assert):
+    slice_args = density.SliceArguments(c=1.3, normal=normal)
     graph = visualizer_quiver.to_quiver_from_mapping(
         visualizer_quiver.ref.selector,
         visualizer_quiver.ref.selections,
-        normal=normal,
-        c=1.3,
+        slice_args
     )
     _check_quiver_normal(graph, visualizer_quiver, normal, Assert)
 
 
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_quiver_from_mapping_normal(visualizer_quiver_selected, normal, Assert):
+    slice_args = density.SliceArguments(c=1.3, normal=normal)
     graph = visualizer_quiver_selected.to_quiver_from_data(
-        visualizer_quiver_selected.ref.data3d[0], normal=normal, c=1.3
+        visualizer_quiver_selected.ref.data3d[0], slice_args
     )
     _check_quiver_normal(graph, visualizer_quiver_selected, normal, Assert)
 
@@ -327,6 +329,18 @@ def _check_quiver_normal(graph, visualizer_quiver, normal, Assert):
 
 
 def test_quiver_collinear(visualizer, Assert):
+    slice_args = density.SliceArguments(c=1.3)
     graph = visualizer.to_quiver_from_mapping(
-        visualizer.ref.selector, visualizer.ref.selections, c=1.3
+        visualizer.ref.selector, visualizer.ref.selections, slice_args
     )
+
+def test_slice_arguments():
+    with pytest.raises(IncorrectUsage): density.SliceArguments(a=1.0,b=1.0)
+    with pytest.raises(IncorrectUsage): density.SliceArguments(b=1.0,c=1.0)
+    with pytest.raises(IncorrectUsage): density.SliceArguments(a=1.0,c=1.0)
+    with pytest.raises(IncorrectUsage): density.SliceArguments(a=1.0,b=1.0,c=1.0)
+    with pytest.raises(IncorrectUsage): density.SliceArguments()
+
+    slice_args = density.SliceArguments(b=1.0, supercell=(1,1,1))
+    assert slice_args.a is None
+    assert slice_args.c is None

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -209,7 +209,6 @@ def test_quiver_normal(visualizer_quiver, normal, Assert):
         Assert.allclose(series.lattice.cell, expected_plane.cell)
         Assert.allclose(series.lattice.vectors, expected_plane.vectors)
 
+
 def test_quiver_collinear(visualizer, Assert):
-    graph = visualizer.to_quiver(
-        visualizer.ref.selections, c=1.3
-    )
+    graph = visualizer.to_quiver(visualizer.ref.selections, c=1.3)

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -40,7 +40,14 @@ def _make_visualizer(raw_data, request, data_ndim: int):
         else:
             raise NotImplementedError(f"ndim {data_ndim} not implemented.")
         ref_data = [data3d.T[0]]
-        selector = index.Selector({-1: {"": 0,}}, data3d)
+        selector = index.Selector(
+            {
+                -1: {
+                    "": 0,
+                }
+            },
+            data3d,
+        )
         selections = [("",)]
     else:
         raise NotImplementedError(f"Requested param {request.param} not implemented.")
@@ -63,6 +70,7 @@ def visualizer(raw_data, request):
 @pytest.fixture(params=["selected"])
 def visualizer_selected(raw_data, request):
     return _make_visualizer(raw_data, request, 3)
+
 
 @pytest.fixture(params=["simple", "with_selections"])
 def visualizer_quiver(raw_data, request):
@@ -92,7 +100,9 @@ def test_view(visualizer, Assert):
 
 @pytest.mark.parametrize("supercell", [(2, 3, 2), 3, (2, 5, 1)])
 def test_view_supercell(visualizer, supercell, Assert):
-    view = visualizer.to_view(visualizer.ref.selector, visualizer.ref.selections, supercell=supercell)
+    view = visualizer.to_view(
+        visualizer.ref.selector, visualizer.ref.selections, supercell=supercell
+    )
 
     Assert.same_structure_view(
         visualizer.ref.structure.to_view(supercell=supercell), view
@@ -114,7 +124,9 @@ def test_view_supercell(visualizer, supercell, Assert):
     (({"a": 0.2}, 0, 1), ({"b": 0.5}, 1, 2), ({"c": 1.3}, 2, 1)),
 )
 def test_contour_from_mapping(visualizer, kwargs, index, position, Assert):
-    graph = visualizer.to_contour_from_mapping(visualizer.ref.selector, visualizer.ref.selections, **kwargs)
+    graph = visualizer.to_contour_from_mapping(
+        visualizer.ref.selector, visualizer.ref.selections, **kwargs
+    )
     _check_contour(graph, visualizer, index, position, Assert)
 
 
@@ -123,10 +135,12 @@ def test_contour_from_mapping(visualizer, kwargs, index, position, Assert):
     (({"a": 0.2}, 0, 1), ({"b": 0.5}, 1, 2), ({"c": 1.3}, 2, 1)),
 )
 def test_contour_from_data(visualizer_selected, kwargs, index, position, Assert):
-    graph = visualizer_selected.to_contour_from_data(visualizer_selected.ref.data3d[0], **kwargs)
+    graph = visualizer_selected.to_contour_from_data(
+        visualizer_selected.ref.data3d[0], **kwargs
+    )
     _check_contour(graph, visualizer_selected, index, position, Assert)
 
-    
+
 def _check_contour(graph, visualizer, index, position, Assert):
     assert len(graph) == len(visualizer.ref.selections)
     for sel, series, data in zip(
@@ -148,13 +162,18 @@ def _check_contour(graph, visualizer, index, position, Assert):
             expected_label = ""
         assert series.label == expected_label
 
+
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_contour_from_mapping_supercell(visualizer, supercell, Assert):
     kwargs, index = ({"c": 1.3}, 2)
     graph = visualizer.to_contour_from_mapping(
-        visualizer.ref.selector, visualizer.ref.selections, supercell=supercell, **kwargs
+        visualizer.ref.selector,
+        visualizer.ref.selections,
+        supercell=supercell,
+        **kwargs,
     )
     _check_contour_supercell(graph, visualizer, index, supercell, Assert)
+
 
 def _check_contour_supercell(graph, visualizer, index, supercell, Assert):
     assert len(graph) == len(visualizer.ref.selections)
@@ -169,6 +188,7 @@ def _check_contour_supercell(graph, visualizer, index, supercell, Assert):
         )
         Assert.allclose(series.supercell, expected_supercell)
 
+
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_contour_from_data_supercell(visualizer_selected, supercell, Assert):
     kwargs, index = ({"c": 1.3}, 2)
@@ -180,12 +200,17 @@ def test_contour_from_data_supercell(visualizer_selected, supercell, Assert):
 
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_contour_from_mapping_normal(visualizer, normal, Assert):
-    graph = visualizer.to_contour_from_mapping(visualizer.ref.selector, visualizer.ref.selections, normal=normal, c=1.3)
+    graph = visualizer.to_contour_from_mapping(
+        visualizer.ref.selector, visualizer.ref.selections, normal=normal, c=1.3
+    )
     _check_contour_normal(graph, visualizer, normal, Assert)
+
 
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_contour_from_data_normal(visualizer_selected, normal, Assert):
-    graph = visualizer_selected.to_contour_from_data(visualizer_selected.ref.data3d[0], normal=normal, c=1.3)
+    graph = visualizer_selected.to_contour_from_data(
+        visualizer_selected.ref.data3d[0], normal=normal, c=1.3
+    )
     _check_contour_normal(graph, visualizer_selected, normal, Assert)
 
 
@@ -201,12 +226,17 @@ def _check_contour_normal(graph, visualizer, normal, Assert):
 
 def test_quiver_from_mapping(visualizer_quiver, Assert):
     kwargs, index, position = ({"c": 1.3}, 2, 1)
-    graph = visualizer_quiver.to_quiver_from_mapping(visualizer_quiver.ref.selector, visualizer_quiver.ref.selections, **kwargs)
+    graph = visualizer_quiver.to_quiver_from_mapping(
+        visualizer_quiver.ref.selector, visualizer_quiver.ref.selections, **kwargs
+    )
     _check_quiver(graph, visualizer_quiver, position, index, Assert)
+
 
 def test_quiver_from_data(visualizer_quiver_selected, Assert):
     kwargs, index, position = ({"c": 1.3}, 2, 1)
-    graph = visualizer_quiver_selected.to_quiver_from_data(visualizer_quiver_selected.ref.data3d[0], **kwargs)
+    graph = visualizer_quiver_selected.to_quiver_from_data(
+        visualizer_quiver_selected.ref.data3d[0], **kwargs
+    )
     _check_quiver(graph, visualizer_quiver_selected, position, index, Assert)
 
 
@@ -237,9 +267,12 @@ def test_quiver_from_mapping_supercell(visualizer_quiver, supercell, Assert):
     kwargs, index = ({"c": 1.3}, 2)
     graph = visualizer_quiver.to_quiver_from_mapping(
         visualizer_quiver.ref.selector,
-        visualizer_quiver.ref.selections, supercell=supercell, **kwargs
+        visualizer_quiver.ref.selections,
+        supercell=supercell,
+        **kwargs,
     )
     _check_quiver_supercell(graph, visualizer_quiver, supercell, index, Assert)
+
 
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_quiver_from_data_supercell(visualizer_quiver_selected, supercell, Assert):
@@ -248,6 +281,7 @@ def test_quiver_from_data_supercell(visualizer_quiver_selected, supercell, Asser
         visualizer_quiver_selected.ref.data3d[0], supercell=supercell, **kwargs
     )
     _check_quiver_supercell(graph, visualizer_quiver_selected, supercell, index, Assert)
+
 
 def _check_quiver_supercell(graph, visualizer_quiver, supercell, index, Assert):
     assert len(graph) == len(visualizer_quiver.ref.selections)
@@ -267,9 +301,12 @@ def _check_quiver_supercell(graph, visualizer_quiver, supercell, index, Assert):
 def test_quiver_from_mapping_normal(visualizer_quiver, normal, Assert):
     graph = visualizer_quiver.to_quiver_from_mapping(
         visualizer_quiver.ref.selector,
-        visualizer_quiver.ref.selections, normal=normal, c=1.3
+        visualizer_quiver.ref.selections,
+        normal=normal,
+        c=1.3,
     )
     _check_quiver_normal(graph, visualizer_quiver, normal, Assert)
+
 
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_quiver_from_mapping_normal(visualizer_quiver_selected, normal, Assert):
@@ -277,6 +314,7 @@ def test_quiver_from_mapping_normal(visualizer_quiver_selected, normal, Assert):
         visualizer_quiver_selected.ref.data3d[0], normal=normal, c=1.3
     )
     _check_quiver_normal(graph, visualizer_quiver_selected, normal, Assert)
+
 
 def _check_quiver_normal(graph, visualizer_quiver, normal, Assert):
     assert len(graph) == len(visualizer_quiver.ref.selections)
@@ -289,4 +327,6 @@ def _check_quiver_normal(graph, visualizer_quiver, normal, Assert):
 
 
 def test_quiver_collinear(visualizer, Assert):
-    graph = visualizer.to_quiver_from_mapping(visualizer.ref.selector, visualizer.ref.selections, c=1.3)
+    graph = visualizer.to_quiver_from_mapping(
+        visualizer.ref.selector, visualizer.ref.selections, c=1.3
+    )

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -33,23 +33,6 @@ def _make_visualizer(raw_data, request, data_ndim: int):
         ref_data = [data3d.T[0], data3d.T[1]]
         selector = index.Selector({-1: {"spin up": 0, "spin down": 1}}, data3d)
         selections = [("spin up",), ("spin down",)]
-    elif request.param == "selected":
-        if data_ndim == 3:
-            data3d = np.ones(shape=(3, 4, 5, 10))
-        elif data_ndim == 4:
-            data3d = np.ones(shape=(3, 4, 5, 3, 10))
-        else:
-            raise NotImplementedError(f"ndim {data_ndim} not implemented.")
-        ref_data = [data3d.T[0]]
-        selector = index.Selector(
-            {
-                -1: {
-                    "": 0,
-                }
-            },
-            data3d,
-        )
-        selections = [("",)]
     else:
         raise NotImplementedError(f"Requested param {request.param} not implemented.")
 
@@ -68,18 +51,8 @@ def visualizer(raw_data, request):
     return _make_visualizer(raw_data, request, 3)
 
 
-@pytest.fixture(params=["selected"])
-def visualizer_selected(raw_data, request):
-    return _make_visualizer(raw_data, request, 3)
-
-
 @pytest.fixture(params=["simple", "with_selections"])
 def visualizer_quiver(raw_data, request):
-    return _make_visualizer(raw_data, request, 4)
-
-
-@pytest.fixture(params=["selected"])
-def visualizer_quiver_selected(raw_data, request):
     return _make_visualizer(raw_data, request, 4)
 
 

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -1,25 +1,34 @@
 from types import SimpleNamespace
-from py4vasp import raw
-from py4vasp._util import density, slicing
-from py4vasp._util import index
-from py4vasp._calculation.structure import Structure
-from py4vasp._calculation.density import Density
 
 import numpy as np
 import pytest
 
+from py4vasp import raw
+from py4vasp._calculation.density import Density
+from py4vasp._calculation.structure import Structure
+from py4vasp._util import density, index, slicing
 
-@pytest.fixture(params=["simple", "with_selections"])
-def visualizer(raw_data, request): 
+
+def _make_visualizer(raw_data, request, data_ndim: int):
     structure = Structure.from_data(raw_data.structure("Sr2TiO4"))
     raw_density = raw_data.density("Sr2TiO4")
-    if (request.param == "simple"):
-        data3d = np.ones(shape=(3,4,5))
+    if request.param == "simple":
+        if data_ndim == 3:
+            data3d = np.ones(shape=(3, 4, 5))
+        elif data_ndim == 4:
+            data3d = np.ones(shape=(3, 4, 5, 3))
+        else:
+            raise NotImplementedError(f"ndim {data_ndim} not implemented.")
         ref_data = [data3d.T]
         selector = index.Selector({}, data3d)
         selections = [()]
-    elif (request.param == "with_selections"):
-        data3d = np.ones(shape=(3,4,5,10))
+    elif request.param == "with_selections":
+        if data_ndim == 3:
+            data3d = np.ones(shape=(3, 4, 5, 10))
+        elif data_ndim == 4:
+            data3d = np.ones(shape=(3, 4, 5, 3, 10))
+        else:
+            raise NotImplementedError(f"ndim {data_ndim} not implemented.")
         ref_data = [data3d.T[0], data3d.T[1]]
         selector = index.Selector({-1: {"spin up": 0, "spin down": 1}}, data3d)
         selections = [("spin up",), ("spin down",)]
@@ -36,29 +45,13 @@ def visualizer(raw_data, request):
 
 
 @pytest.fixture(params=["simple", "with_selections"])
-def visualizer_quiver(raw_data, request): 
-    structure = Structure.from_data(raw_data.structure("Sr2TiO4"))
-    raw_density = raw_data.density("Sr2TiO4")
-    if (request.param == "simple"):
-        data3d = np.ones(shape=(3,4,5,3))
-        ref_data = [data3d.T]
-        selector = index.Selector({}, data3d)
-        selections = [()]
-    elif (request.param == "with_selections"):
-        data3d = np.ones(shape=(3,4,5,3,10))
-        ref_data = [data3d.T[0], data3d.T[1]]
-        selector = index.Selector({-1: {"spin up": 0, "spin down": 1}}, data3d)
-        selections = [("spin up",), ("spin down",)]
-    else:
-        raise NotImplementedError(f"Requested param {request.param} not implemented.")
+def visualizer(raw_data, request):
+    return _make_visualizer(raw_data, request, 3)
 
-    visualizer = density.Visualizer(structure, selector)
-    visualizer.ref = SimpleNamespace()
-    visualizer.ref.structure = structure
-    visualizer.ref.data3d = ref_data
-    visualizer.ref.selections = selections
-    visualizer.ref.density = Density.from_data(raw_density)
-    return visualizer
+
+@pytest.fixture(params=["simple", "with_selections"])
+def visualizer_quiver(raw_data, request):
+    return _make_visualizer(raw_data, request, 4)
 
 
 def test_view(visualizer, Assert):
@@ -66,34 +59,47 @@ def test_view(visualizer, Assert):
 
     Assert.same_structure_view(visualizer.ref.structure.to_view(), view)
     assert len(view.grid_scalars) == len(visualizer.ref.selections)
-    for sel, scalar, data in zip(visualizer.ref.selections, view.grid_scalars, visualizer.ref.data3d):
-        if (len(sel)>0): expected_label = sel[0]
-        else: expected_label = ""
-        assert (scalar.label == expected_label) 
+    for sel, scalar, data in zip(
+        visualizer.ref.selections, view.grid_scalars, visualizer.ref.data3d
+    ):
+        if len(sel) > 0:
+            expected_label = sel[0]
+        else:
+            expected_label = ""
+        assert scalar.label == expected_label
         Assert.allclose(scalar.quantity, data)
 
 
-@pytest.mark.parametrize("supercell", [(2,3,2), 3, (2,5,1)])
+@pytest.mark.parametrize("supercell", [(2, 3, 2), 3, (2, 5, 1)])
 def test_view_supercell(visualizer, supercell, Assert):
     view = visualizer.to_view(visualizer.ref.selections, supercell=supercell)
 
-    Assert.same_structure_view(visualizer.ref.structure.to_view(supercell=supercell), view)
+    Assert.same_structure_view(
+        visualizer.ref.structure.to_view(supercell=supercell), view
+    )
     assert len(view.grid_scalars) == len(visualizer.ref.selections)
-    for sel, scalar, data in zip(visualizer.ref.selections, view.grid_scalars, visualizer.ref.data3d):
-        if (len(sel)>0): expected_label = sel[0]
-        else: expected_label = ""
-        assert (scalar.label == expected_label) 
+    for sel, scalar, data in zip(
+        visualizer.ref.selections, view.grid_scalars, visualizer.ref.data3d
+    ):
+        if len(sel) > 0:
+            expected_label = sel[0]
+        else:
+            expected_label = ""
+        assert scalar.label == expected_label
         Assert.allclose(scalar.quantity, data)
-    
+
+
 @pytest.mark.parametrize(
     "kwargs, index, position",
     (({"a": 0.2}, 0, 1), ({"b": 0.5}, 1, 2), ({"c": 1.3}, 2, 1)),
 )
 def test_contour(visualizer, kwargs, index, position, Assert):
     graph = visualizer.to_contour(visualizer.ref.selections, **kwargs)
-    
+
     assert len(graph) == len(visualizer.ref.selections)
-    for sel, series, data in zip(visualizer.ref.selections, graph.series, visualizer.ref.data3d):
+    for sel, series, data in zip(
+        visualizer.ref.selections, graph.series, visualizer.ref.data3d
+    ):
         slice_ = [slice(None), slice(None), slice(None)]
         slice_[index] = position
         expected_data = np.array(data)[tuple(slice_)]
@@ -104,17 +110,20 @@ def test_contour(visualizer, kwargs, index, position, Assert):
         expected_products = lattice_vectors @ lattice_vectors.T
         actual_products = series.lattice.vectors @ series.lattice.vectors.T
         Assert.allclose(actual_products, expected_products)
-        if (len(sel)>0): expected_label = sel[0]
-        else: expected_label = ""
-        assert (series.label == expected_label) 
+        if len(sel) > 0:
+            expected_label = sel[0]
+        else:
+            expected_label = ""
+        assert series.label == expected_label
 
-@pytest.mark.parametrize(
-    "supercell", [(2,3), 3, (2,5)]
-)
+
+@pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_contour_supercell(visualizer, supercell, Assert):
     kwargs, index = ({"c": 1.3}, 2)
-    graph = visualizer.to_contour(visualizer.ref.selections, supercell=supercell, **kwargs)
-    
+    graph = visualizer.to_contour(
+        visualizer.ref.selections, supercell=supercell, **kwargs
+    )
+
     assert len(graph) == len(visualizer.ref.selections)
     for series in graph.series:
         lattice_vectors = visualizer.ref.structure.lattice_vectors()
@@ -122,51 +131,57 @@ def test_contour_supercell(visualizer, supercell, Assert):
         expected_products = lattice_vectors @ lattice_vectors.T
         actual_products = series.lattice.vectors @ series.lattice.vectors.T
         Assert.allclose(actual_products, expected_products)
-        expected_supercell = supercell if isinstance(supercell, tuple) else (supercell, supercell)
+        expected_supercell = (
+            supercell if isinstance(supercell, tuple) else (supercell, supercell)
+        )
         Assert.allclose(series.supercell, expected_supercell)
 
 
-@pytest.mark.parametrize(
-    "normal", [None, "auto", "x"]
-)
+@pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_contour_normal(visualizer, normal, Assert):
     graph = visualizer.to_contour(visualizer.ref.selections, normal=normal, c=1.3)
-    
+
     assert len(graph) == len(visualizer.ref.selections)
     for series in graph.series:
-        expected_plane = slicing.plane(visualizer.ref.structure.lattice_vectors(), "c", normal)
+        expected_plane = slicing.plane(
+            visualizer.ref.structure.lattice_vectors(), "c", normal
+        )
         Assert.allclose(series.lattice.cell, expected_plane.cell)
         Assert.allclose(series.lattice.vectors, expected_plane.vectors)
 
 
 def test_quiver(visualizer_quiver, Assert):
-    kwargs,index,position = ({"c": 1.3}, 2, 1)
+    kwargs, index, position = ({"c": 1.3}, 2, 1)
     graph = visualizer_quiver.to_quiver(visualizer_quiver.ref.selections, **kwargs)
-    
+
     assert len(graph) == len(visualizer_quiver.ref.selections)
-    for sel, series, data in zip(visualizer_quiver.ref.selections, graph.series, visualizer_quiver.ref.data3d):
-        slice_ = [slice(0,2), slice(None), slice(None), slice(None)]
-        slice_[index+1] = position
+    for sel, series, data in zip(
+        visualizer_quiver.ref.selections, graph.series, visualizer_quiver.ref.data3d
+    ):
+        slice_ = [slice(0, 2), slice(None), slice(None), slice(None)]
+        slice_[index + 1] = position
         expected_data = np.array(data)[tuple(slice_)]
         Assert.allclose(series.data, expected_data)
-        
+
         lattice_vectors = visualizer_quiver.ref.structure.lattice_vectors()
         lattice_vectors = np.delete(lattice_vectors, index, axis=0)
         expected_products = lattice_vectors @ lattice_vectors.T
         actual_products = series.lattice.vectors @ series.lattice.vectors.T
         Assert.allclose(actual_products, expected_products)
-        if (len(sel)>0): expected_label = sel[0]
-        else: expected_label = ""
-        assert (series.label == expected_label) 
+        if len(sel) > 0:
+            expected_label = sel[0]
+        else:
+            expected_label = ""
+        assert series.label == expected_label
 
 
-@pytest.mark.parametrize(
-    "supercell", [(2,3), 3, (2,5)]
-)
+@pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
 def test_quiver_supercell(visualizer_quiver, supercell, Assert):
     kwargs, index = ({"c": 1.3}, 2)
-    graph = visualizer_quiver.to_quiver(visualizer_quiver.ref.selections, supercell=supercell, **kwargs)
-    
+    graph = visualizer_quiver.to_quiver(
+        visualizer_quiver.ref.selections, supercell=supercell, **kwargs
+    )
+
     assert len(graph) == len(visualizer_quiver.ref.selections)
     for series in graph.series:
         lattice_vectors = visualizer_quiver.ref.structure.lattice_vectors()
@@ -174,18 +189,22 @@ def test_quiver_supercell(visualizer_quiver, supercell, Assert):
         expected_products = lattice_vectors @ lattice_vectors.T
         actual_products = series.lattice.vectors @ series.lattice.vectors.T
         Assert.allclose(actual_products, expected_products)
-        expected_supercell = supercell if isinstance(supercell, tuple) else (supercell, supercell)
+        expected_supercell = (
+            supercell if isinstance(supercell, tuple) else (supercell, supercell)
+        )
         Assert.allclose(series.supercell, expected_supercell)
 
 
-@pytest.mark.parametrize(
-    "normal", [None, "auto", "x"]
-)
+@pytest.mark.parametrize("normal", [None, "auto", "x"])
 def test_quiver_normal(visualizer_quiver, normal, Assert):
-    graph = visualizer_quiver.to_quiver(visualizer_quiver.ref.selections, normal=normal, c=1.3)
-    
+    graph = visualizer_quiver.to_quiver(
+        visualizer_quiver.ref.selections, normal=normal, c=1.3
+    )
+
     assert len(graph) == len(visualizer_quiver.ref.selections)
     for series in graph.series:
-        expected_plane = slicing.plane(visualizer_quiver.ref.structure.lattice_vectors(), "c", normal)
+        expected_plane = slicing.plane(
+            visualizer_quiver.ref.structure.lattice_vectors(), "c", normal
+        )
         Assert.allclose(series.lattice.cell, expected_plane.cell)
         Assert.allclose(series.lattice.vectors, expected_plane.vectors)

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -1,13 +1,13 @@
 from types import SimpleNamespace
 
 import numpy as np
-from py4vasp.exception import IncorrectUsage
 import pytest
 
 from py4vasp import raw
 from py4vasp._calculation.density import Density
 from py4vasp._calculation.structure import Structure
 from py4vasp._util import density, index, slicing
+from py4vasp.exception import IncorrectUsage
 
 
 def _make_visualizer(raw_data, request, data_ndim: int):
@@ -84,7 +84,13 @@ def visualizer_quiver_selected(raw_data, request):
 
 
 def test_view(visualizer, Assert):
-    view = visualizer.to_view(visualizer.ref.selector, visualizer.ref.selections)
+    dataDict = {
+        (selection[0] if selection else ""): (visualizer.ref.selector[selection].T)[
+            np.newaxis
+        ]
+        for selection in visualizer.ref.selections
+    }
+    view = visualizer.to_view(dataDict)
 
     Assert.same_structure_view(visualizer.ref.structure.to_view(), view)
     assert len(view.grid_scalars) == len(visualizer.ref.selections)
@@ -101,9 +107,13 @@ def test_view(visualizer, Assert):
 
 @pytest.mark.parametrize("supercell", [(2, 3, 2), 3, (2, 5, 1)])
 def test_view_supercell(visualizer, supercell, Assert):
-    view = visualizer.to_view(
-        visualizer.ref.selector, visualizer.ref.selections, supercell=supercell
-    )
+    dataDict = {
+        (selection[0] if selection else ""): (visualizer.ref.selector[selection].T)[
+            np.newaxis
+        ]
+        for selection in visualizer.ref.selections
+    }
+    view = visualizer.to_view(dataDict, supercell=supercell)
 
     Assert.same_structure_view(
         visualizer.ref.structure.to_view(supercell=supercell), view
@@ -122,24 +132,19 @@ def test_view_supercell(visualizer, supercell, Assert):
 
 @pytest.mark.parametrize(
     "slice_args, index, position",
-    ((density.SliceArguments(a=0.2), 0, 1), (density.SliceArguments(b=0.5), 1, 2), (density.SliceArguments(c=1.3), 2, 1)),
+    (
+        (density.SliceArguments(a=0.2), 0, 1),
+        (density.SliceArguments(b=0.5), 1, 2),
+        (density.SliceArguments(c=1.3), 2, 1),
+    ),
 )
-def test_contour_from_mapping(visualizer, slice_args, index, position, Assert):
-    graph = visualizer.to_contour_from_mapping(
-        visualizer.ref.selector, visualizer.ref.selections, slice_args
-    )
+def test_contour(visualizer, slice_args, index, position, Assert):
+    dataDict = {
+        (selection[0] if selection else ""): visualizer.ref.selector[selection].T
+        for selection in visualizer.ref.selections
+    }
+    graph = visualizer.to_contour(dataDict, slice_args)
     _check_contour(graph, visualizer, index, position, Assert)
-
-
-@pytest.mark.parametrize(
-    "slice_args, index, position",
-    ((density.SliceArguments(a=0.2), 0, 1), (density.SliceArguments(b=0.5), 1, 2), (density.SliceArguments(c=1.3), 2, 1)),
-)
-def test_contour_from_data(visualizer_selected, slice_args, index, position, Assert):
-    graph = visualizer_selected.to_contour_from_data(
-        visualizer_selected.ref.data3d[0], slice_args
-    )
-    _check_contour(graph, visualizer_selected, index, position, Assert)
 
 
 def _check_contour(graph, visualizer, index, position, Assert):
@@ -165,11 +170,14 @@ def _check_contour(graph, visualizer, index, position, Assert):
 
 
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
-def test_contour_from_mapping_supercell(visualizer, supercell, Assert):
+def test_contour_supercell(visualizer, supercell, Assert):
+    dataDict = {
+        (selection[0] if selection else ""): visualizer.ref.selector[selection].T
+        for selection in visualizer.ref.selections
+    }
     slice_args, index = (density.SliceArguments(c=1.3, supercell=supercell), 2)
-    graph = visualizer.to_contour_from_mapping(
-        visualizer.ref.selector,
-        visualizer.ref.selections,
+    graph = visualizer.to_contour(
+        dataDict,
         slice_args=slice_args,
     )
     _check_contour_supercell(graph, visualizer, index, supercell, Assert)
@@ -189,31 +197,15 @@ def _check_contour_supercell(graph, visualizer, index, supercell, Assert):
         Assert.allclose(series.supercell, expected_supercell)
 
 
-@pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
-def test_contour_from_data_supercell(visualizer_selected, supercell, Assert):
-    slice_args, index = (density.SliceArguments(c=1.3, supercell=supercell), 2)
-    graph = visualizer_selected.to_contour_from_data(
-        visualizer_selected.ref.data3d[0], slice_args
-    )
-    _check_contour_supercell(graph, visualizer_selected, index, supercell, Assert)
-
-
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
-def test_contour_from_mapping_normal(visualizer, normal, Assert):
+def test_contour_normal(visualizer, normal, Assert):
+    dataDict = {
+        (selection[0] if selection else ""): visualizer.ref.selector[selection].T
+        for selection in visualizer.ref.selections
+    }
     slice_args = density.SliceArguments(c=1.3, normal=normal)
-    graph = visualizer.to_contour_from_mapping(
-        visualizer.ref.selector, visualizer.ref.selections, slice_args
-    )
+    graph = visualizer.to_contour(dataDict, slice_args)
     _check_contour_normal(graph, visualizer, normal, Assert)
-
-
-@pytest.mark.parametrize("normal", [None, "auto", "x"])
-def test_contour_from_data_normal(visualizer_selected, normal, Assert):
-    slice_args = density.SliceArguments(c=1.3, normal=normal)
-    graph = visualizer_selected.to_contour_from_data(
-        visualizer_selected.ref.data3d[0], slice_args
-    )
-    _check_contour_normal(graph, visualizer_selected, normal, Assert)
 
 
 def _check_contour_normal(graph, visualizer, normal, Assert):
@@ -226,20 +218,14 @@ def _check_contour_normal(graph, visualizer, normal, Assert):
         Assert.allclose(series.lattice.vectors, expected_plane.vectors)
 
 
-def test_quiver_from_mapping(visualizer_quiver, Assert):
+def test_quiver(visualizer_quiver, Assert):
+    dataDict = {
+        (selection[0] if selection else ""): visualizer_quiver.ref.selector[selection].T
+        for selection in visualizer_quiver.ref.selections
+    }
     slice_args, index, position = (density.SliceArguments(c=1.3), 2, 1)
-    graph = visualizer_quiver.to_quiver_from_mapping(
-        visualizer_quiver.ref.selector, visualizer_quiver.ref.selections, slice_args
-    )
+    graph = visualizer_quiver.to_quiver(dataDict, slice_args)
     _check_quiver(graph, visualizer_quiver, position, index, Assert)
-
-
-def test_quiver_from_data(visualizer_quiver_selected, Assert):
-    slice_args, index, position = (density.SliceArguments(c=1.3), 2, 1)
-    graph = visualizer_quiver_selected.to_quiver_from_data(
-        visualizer_quiver_selected.ref.data3d[0], slice_args
-    )
-    _check_quiver(graph, visualizer_quiver_selected, position, index, Assert)
 
 
 def _check_quiver(graph, visualizer_quiver, position, index, Assert):
@@ -265,23 +251,17 @@ def _check_quiver(graph, visualizer_quiver, position, index, Assert):
 
 
 @pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
-def test_quiver_from_mapping_supercell(visualizer_quiver, supercell, Assert):
+def test_quiver_supercell(visualizer_quiver, supercell, Assert):
+    dataDict = {
+        (selection[0] if selection else ""): visualizer_quiver.ref.selector[selection].T
+        for selection in visualizer_quiver.ref.selections
+    }
     slice_args, index = (density.SliceArguments(c=1.3, supercell=supercell), 2)
-    graph = visualizer_quiver.to_quiver_from_mapping(
-        visualizer_quiver.ref.selector,
-        visualizer_quiver.ref.selections,
+    graph = visualizer_quiver.to_quiver(
+        dataDict,
         slice_args,
     )
     _check_quiver_supercell(graph, visualizer_quiver, supercell, index, Assert)
-
-
-@pytest.mark.parametrize("supercell", [(2, 3), 3, (2, 5)])
-def test_quiver_from_data_supercell(visualizer_quiver_selected, supercell, Assert):
-    slice_args, index = (density.SliceArguments(c=1.3, supercell=supercell), 2)
-    graph = visualizer_quiver_selected.to_quiver_from_data(
-        visualizer_quiver_selected.ref.data3d[0], slice_args
-    )
-    _check_quiver_supercell(graph, visualizer_quiver_selected, supercell, index, Assert)
 
 
 def _check_quiver_supercell(graph, visualizer_quiver, supercell, index, Assert):
@@ -299,23 +279,14 @@ def _check_quiver_supercell(graph, visualizer_quiver, supercell, index, Assert):
 
 
 @pytest.mark.parametrize("normal", [None, "auto", "x"])
-def test_quiver_from_mapping_normal(visualizer_quiver, normal, Assert):
+def test_quiver_normal(visualizer_quiver, normal, Assert):
+    dataDict = {
+        (selection[0] if selection else ""): visualizer_quiver.ref.selector[selection].T
+        for selection in visualizer_quiver.ref.selections
+    }
     slice_args = density.SliceArguments(c=1.3, normal=normal)
-    graph = visualizer_quiver.to_quiver_from_mapping(
-        visualizer_quiver.ref.selector,
-        visualizer_quiver.ref.selections,
-        slice_args
-    )
+    graph = visualizer_quiver.to_quiver(dataDict, slice_args)
     _check_quiver_normal(graph, visualizer_quiver, normal, Assert)
-
-
-@pytest.mark.parametrize("normal", [None, "auto", "x"])
-def test_quiver_from_mapping_normal(visualizer_quiver_selected, normal, Assert):
-    slice_args = density.SliceArguments(c=1.3, normal=normal)
-    graph = visualizer_quiver_selected.to_quiver_from_data(
-        visualizer_quiver_selected.ref.data3d[0], slice_args
-    )
-    _check_quiver_normal(graph, visualizer_quiver_selected, normal, Assert)
 
 
 def _check_quiver_normal(graph, visualizer_quiver, normal, Assert):
@@ -329,18 +300,26 @@ def _check_quiver_normal(graph, visualizer_quiver, normal, Assert):
 
 
 def test_quiver_collinear(visualizer, Assert):
+    dataDict = {
+        (selection[0] if selection else ""): visualizer.ref.selector[selection].T
+        for selection in visualizer.ref.selections
+    }
     slice_args = density.SliceArguments(c=1.3)
-    graph = visualizer.to_quiver_from_mapping(
-        visualizer.ref.selector, visualizer.ref.selections, slice_args
-    )
+    graph = visualizer.to_quiver(dataDict, slice_args)
+
 
 def test_slice_arguments():
-    with pytest.raises(IncorrectUsage): density.SliceArguments(a=1.0,b=1.0)
-    with pytest.raises(IncorrectUsage): density.SliceArguments(b=1.0,c=1.0)
-    with pytest.raises(IncorrectUsage): density.SliceArguments(a=1.0,c=1.0)
-    with pytest.raises(IncorrectUsage): density.SliceArguments(a=1.0,b=1.0,c=1.0)
-    with pytest.raises(IncorrectUsage): density.SliceArguments()
+    with pytest.raises(IncorrectUsage):
+        density.SliceArguments(a=1.0, b=1.0)
+    with pytest.raises(IncorrectUsage):
+        density.SliceArguments(b=1.0, c=1.0)
+    with pytest.raises(IncorrectUsage):
+        density.SliceArguments(a=1.0, c=1.0)
+    with pytest.raises(IncorrectUsage):
+        density.SliceArguments(a=1.0, b=1.0, c=1.0)
+    with pytest.raises(IncorrectUsage):
+        density.SliceArguments()
 
-    slice_args = density.SliceArguments(b=1.0, supercell=(1,1,1))
+    slice_args = density.SliceArguments(b=1.0, supercell=(1, 1, 1))
     assert slice_args.a is None
     assert slice_args.c is None

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -208,3 +208,8 @@ def test_quiver_normal(visualizer_quiver, normal, Assert):
         )
         Assert.allclose(series.lattice.cell, expected_plane.cell)
         Assert.allclose(series.lattice.vectors, expected_plane.vectors)
+
+def test_quiver_collinear(visualizer, Assert):
+    graph = visualizer.to_quiver(
+        visualizer.ref.selections, c=1.3
+    )

--- a/tests/util/test_densityvisualizer.py
+++ b/tests/util/test_densityvisualizer.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 from py4vasp import raw
-from py4vasp._util import density
+from py4vasp._util import density, slicing
 from py4vasp._util import index
 from py4vasp._calculation.structure import Structure
 from py4vasp._calculation.density import Density
@@ -21,7 +21,33 @@ def visualizer(raw_data, request):
     elif (request.param == "with_selections"):
         data3d = np.ones(shape=(3,4,5,10))
         ref_data = [data3d.T[0], data3d.T[1]]
-        selector = index.Selector({3: {"spin up": 0, "spin down": 1}}, data3d)
+        selector = index.Selector({-1: {"spin up": 0, "spin down": 1}}, data3d)
+        selections = [("spin up",), ("spin down",)]
+    else:
+        raise NotImplementedError(f"Requested param {request.param} not implemented.")
+
+    visualizer = density.Visualizer(structure, selector)
+    visualizer.ref = SimpleNamespace()
+    visualizer.ref.structure = structure
+    visualizer.ref.data3d = ref_data
+    visualizer.ref.selections = selections
+    visualizer.ref.density = Density.from_data(raw_density)
+    return visualizer
+
+
+@pytest.fixture(params=["simple", "with_selections"])
+def visualizer_quiver(raw_data, request): 
+    structure = Structure.from_data(raw_data.structure("Sr2TiO4"))
+    raw_density = raw_data.density("Sr2TiO4")
+    if (request.param == "simple"):
+        data3d = np.ones(shape=(3,4,5,3))
+        ref_data = [data3d.T]
+        selector = index.Selector({}, data3d)
+        selections = [()]
+    elif (request.param == "with_selections"):
+        data3d = np.ones(shape=(3,4,5,3,10))
+        ref_data = [data3d.T[0], data3d.T[1]]
+        selector = index.Selector({-1: {"spin up": 0, "spin down": 1}}, data3d)
         selections = [("spin up",), ("spin down",)]
     else:
         raise NotImplementedError(f"Requested param {request.param} not implemented.")
@@ -63,12 +89,11 @@ def test_view_supercell(visualizer, supercell, Assert):
     "kwargs, index, position",
     (({"a": 0.2}, 0, 1), ({"b": 0.5}, 1, 2), ({"c": 1.3}, 2, 1)),
 )
-def test_contour_of_charge(visualizer, kwargs, index, position, Assert):
+def test_contour(visualizer, kwargs, index, position, Assert):
     graph = visualizer.to_contour(visualizer.ref.selections, **kwargs)
     
     assert len(graph) == len(visualizer.ref.selections)
-    for idg, (sel, data) in enumerate(zip(visualizer.ref.selections, visualizer.ref.data3d)):
-        series = graph.series[idg]
+    for sel, series, data in zip(visualizer.ref.selections, graph.series, visualizer.ref.data3d):
         slice_ = [slice(None), slice(None), slice(None)]
         slice_[index] = position
         expected_data = np.array(data)[tuple(slice_)]
@@ -80,5 +105,87 @@ def test_contour_of_charge(visualizer, kwargs, index, position, Assert):
         actual_products = series.lattice.vectors @ series.lattice.vectors.T
         Assert.allclose(actual_products, expected_products)
         if (len(sel)>0): expected_label = sel[0]
-        else: expected_label = "charge"
+        else: expected_label = ""
         assert (series.label == expected_label) 
+
+@pytest.mark.parametrize(
+    "supercell", [(2,3), 3, (2,5)]
+)
+def test_contour_supercell(visualizer, supercell, Assert):
+    kwargs, index = ({"c": 1.3}, 2)
+    graph = visualizer.to_contour(visualizer.ref.selections, supercell=supercell, **kwargs)
+    
+    assert len(graph) == len(visualizer.ref.selections)
+    for series in graph.series:
+        lattice_vectors = visualizer.ref.structure.lattice_vectors()
+        lattice_vectors = np.delete(lattice_vectors, index, axis=0)
+        expected_products = lattice_vectors @ lattice_vectors.T
+        actual_products = series.lattice.vectors @ series.lattice.vectors.T
+        Assert.allclose(actual_products, expected_products)
+        expected_supercell = supercell if isinstance(supercell, tuple) else (supercell, supercell)
+        Assert.allclose(series.supercell, expected_supercell)
+
+
+@pytest.mark.parametrize(
+    "normal", [None, "auto", "x"]
+)
+def test_contour_normal(visualizer, normal, Assert):
+    graph = visualizer.to_contour(visualizer.ref.selections, normal=normal, c=1.3)
+    
+    assert len(graph) == len(visualizer.ref.selections)
+    for series in graph.series:
+        expected_plane = slicing.plane(visualizer.ref.structure.lattice_vectors(), "c", normal)
+        Assert.allclose(series.lattice.cell, expected_plane.cell)
+        Assert.allclose(series.lattice.vectors, expected_plane.vectors)
+
+
+def test_quiver(visualizer_quiver, Assert):
+    kwargs,index,position = ({"c": 1.3}, 2, 1)
+    graph = visualizer_quiver.to_quiver(visualizer_quiver.ref.selections, **kwargs)
+    
+    assert len(graph) == len(visualizer_quiver.ref.selections)
+    for sel, series, data in zip(visualizer_quiver.ref.selections, graph.series, visualizer_quiver.ref.data3d):
+        slice_ = [slice(0,2), slice(None), slice(None), slice(None)]
+        slice_[index+1] = position
+        expected_data = np.array(data)[tuple(slice_)]
+        Assert.allclose(series.data, expected_data)
+        
+        lattice_vectors = visualizer_quiver.ref.structure.lattice_vectors()
+        lattice_vectors = np.delete(lattice_vectors, index, axis=0)
+        expected_products = lattice_vectors @ lattice_vectors.T
+        actual_products = series.lattice.vectors @ series.lattice.vectors.T
+        Assert.allclose(actual_products, expected_products)
+        if (len(sel)>0): expected_label = sel[0]
+        else: expected_label = ""
+        assert (series.label == expected_label) 
+
+
+@pytest.mark.parametrize(
+    "supercell", [(2,3), 3, (2,5)]
+)
+def test_quiver_supercell(visualizer_quiver, supercell, Assert):
+    kwargs, index = ({"c": 1.3}, 2)
+    graph = visualizer_quiver.to_quiver(visualizer_quiver.ref.selections, supercell=supercell, **kwargs)
+    
+    assert len(graph) == len(visualizer_quiver.ref.selections)
+    for series in graph.series:
+        lattice_vectors = visualizer_quiver.ref.structure.lattice_vectors()
+        lattice_vectors = np.delete(lattice_vectors, index, axis=0)
+        expected_products = lattice_vectors @ lattice_vectors.T
+        actual_products = series.lattice.vectors @ series.lattice.vectors.T
+        Assert.allclose(actual_products, expected_products)
+        expected_supercell = supercell if isinstance(supercell, tuple) else (supercell, supercell)
+        Assert.allclose(series.supercell, expected_supercell)
+
+
+@pytest.mark.parametrize(
+    "normal", [None, "auto", "x"]
+)
+def test_quiver_normal(visualizer_quiver, normal, Assert):
+    graph = visualizer_quiver.to_quiver(visualizer_quiver.ref.selections, normal=normal, c=1.3)
+    
+    assert len(graph) == len(visualizer_quiver.ref.selections)
+    for series in graph.series:
+        expected_plane = slicing.plane(visualizer_quiver.ref.structure.lattice_vectors(), "c", normal)
+        Assert.allclose(series.lattice.cell, expected_plane.cell)
+        Assert.allclose(series.lattice.vectors, expected_plane.vectors)


### PR DESCRIPTION
Introducing theming to Contour, allowing to set color_scheme (the type of coloring the plot should receive, depending on whether the data is strictly positive, negative, signed, ...), and color_limits (vmin, vmax on the colorbar scale).

Adding traces_as_periodic as an argument to Contour, which decides whether the given datapoints should correspond to the center of heatmap cells or their bottom-left corner, and the same for the center of shown arrows when using to_quiver, which are always drawn to match an equivalent call to to_contour.

Refactoring density-like classes to use Visualizer as a helper class useful for defining new, density-like classes with implementations of to_view, to_contour and to_quiver. Check density, current_density and exciton_density for examples.

