### PR TITLE
Tilted contours and quivers & color schemes for Contour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.vscode/
 
 # Translations
 *.mo

--- a/src/py4vasp/_calculation/partial_density.py
+++ b/src/py4vasp/_calculation/partial_density.py
@@ -211,7 +211,9 @@ class PartialDensity(base.Refinery, structure.Mixin, view.Mixin):
         spin_label = "both spin channels" if spin == "total" else f"spin {spin}"
         stoichiometry = self._stoichiometry()
         label = f"STM of {stoichiometry} for {spin_label} at constant current={current*1e9:.2f} nA"
-        return Contour(data=scan, lattice=self._get_stm_plane(), label=label)
+        return Contour(
+            data=scan, lattice=self._get_stm_plane(), label=label, color_scheme="stm"
+        )
 
     def _constant_height_stm(self, smoothed_charge, tip_height, spin, stm_settings):
         zz = self._z_index_for_height(tip_height + self._get_highest_z_coord())

--- a/src/py4vasp/_calculation/partial_density.py
+++ b/src/py4vasp/_calculation/partial_density.py
@@ -212,7 +212,10 @@ class PartialDensity(base.Refinery, structure.Mixin, view.Mixin):
         stoichiometry = self._stoichiometry()
         label = f"STM of {stoichiometry} for {spin_label} at constant current={current*1e9:.2f} nA"
         return Contour(
-            data=scan, lattice=self._get_stm_plane(), label=label, color_scheme="stm"
+            data=scan,
+            lattice=self._get_stm_plane(),
+            label=label,
+            color_scheme="monochrome",
         )
 
     def _constant_height_stm(self, smoothed_charge, tip_height, spin, stm_settings):

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -393,12 +393,10 @@ class Contour(trace.Trace):
         return {
             "default": Contour._get_fallback_colormap(),
             "monochrome": "turbid_r",
-            "stm": "turbid_r",
             "positive": "Reds",
             "negative": "Blues_r",
             "sequential": "Viridis",
             "diverging": "RdBu_r",
-            "cyclical": "Twilight",
         }
 
     def _get_color_range(self, z: np.ndarray) -> tuple:

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -64,7 +64,7 @@ class Contour(trace.Trace):
     - "negative": Values are only negative.
     
     Additionally, any of the color maps listed in _COLORMAP_LIST (and their names appended with 
-    "_r") are also valid options.
+    "_r") are also valid inputs, but the list itself might be subject to change on future releases.
     """
     color_limits: tuple = None
     """Is a tuple that sets the minimum and maximum of the color scale. Can be:

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -17,9 +17,6 @@ go = import_.optional("plotly.graph_objects")
 px = import_.optional("plotly.express")
 interpolate = import_.optional("scipy.interpolate")
 
-_COLORMAP_LIST = px.colors.named_colorscales()
-_COLORMAP_LIST_R = [c + "_r" for c in _COLORMAP_LIST]
-
 
 @dataclasses.dataclass
 class Contour(trace.Trace):
