### PR TITLE
Fix: TypeError reading DOS for element with non-contiguous atoms

### DIFF
--- a/src/py4vasp/_util/index.py
+++ b/src/py4vasp/_util/index.py
@@ -127,14 +127,14 @@ class Selector:
     def _make_label(self, map_, number, index, size):
         if not self._use_number_labels:
             return number
-        indices = range(size)
-        index, *rest = list(indices[_make_slice(index)])
+        indices = np.arange(size)
+        index, *rest = indices[_make_slice(index)].tolist()
         message = f"Integer label {number} maps to more than a single index."
         _raise_error_if_list_not_empty(rest, message)
         for key, value in map_.items():
             if key.isdecimal():
                 continue
-            range_ = indices[_make_slice(value)]
+            range_ = indices[_make_slice(value)].tolist()
             if index in range_:
                 return f"{key}_{range_.index(index) + 1}"
         return number

--- a/tests/util/test_index.py
+++ b/tests/util/test_index.py
@@ -453,6 +453,18 @@ def test_labels_without_number_labels():
     assert selector.label(("0",)) == "0"
 
 
+@pytest.mark.parametrize(
+    "selection, label",
+    [("1", "A_1"), ("2", "B_1"), ("3", "A_2")],
+)
+def test_number_labels_with_noncontiguous_indices(selection, label):
+    # an element with non-contiguous atoms (e.g. POSCAR order A B A) maps a key
+    # to a list of indices, which _make_slice turns into a numpy array
+    map_ = {0: {"A": [0, 2], "B": [1], "1": 0, "2": 1, "3": 2}}
+    selector = index.Selector(map_, np.zeros(3), use_number_labels=True)
+    assert selector.label((selection,)) == label
+
+
 def test_error_when_duplicate_key():
     with pytest.raises(exception._Py4VaspInternalError):
         index.Selector({0: {"A": 1}, 1: {"A": 2}}, None)


### PR DESCRIPTION
When an element occupies non-contiguous atom positions (common with multi-species structures, e.g. KPOINTS_OPT band/DOS runs), its atom indices stay a list, which _make_slice converts to a numpy array. _make_label indexed a Python range with that array, raising "TypeError: only integer scalar arrays can be converted to a scalar index". Use np.arange + tolist so slice and array indexing both work.