@@ -58,13 +55,13 @@ class Contour(trace.Trace):
     """The color_scheme argument informs the chosen color map and parameters for the contours plot.
     It should be chosen according to the nature of the data to be plotted, as one of the following:
     - "auto": py4vasp will try to infer the color scheme on its own.
-    - "monochrome" OR "stm": (Default) Standard colorscheme for stm.
+    - "monochrome" OR "stm": (Default) Standard colorscheme for STM.
     - "positive": Values are only positive.
     - "signed": Values are mixed - positive and negative.
     - "negative": Values are only negative.
     
-    Additionally, any of the color maps listed in _COLORMAP_LIST (and their names appended with 
-    "_r") are also valid inputs, but the list itself might be subject to change on future releases.
+    Additionally, any of the color maps obtained via _get_valid_external_colormaps() are also valid 
+    inputs, but the list itself might be subject to change on future releases.
     """
     color_limits: tuple = None
     """Is a tuple that sets the minimum and maximum of the color scale. Can be:
@@ -384,7 +381,7 @@ class Contour(trace.Trace):
             selected_color_scheme = [[0, color_lower], [1, color_center]]
         # Defaulting to color map if not yet set
         if selected_color_scheme is None:
-            if self.color_scheme in (_COLORMAP_LIST + _COLORMAP_LIST_R):
+            if self.color_scheme in Contour._get_valid_external_colormaps():
                 selected_color_scheme = self.color_scheme
             else:
                 selected_color_scheme = [
@@ -394,6 +391,12 @@ class Contour(trace.Trace):
                 ]
 
         return selected_color_scheme
+
+    @staticmethod
+    def _get_valid_external_colormaps() -> list:
+        return px.colors.named_colorscales() + [
+            cmp + "_r" for cmp in px.colors.named_colorscales()
+        ]
 
     def _get_color_range(self, z: np.ndarray) -> tuple:
         if self.color_limits is None:

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -72,6 +72,27 @@ class Contour(trace.Trace):
     If False, traces (contour and quiver) are shifted so that the heatmap cells visually
     align with the supercell instead. No periodic images are required, but the visual
     presentation might be misleading."""
+    num_periodic_add: int = 0
+    """The number of periodic rows and columns (>= 0) of heatmap/contour cells added to the plot 
+    if and only if interpolation is required and traces_as_periodic is True. 
+    by default, traces_as_periodic will cause the first row and first column to be repeated.
+    num_periodic_add can be used to repeat additional rows and columns.
+    Periodicity will be enforced in the direction of lattice vectors first, then alternate.
+
+    Example:
+    num_periodic_add = 2
+    
+    ```
+    o4|o1o2o3o4|o1o2
+       --------
+    m4|m1m2m3m4|m1m2
+    n4|n1n2n3n4|n1n2
+    o4|o1o2o3o4|o1o2
+       --------
+    m4|m1m2m3m4|m1m2
+    n4|n1n2n3n4|n1n2
+    ```
+    """
     supercell: np.array = (1, 1)
     "Multiple of each lattice vector to be drawn."
     show_cell: bool = True
@@ -194,12 +215,15 @@ class Contour(trace.Trace):
         subsampled_data = data[np.ix_(x_indices, y_indices)]
         return subsampled_data
 
-    def _extend_data_contour(self, data):
+    def _extend_data_contour(self, data, periodic_expand=1):
         xdim, ydim = data.shape
 
+        periodic_left = 0
+        if (self.traces_as_periodic) and (periodic_expand > 1):
+            periodic_left = int(np.floor((periodic_expand - 1) / 2))
         # Create index arrays with "wrapped" boundaries
-        x_indices = np.arange(0, xdim + (1 if self.traces_as_periodic else 0)) % xdim
-        y_indices = np.arange(0, ydim + (1 if self.traces_as_periodic else 0)) % ydim
+        x_indices = (np.arange(0, xdim + periodic_expand) % xdim) - periodic_left
+        y_indices = (np.arange(0, ydim + periodic_expand) % ydim) - periodic_left
 
         # Access data using advanced indexing
         subsampled_data = data[np.ix_(x_indices, y_indices)]
@@ -228,20 +252,49 @@ class Contour(trace.Trace):
         points_per_line = np.sqrt(points_per_area) * self._interpolation_factor
         lengths = np.sum(np.abs(lattice), axis=0)
         shape = np.ceil(points_per_line * lengths).astype(int)
-        line_mesh_a = self._make_mesh(lattice, data.shape[1], 0)
-        line_mesh_b = self._make_mesh(lattice, data.shape[0], 1)
+        # obtain min and max for final grid
+        line_mesh_a = self._make_mesh(lattice, data.shape[1], 0, periodic_expand=1)
+        line_mesh_b = self._make_mesh(lattice, data.shape[0], 1, periodic_expand=1)
+        x_in, y_in = (line_mesh_a[:, np.newaxis] + line_mesh_b[np.newaxis, :]).T
+        x_in = x_in.flatten()
+        y_in = y_in.flatten()
+        xmin, xmax = x_in.min(), x_in.max()
+        ymin, ymax = y_in.min(), y_in.max()
+
+        periodic_expand = 1 + self.num_periodic_add
+        line_mesh_a = self._make_mesh(
+            lattice, data.shape[1], 0, periodic_expand=periodic_expand
+        )
+        line_mesh_b = self._make_mesh(
+            lattice, data.shape[0], 1, periodic_expand=periodic_expand
+        )
         x_in, y_in = (line_mesh_a[:, np.newaxis] + line_mesh_b[np.newaxis, :]).T
         x_in = x_in.flatten()
         y_in = y_in.flatten()
         z_in = (
-            self._extend_data_contour(data).flatten()
-            if self.traces_as_periodic
+            self._extend_data_contour(data, periodic_expand=periodic_expand).flatten()
+            if (self.traces_as_periodic)
             else data.flatten()
         )
-        x_out, y_out = np.meshgrid(
-            np.linspace(x_in.min(), x_in.max(), shape[0]),
-            np.linspace(y_in.min(), y_in.max(), shape[1]),
+
+        # make sure the actual grid aligns with shifts
+        x_line_mesh = np.linspace(
+            xmin,
+            xmax,
+            shape[0] + (1 if self.traces_as_periodic else 0),
+            endpoint=self.traces_as_periodic,
         )
+        y_line_mesh = np.linspace(
+            ymin,
+            ymax,
+            shape[1] + (1 if self.traces_as_periodic else 0),
+            endpoint=self.traces_as_periodic,
+        )
+        x_out, y_out = np.meshgrid(
+            x_line_mesh,
+            y_line_mesh,
+        )
+
         z_out = interpolate.griddata((x_in, y_in), z_in, (x_out, y_out), method="cubic")
         return x_out[0], y_out[:, 0], z_out
 
@@ -251,20 +304,32 @@ class Contour(trace.Trace):
         return (
             x,
             y,
-            self._extend_data_contour(data),
+            self._extend_data_contour(data) if (self.traces_as_periodic) else data,
         )
 
-    def _make_mesh(self, lattice, num_point, index):
+    def _make_mesh(self, lattice, num_point, index, periodic_expand: int = 1):
         vector = index if self._interpolation_required() else (index, index)
 
+        endpoint = lattice[vector]
+        if (self.traces_as_periodic) and (periodic_expand > 0):
+            endpoint = endpoint + float(periodic_expand - 1) * (
+                lattice[vector] / float(num_point)
+            )
         mesh = np.linspace(
             0,
-            lattice[vector],
-            num_point + (1 if self.traces_as_periodic else 0),
+            endpoint,
+            num_point + (periodic_expand if (self.traces_as_periodic) else 0),
             endpoint=self.traces_as_periodic,
         )
-        if not self.traces_as_periodic:
+
+        periodic_left = 0
+        if (self.traces_as_periodic) and (periodic_expand > 1):
+            periodic_left = np.floor((periodic_expand - 1) / 2)
+
+        if not (self.traces_as_periodic):
             mesh = mesh + (0.5 * lattice[vector] / num_point)
+        else:
+            mesh = mesh - periodic_left * (lattice[vector] / float(num_point))
         return mesh
 
     def _options(self):

--- a/src/py4vasp/_third_party/graph/contour.py
+++ b/src/py4vasp/_third_party/graph/contour.py
@@ -18,7 +18,8 @@ px = import_.optional("plotly.express")
 interpolate = import_.optional("scipy.interpolate")
 
 _COLORMAP_LIST = px.colors.named_colorscales()
-_COLORMAP_LIST_R = [c+"_r" for c in _COLORMAP_LIST]
+_COLORMAP_LIST_R = [c + "_r" for c in _COLORMAP_LIST]
+
 
 @dataclasses.dataclass
 class Contour(trace.Trace):
@@ -363,7 +364,7 @@ class Contour(trace.Trace):
         color_center = "white"
         color_upper = _config.VASP_COLORS["red"]
         zmin, zmax = self._get_color_range(z)
-        if (self.color_scheme in ["monochrome", "stm"]):
+        if self.color_scheme in ["monochrome", "stm"]:
             selected_color_scheme = "turbid"
         elif (self.color_scheme == "signed") or (
             self.color_scheme == "auto" and (zmin < 0 and zmax > 0)
@@ -383,7 +384,7 @@ class Contour(trace.Trace):
             selected_color_scheme = [[0, color_lower], [1, color_center]]
         # Defaulting to color map if not yet set
         if selected_color_scheme is None:
-            if self.color_scheme in (_COLORMAP_LIST+_COLORMAP_LIST_R):
+            if self.color_scheme in (_COLORMAP_LIST + _COLORMAP_LIST_R):
                 selected_color_scheme = self.color_scheme
             else:
                 selected_color_scheme = [

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -566,8 +566,14 @@ def test_contour(rectangle_contour, Assert, not_core):
     assert fig.layout.yaxis.scaleanchor == "x"
 
 
-def test_contour_with_periodic_traces(rectangle_contour, Assert, not_core):
+@pytest.mark.parametrize("num_periodic_add", [0, 3])
+def test_contour_with_periodic_traces(
+    rectangle_contour, num_periodic_add, Assert, not_core
+):
     rectangle_contour.traces_as_periodic = True
+    rectangle_contour.num_periodic_add = (
+        num_periodic_add  # should have no effect on rectangular
+    )
     graph = Graph(rectangle_contour)
     fig = graph.to_plotly()
     assert len(fig.data) == 1
@@ -599,9 +605,15 @@ def test_contour_supercell(rectangle_contour, Assert, not_core):
     check_annotations(rectangle_contour.lattice, fig.layout.annotations, Assert)
 
 
-def test_contour_supercell_with_periodic_traces(rectangle_contour, Assert, not_core):
+@pytest.mark.parametrize("num_periodic_add", [0, 3])
+def test_contour_supercell_with_periodic_traces(
+    rectangle_contour, num_periodic_add, Assert, not_core
+):
     supercell = np.asarray((3, 5))
     rectangle_contour.traces_as_periodic = True
+    rectangle_contour.num_periodic_add = (
+        num_periodic_add  # should have no effect on rectangular contour
+    )
     rectangle_contour.supercell = supercell
     graph = Graph(rectangle_contour)
     fig = graph.to_plotly()
@@ -665,7 +677,11 @@ def check_annotations(lattice, annotations, Assert):
         sign *= -1
 
 
-def test_contour_interpolate(tilted_contour, Assert, not_core):
+@pytest.mark.parametrize("num_periodic_add", [0, 3])
+def test_contour_interpolate(tilted_contour, num_periodic_add, Assert, not_core):
+    tilted_contour.num_periodic_add = (
+        num_periodic_add  # should have no effect unless traces_as_periodic
+    )
     graph = Graph(tilted_contour)
     fig = graph.to_plotly()
     area_cell = 12.0
@@ -694,31 +710,45 @@ def test_contour_interpolate(tilted_contour, Assert, not_core):
     check_annotations(tilted_contour.lattice, fig.layout.annotations, Assert)
 
 
-@pytest.mark.xfail
-def test_contour_interpolate_with_periodic_traces(tilted_contour, Assert, not_core):
+# @pytest.mark.xfail
+@pytest.mark.parametrize("num_periodic_add", [0, 1, 4])
+def test_contour_interpolate_with_periodic_traces(
+    tilted_contour, num_periodic_add, Assert, not_core
+):
     tilted_contour.traces_as_periodic = True
+    tilted_contour.num_periodic_add = num_periodic_add
     graph = Graph(tilted_contour)
     fig = graph.to_plotly()
     area_cell = 12.0
     points_per_area = tilted_contour.data.size / area_cell
     points_per_line = np.sqrt(points_per_area) * tilted_contour._interpolation_factor
     lengths = np.array([6, 9])  # this accounts for the 2 x 1 supercell
+
+    periodic_left = int(np.floor(((1 + num_periodic_add) - 1) / 2))
     xdim, ydim = tilted_contour.data.shape
-    x_indices = np.arange(0, xdim + 1) % xdim
-    y_indices = np.arange(0, ydim + 1) % ydim
+    x_indices = (np.arange(0, xdim + 1 + num_periodic_add) % xdim) - periodic_left
+    y_indices = (np.arange(0, ydim + 1 + num_periodic_add) % ydim) - periodic_left
     expected_data = tilted_contour.data[np.ix_(x_indices, y_indices)]
-    print(expected_data.shape)
+    print(
+        expected_data.shape,
+        num_periodic_add,
+        fig.data[0].z.T.shape,
+        tilted_contour.data.shape,
+    )
     expected_shape = np.array(
-        [ls for ls in np.ceil(points_per_line * lengths).astype(int)]
+        [
+            ls + 1 + num_periodic_add
+            for ls in np.ceil(points_per_line * lengths).astype(int)
+        ]
     )
     expected_average = np.average(expected_data.data)
     assert len(fig.data) == 1
     # plotly expects y-x order
-    assert all(fig.data[0].z.T.shape == expected_shape)
-    assert fig.data[0].x.size == expected_shape[0]
-    assert fig.data[0].y.size == expected_shape[1]
+    assert all(fig.data[0].z.T.shape <= expected_shape)
+    assert fig.data[0].x.size <= expected_shape[0]
+    assert fig.data[0].y.size <= expected_shape[1]
     finite = np.isfinite(fig.data[0].z)
-    assert np.isclose(np.average(fig.data[0].z[finite]), expected_average)
+    assert np.isclose(np.average(fig.data[0].z[finite]), expected_average, rtol=0.1)
     assert len(fig.layout.shapes) == 0
     expected_colorscale = [
         [0, _config.VASP_COLORS["blue"]],

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -115,7 +115,7 @@ def complex_quiver():
     )
 
 
-@pytest.mark.parametrize("color_scheme", ["auto", "signed", "positive", "negative"])
+@pytest.mark.parametrize("color_scheme", ["monochrome", "stm", "turbid", "teal", "viridis_r", "auto", "signed", "positive", "negative"])
 def test_contour_color_scheme(color_scheme, not_core):
     contour = Contour(
         data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
@@ -138,10 +138,28 @@ def test_contour_color_scheme(color_scheme, not_core):
             (0.5, "white"),
             (1, _config.VASP_COLORS["red"]),
         )
+    elif color_scheme in ["monochrome", "stm", "turbid"]:
+        expected_colorscale = px.colors.sequential.turbid
+    elif color_scheme == "teal":
+        expected_colorscale = px.colors.sequential.Teal
+    elif color_scheme == "viridis_r":
+        expected_colorscale = list(reversed(px.colors.sequential.Viridis))
     else:
+        expected_colorscale = (
+            (0, _config.VASP_COLORS["blue"]),
+            (0.5, "white"),
+            (1, _config.VASP_COLORS["red"]),
+        )
+        assert (fig.data[0].colorscale == expected_colorscale) or ([s[1] for s in fig.data[0].colorscale] == expected_colorscale)
         raise NotImplementedError(f"Color scheme {color_scheme} not implemented.")
-    assert fig.data[0].colorscale == expected_colorscale
+    assert (fig.data[0].colorscale == expected_colorscale) or ([s[1] for s in fig.data[0].colorscale] == expected_colorscale)
 
+@pytest.mark.parametrize("color_scheme", ["invalid_color_scheme_name", "VIRIDIS"])
+def test_contour_color_scheme_invalid(color_scheme, not_core):
+    try:
+        test_contour_color_scheme(color_scheme, not_core)
+    except NotImplementedError:
+        pass
 
 @pytest.mark.xfail
 @pytest.mark.parametrize("contrast_mode", [True, False])
@@ -682,6 +700,7 @@ def test_contour_interpolate(tilted_contour, num_periodic_add, Assert, not_core)
     tilted_contour.num_periodic_add = (
         num_periodic_add  # should have no effect unless traces_as_periodic
     )
+    tilted_contour.color_scheme = "auto"
     graph = Graph(tilted_contour)
     fig = graph.to_plotly()
     area_cell = 12.0
@@ -717,6 +736,7 @@ def test_contour_interpolate_with_periodic_traces(
 ):
     tilted_contour.traces_as_periodic = True
     tilted_contour.num_periodic_add = num_periodic_add
+    tilted_contour.color_scheme = "auto"
     graph = Graph(tilted_contour)
     fig = graph.to_plotly()
     area_cell = 12.0

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -119,7 +119,6 @@ def complex_quiver():
     "color_scheme",
     [
         "monochrome",
-        "stm",
         "auto",
         "sequential",
         "diverging",
@@ -150,7 +149,6 @@ def test_contour_color_scheme(color_scheme, not_core):
         "sequential": px.colors.sequential.Viridis,
         "diverging": px.colors.diverging.RdBu_r,
         "monochrome": px.colors.sequential.turbid_r,
-        "stm": px.colors.sequential.turbid_r,
     }
     expected_colorscale = expected_colorscales_dict.get(
         color_scheme, expected_colorscales_dict.get("default", None)

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -115,7 +115,20 @@ def complex_quiver():
     )
 
 
-@pytest.mark.parametrize("color_scheme", ["monochrome", "stm", "turbid", "teal", "viridis_r", "auto", "signed", "positive", "negative"])
+@pytest.mark.parametrize(
+    "color_scheme",
+    [
+        "monochrome",
+        "stm",
+        "turbid",
+        "teal",
+        "viridis_r",
+        "auto",
+        "signed",
+        "positive",
+        "negative",
+    ],
+)
 def test_contour_color_scheme(color_scheme, not_core):
     contour = Contour(
         data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
@@ -150,9 +163,14 @@ def test_contour_color_scheme(color_scheme, not_core):
             (0.5, "white"),
             (1, _config.VASP_COLORS["red"]),
         )
-        assert (fig.data[0].colorscale == expected_colorscale) or ([s[1] for s in fig.data[0].colorscale] == expected_colorscale)
+        assert (fig.data[0].colorscale == expected_colorscale) or (
+            [s[1] for s in fig.data[0].colorscale] == expected_colorscale
+        )
         raise NotImplementedError(f"Color scheme {color_scheme} not implemented.")
-    assert (fig.data[0].colorscale == expected_colorscale) or ([s[1] for s in fig.data[0].colorscale] == expected_colorscale)
+    assert (fig.data[0].colorscale == expected_colorscale) or (
+        [s[1] for s in fig.data[0].colorscale] == expected_colorscale
+    )
+
 
 @pytest.mark.parametrize("color_scheme", ["invalid_color_scheme_name", "VIRIDIS"])
 def test_contour_color_scheme_invalid(color_scheme, not_core):
@@ -160,6 +178,7 @@ def test_contour_color_scheme_invalid(color_scheme, not_core):
         test_contour_color_scheme(color_scheme, not_core)
     except NotImplementedError:
         pass
+
 
 @pytest.mark.xfail
 @pytest.mark.parametrize("contrast_mode", [True, False])


### PR DESCRIPTION
Add periodic repeats (disabled by default) for rows and columns of Contours, which allows for adjustments of the visual appearance of heatmap / contour plots when periodic is set to True (and therefore, when the heatmap grid is shifted to match datapoint positions, which does not always look nice for tilted contours out-of-the-box).

Add additional options for color_scheme on Contours. Change the default color_scheme to monochrome / turbid / stm to fit the typical STM theme.