### PR TITLE
Replace not_core fixture with per-test importorskip

### DIFF
--- a/tests/calculation/conftest.py
+++ b/tests/calculation/conftest.py
@@ -23,7 +23,7 @@ def mock_schema():
 
 
 @pytest.fixture
-def check_factory_methods(mock_schema, not_core):
+def check_factory_methods(mock_schema):
     def inner(cls, data, parameters={}, skip_methods=[]):
         instance = cls.from_path()
         check_instance_accesses_data(instance, data, parameters, skip_methods)
@@ -68,7 +68,8 @@ def should_test_method(name, parameters, skip_methods):
 def check_method_accesses_data(quantity, data, method_under_test, file, **kwargs):
     with patch("py4vasp.raw.access") as mock_access:
         mock_access.return_value.__enter__.side_effect = lambda *_: data
-        execute_method(method_under_test, **kwargs)
+        if not execute_method(method_under_test, **kwargs):
+            return  # optional package missing, cannot verify data access
         check_mock_called(mock_access, quantity, file)
         mock_access.reset_mock()
         if "selection" in kwargs:
@@ -100,6 +101,9 @@ def _method_accepts_selection(method):
 def execute_method(method_under_test, **kwargs):
     try:
         method_under_test(**kwargs)
+    except exception.ModuleNotInstalled:
+        # optional package not available, so this method cannot be tested
+        return False
     except (
         exception.NotImplemented,
         exception.IncorrectUsage,
@@ -110,6 +114,7 @@ def execute_method(method_under_test, **kwargs):
     ):
         # ignore errors from mock data or unsupported arguments
         pass
+    return True
 
 
 def check_mock_called(mock_access, quantity, file, selection=None):
@@ -121,5 +126,6 @@ def check_mock_called(mock_access, quantity, file, selection=None):
 
 
 @pytest.fixture
-def format_(not_core):
+def format_():
+    pytest.importorskip("IPython")
     return formatters.DisplayFormatter().format

--- a/tests/calculation/test_band.py
+++ b/tests/calculation/test_band.py
@@ -370,14 +370,16 @@ def test_more_projections_style(raw_data, Assert):
     Assert.allclose(band["g_down"], zero)
 
 
-def test_single_polarized_to_frame(single_band, Assert, not_core):
+def test_single_polarized_to_frame(single_band, Assert):
+    pytest.importorskip("pandas")
     actual = single_band.to_frame(fermi_energy=single_band.ref.fermi_energy_argument)
     Assert.allclose(actual.bands, single_band.ref.bands[:, 0])
     Assert.allclose(actual.occupations, single_band.ref.occupations[:, 0])
     Assert.allclose(actual.kpoint_distances, single_band.ref.kpoints.distances())
 
 
-def test_multiple_bands_to_frame(multiple_bands, Assert, not_core):
+def test_multiple_bands_to_frame(multiple_bands, Assert):
+    pytest.importorskip("pandas")
     actual = multiple_bands.to_frame()
     Assert.allclose(actual.bands, multiple_bands.ref.bands.T.flatten())
     Assert.allclose(actual.occupations, multiple_bands.ref.occupations.T.flatten())
@@ -385,7 +387,8 @@ def test_multiple_bands_to_frame(multiple_bands, Assert, not_core):
     Assert.allclose(actual.kpoint_distances, kpoint_distances)
 
 
-def test_line_with_labels_to_frame(line_with_labels, Assert, not_core):
+def test_line_with_labels_to_frame(line_with_labels, Assert):
+    pytest.importorskip("pandas")
     actual = line_with_labels.to_frame()
     kpoint_distances = np.repeat(line_with_labels.ref.kpoints.distances(), repeats=3)
     kpoint_labels = np.repeat(line_with_labels.ref.kpoints.labels(), repeats=3)
@@ -394,13 +397,15 @@ def test_line_with_labels_to_frame(line_with_labels, Assert, not_core):
     Assert.allclose(actual_kpoint_labels, kpoint_labels)
 
 
-def test_with_projectors_to_frame(with_projectors, Assert, not_core):
+def test_with_projectors_to_frame(with_projectors, Assert):
+    pytest.importorskip("pandas")
     actual = with_projectors.to_frame("Sr p")
     Assert.allclose(actual.Sr, with_projectors.ref.Sr.T.flatten())
     Assert.allclose(actual.p, with_projectors.ref.p.T.flatten())
 
 
-def test_spin_polarized_to_frame(spin_polarized, Assert, not_core):
+def test_spin_polarized_to_frame(spin_polarized, Assert):
+    pytest.importorskip("pandas")
     actual = spin_polarized.to_frame()
     ref = spin_polarized.ref
     Assert.allclose(actual.bands_up, ref.bands_up.T.flatten())
@@ -409,7 +414,8 @@ def test_spin_polarized_to_frame(spin_polarized, Assert, not_core):
     Assert.allclose(actual.occupations_down, ref.occupations_down.T.flatten())
 
 
-def test_spin_projectors_to_frame(spin_projectors, Assert, not_core):
+def test_spin_projectors_to_frame(spin_projectors, Assert):
+    pytest.importorskip("pandas")
     actual = spin_projectors.to_frame(selection="O Fe(d)")
     Assert.allclose(actual.O_up, spin_projectors.ref.O_up.T.flatten())
     Assert.allclose(actual.O_down, spin_projectors.ref.O_down.T.flatten())

--- a/tests/calculation/test_dos.py
+++ b/tests/calculation/test_dos.py
@@ -154,14 +154,16 @@ def test_read_excess_orbital_types(raw_data, Assert):
     Assert.allclose(actual["g_down"], zero)
 
 
-def test_Sr2TiO4_to_frame(Sr2TiO4, Assert, not_core):
+def test_Sr2TiO4_to_frame(Sr2TiO4, Assert):
+    pytest.importorskip("pandas")
     actual = Sr2TiO4.to_frame()
     Assert.allclose(actual.energies, Sr2TiO4.ref.energies)
     Assert.allclose(actual.total, Sr2TiO4.ref.dos)
     assert actual.fermi_energy == Sr2TiO4.ref.fermi_energy
 
 
-def test_Fe3O4_to_frame(Fe3O4, Assert, not_core):
+def test_Fe3O4_to_frame(Fe3O4, Assert):
+    pytest.importorskip("pandas")
     actual = Fe3O4.to_frame()
     Assert.allclose(actual.energies, Fe3O4.ref.energies)
     Assert.allclose(actual.up, Fe3O4.ref.dos_up)
@@ -169,7 +171,8 @@ def test_Fe3O4_to_frame(Fe3O4, Assert, not_core):
     assert actual.fermi_energy == Fe3O4.ref.fermi_energy
 
 
-def test_Sr2TiO4_projectors_to_frame(Sr2TiO4_projectors, Assert, not_core):
+def test_Sr2TiO4_projectors_to_frame(Sr2TiO4_projectors, Assert):
+    pytest.importorskip("pandas")
     equivalent_selections = [
         "s Sr(d) Ti O(px,dxy) 2(p) 4 3(dz2) 1:2(p)",
         "2( p), dz2(3) Sr(d) p(1:2), s, 4 Ti px(O) O(dxy)",
@@ -187,7 +190,8 @@ def test_Sr2TiO4_projectors_to_frame(Sr2TiO4_projectors, Assert, not_core):
         Assert.allclose(actual.O_1, Sr2TiO4_projectors.ref.O_1)
 
 
-def test_Ba2PbO4_to_frame(Ba2PbO4, Assert, not_core):
+def test_Ba2PbO4_to_frame(Ba2PbO4, Assert):
+    pytest.importorskip("pandas")
     actual = Ba2PbO4.to_frame("sigma_z Pb(total, y) Ba(x) O(sigma_2)")
     Assert.allclose(actual.energies, Ba2PbO4.ref.energies)
     Assert.allclose(actual.total, Ba2PbO4.ref.dos)

--- a/tests/calculation/test_effective_coulomb.py
+++ b/tests/calculation/test_effective_coulomb.py
@@ -286,7 +286,8 @@ def test_plot_invalid_selection(nonpolarized_crpar, selection):
         effective_coulomb.plot(selection)
 
 
-def test_plot_with_analytic_continuation(nonpolarized_crpar, not_core, Assert):
+def test_plot_with_analytic_continuation(nonpolarized_crpar, Assert):
+    pytest.importorskip("scipy")
     omega_data = nonpolarized_crpar.ref.omega_data
     omega = np.linspace(0, 10, 20)
     expected_U = numeric.analytic_continuation(
@@ -302,9 +303,8 @@ def test_plot_with_analytic_continuation(nonpolarized_crpar, not_core, Assert):
     assert series.label == "screened U"
 
 
-def test_plot_with_analytic_continuation_and_spin_selection(
-    collinear_crpar, not_core, Assert
-):
+def test_plot_with_analytic_continuation_and_spin_selection(collinear_crpar, Assert):
+    pytest.importorskip("scipy")
     omega_data = collinear_crpar.ref.omega_data
     omega = np.linspace(0, 10, 20)
     expected_output = 2 * numeric.analytic_continuation(
@@ -318,9 +318,7 @@ def test_plot_with_analytic_continuation_and_spin_selection(
     assert series.label == "screened down~down"
 
 
-def test_plot_with_custom_analytic_continuation_parameters(
-    nonpolarized_crpar, not_core, Assert
-):
+def test_plot_with_custom_analytic_continuation_parameters(nonpolarized_crpar, Assert):
     config = interpolate.AAAConfig(
         rtol=1e-5, max_terms=50, clean_up=False, clean_up_tol=1e-6
     )
@@ -397,7 +395,8 @@ def test_plot_radial_invalid_selection(nonpolarized_crpar, selection):
         effective_coulomb.plot(selection, radius=...)
 
 
-def test_plot_radial_interpolation(nonpolarized_crpar, not_core, Assert):
+def test_plot_radial_interpolation(nonpolarized_crpar, Assert):
+    pytest.importorskip("scipy")
     radial_data = nonpolarized_crpar.ref.radial_data
     radius_in = radial_data["radius"]
     radius_out = np.linspace(0.0, np.max(radius_in), 30)
@@ -414,7 +413,8 @@ def test_plot_radial_interpolation(nonpolarized_crpar, not_core, Assert):
         assert series.marker is None
 
 
-def test_plot_radial_interpolation_with_cutoff(nonpolarized_crpar, not_core, Assert):
+def test_plot_radial_interpolation_with_cutoff(nonpolarized_crpar, Assert):
+    pytest.importorskip("scipy")
     radial_data = nonpolarized_crpar.ref.radial_data
     radius_in = radial_data["radius"][radial_data["radius"] < 10]
     radius_out = np.linspace(0.0, np.max(radius_in), 30)
@@ -431,7 +431,8 @@ def test_plot_radial_interpolation_with_cutoff(nonpolarized_crpar, not_core, Ass
         assert series.marker is None
 
 
-def test_plot_radial_interpolation_spin_selection(collinear_crpa, not_core, Assert):
+def test_plot_radial_interpolation_spin_selection(collinear_crpa, Assert):
+    pytest.importorskip("scipy")
     effective_coulomb = collinear_crpa
     radius_in = effective_coulomb.ref.radial_data["radius"]
     radius_out = np.linspace(0, 10)

--- a/tests/calculation/test_optics.py
+++ b/tests/calculation/test_optics.py
@@ -288,7 +288,8 @@ def _reference_color(eps, energies, spectrum="reflectivity", **kwargs):
     return color.spectrum_to_rgb(wavelengths[order], coefficient[mask][order], **kwargs)
 
 
-def test_color_default(visible, Assert, not_core):
+def test_color_default(visible, Assert):
+    pytest.importorskip("scipy")
     eps = isotropic(visible.ref.dielectric_function)
     expected = _reference_color(eps, visible.ref.energies)
     result = visible.color()
@@ -297,17 +298,20 @@ def test_color_default(visible, Assert, not_core):
     Assert.allclose(result.rgb, expected)
 
 
-def test_color_defaults_match_explicit(visible, not_core):
+def test_color_defaults_match_explicit(visible):
+    pytest.importorskip("scipy")
     assert visible.color() == visible.color(illuminant="D65", cmf="1931_2")
 
 
-def test_color_range(visible, not_core):
+def test_color_range(visible):
+    pytest.importorskip("scipy")
     color = visible.color("xx")
     assert len(color.rgb) == 3
     assert all(0 <= channel <= 1 for channel in color.rgb)
 
 
-def test_color_from_transmission(visible, Assert, not_core):
+def test_color_from_transmission(visible, Assert):
+    pytest.importorskip("scipy")
     # the coefficient is now part of the selection, defaulting to reflectivity
     eps = isotropic(visible.ref.dielectric_function)
     expected = _reference_color(eps, visible.ref.energies, spectrum="transmission")
@@ -316,26 +320,30 @@ def test_color_from_transmission(visible, Assert, not_core):
     Assert.allclose(result.rgb, expected)
 
 
-def test_color_component_switch_changes_result(visible, not_core):
+def test_color_component_switch_changes_result(visible):
+    pytest.importorskip("scipy")
     reflectivity = visible.color("reflectivity").rgb
     transmission = visible.color("transmission").rgb
     assert not np.allclose(reflectivity, transmission)
 
 
-def test_color_list_selection(visible, not_core):
+def test_color_list_selection(visible):
+    pytest.importorskip("scipy")
     result = visible.color("xx, yy")
     assert set(result) == {"reflectivity_xx", "reflectivity_yy"}
     assert all(isinstance(color, Color) for color in result.values())
     assert result["reflectivity_xx"].label() == "reflectivity_xx"
 
 
-def test_color_multiple_components(visible, Assert, not_core):
+def test_color_multiple_components(visible, Assert):
+    pytest.importorskip("scipy")
     result = visible.color("reflectivity, transmission")
     assert set(result) == {"reflectivity", "transmission"}
     Assert.allclose(result["transmission"].rgb, visible.color("transmission").rgb)
 
 
-def test_color_invalid_illuminant_raises_error(visible, not_core):
+def test_color_invalid_illuminant_raises_error(visible):
+    pytest.importorskip("scipy")
     # the illuminant is validated only after scipy interpolates the spectrum, so this
     # path requires the full (not core) installation
     with pytest.raises(exception.IncorrectUsage):
@@ -348,7 +356,8 @@ def test_color_invalid_cmf_raises_error(visible):
         visible.color(cmf="does-not-exist")
 
 
-def test_to_database(visible, Assert, not_core):
+def test_to_database(visible, Assert):
+    pytest.importorskip("scipy")
     from py4vasp._raw.data_db import Optics_DB
 
     handler = OpticsHandler.from_data(visible.ref.raw_data)
@@ -378,7 +387,8 @@ def test_to_database(visible, Assert, not_core):
     assert isinstance(db_data.color_hex, str)
 
 
-def test_to_database_keyed_by_optics(visible, not_core):
+def test_to_database_keyed_by_optics(visible):
+    pytest.importorskip("scipy")
     from py4vasp._raw.data_db import Optics_DB
 
     result = visible._to_database()

--- a/tests/calculation/test_optics_color.py
+++ b/tests/calculation/test_optics_color.py
@@ -43,12 +43,14 @@ def test_xyz_to_srgb_primary_green():
     np.testing.assert_allclose(color.xyz_to_srgb(0, 1, 0), [0, 1, 0])
 
 
-def test_black_spectrum_is_black(not_core):
+def test_black_spectrum_is_black():
+    pytest.importorskip("scipy")
     rgb = color.spectrum_to_rgb(WAVELENGTHS, np.zeros_like(WAVELENGTHS))
     assert np.array_equal(rgb, [0, 0, 0])
 
 
-def test_spectrum_in_unit_range_gives_valid_rgb(not_core):
+def test_spectrum_in_unit_range_gives_valid_rgb():
+    pytest.importorskip("scipy")
     rng = np.random.default_rng(0)
     spectrum = rng.uniform(0, 1, WAVELENGTHS.shape)
     rgb = color.spectrum_to_rgb(WAVELENGTHS, spectrum)
@@ -57,14 +59,16 @@ def test_spectrum_in_unit_range_gives_valid_rgb(not_core):
 
 
 @pytest.mark.parametrize("peak, channel", [(615, 0), (530, 1), (465, 2)])
-def test_monochromatic_spectrum_has_expected_hue(peak, channel, not_core):
+def test_monochromatic_spectrum_has_expected_hue(peak, channel):
+    pytest.importorskip("scipy")
     # A spectrum peaked in the red/green/blue band lights up the R/G/B channel most.
     spectrum = np.exp(-((WAVELENGTHS - peak) ** 2) / (2 * 10**2))
     rgb = color.spectrum_to_rgb(WAVELENGTHS, spectrum, illuminant="E")
     assert np.argmax(rgb) == channel
 
 
-def test_unknown_illuminant_raises_error(not_core):
+def test_unknown_illuminant_raises_error():
+    pytest.importorskip("scipy")
     # the illuminant is validated only after the spectrum is interpolated with scipy,
     # so this path requires the full (not core) installation
     with pytest.raises(exception.IncorrectUsage):

--- a/tests/calculation/test_partial_density.py
+++ b/tests/calculation/test_partial_density.py
@@ -107,7 +107,7 @@ def make_reference_partial_density(raw_data, selection):
     return parchg
 
 
-def test_read(AnyPartialDensity, Assert, not_core):
+def test_read(AnyPartialDensity, Assert):
     actual = AnyPartialDensity.read()
     expected = AnyPartialDensity.ref
     Assert.allclose(actual["bands"], expected.bands)
@@ -118,32 +118,32 @@ def test_read(AnyPartialDensity, Assert, not_core):
     Assert.same_structure(actual["structure"], expected.structure.read())
 
 
-def test_stoichiometry(AnyPartialDensity, not_core):
+def test_stoichiometry(AnyPartialDensity):
     actual = AnyPartialDensity._stoichiometry()
     expected = str(AnyPartialDensity.ref.structure_handler._stoichiometry())
     assert actual == expected
 
 
-def test_bands(AnyPartialDensity, Assert, not_core):
+def test_bands(AnyPartialDensity, Assert):
     actual = AnyPartialDensity.bands()
     expected = AnyPartialDensity.ref.bands
     Assert.allclose(actual, expected)
 
 
-def test_kpoints(AnyPartialDensity, Assert, not_core):
+def test_kpoints(AnyPartialDensity, Assert):
     actual = AnyPartialDensity.kpoints()
     expected = AnyPartialDensity.ref.kpoints
     Assert.allclose(actual, expected)
 
 
-def test_grid(AnyPartialDensity, Assert, not_core):
+def test_grid(AnyPartialDensity, Assert):
     actual = AnyPartialDensity.grid()
     expected = AnyPartialDensity.ref.grid
     Assert.allclose(actual, expected)
 
 
 @pytest.mark.parametrize("selection", (None, "total", "up", "down"))
-def test_plot(PolarizedNonSplitPartialDensity, selection, Assert, not_core):
+def test_plot(PolarizedNonSplitPartialDensity, selection, Assert):
     if selection is not None:
         view = PolarizedNonSplitPartialDensity.plot(selection)
         expected_density = PolarizedNonSplitPartialDensity.to_numpy(selection)
@@ -166,7 +166,7 @@ def test_plot(PolarizedNonSplitPartialDensity, selection, Assert, not_core):
     assert isosurface.opacity == 0.6
 
 
-def test_plot_with_options(NonSplitPartialDensity, Assert, not_core):
+def test_plot_with_options(NonSplitPartialDensity, Assert):
     view = NonSplitPartialDensity.plot(supercell=(1, 2, 3), isolevel=0.6, color="red")
     Assert.allclose(view.supercell, (1, 2, 3))
     assert len(view.grid_scalars) == 1
@@ -177,7 +177,7 @@ def test_plot_with_options(NonSplitPartialDensity, Assert, not_core):
     assert isosurface.color == "red"
 
 
-def test_non_split_to_numpy(PolarizedNonSplitPartialDensity, Assert, not_core):
+def test_non_split_to_numpy(PolarizedNonSplitPartialDensity, Assert):
     actual = PolarizedNonSplitPartialDensity.to_numpy("total")
     expected = PolarizedNonSplitPartialDensity.ref.partial_density
     Assert.allclose(actual, expected[0, 0, 0].T)
@@ -189,7 +189,7 @@ def test_non_split_to_numpy(PolarizedNonSplitPartialDensity, Assert, not_core):
     Assert.allclose(actual, 0.5 * (expected[0, 0, 0].T - expected[0, 0, 1].T))
 
 
-def test_split_to_numpy(PolarizedAllSplitPartialDensity, Assert, not_core):
+def test_split_to_numpy(PolarizedAllSplitPartialDensity, Assert):
     bands = PolarizedAllSplitPartialDensity.ref.bands
     kpoints = PolarizedAllSplitPartialDensity.ref.kpoints
     for band_index, band in enumerate(bands):
@@ -215,15 +215,13 @@ def test_split_to_numpy(PolarizedAllSplitPartialDensity, Assert, not_core):
     assert msg in str(excinfo.value)
 
 
-def test_non_polarized_to_numpy(NonSplitPartialDensity, spin, Assert, not_core):
+def test_non_polarized_to_numpy(NonSplitPartialDensity, spin, Assert):
     actual = NonSplitPartialDensity.to_numpy(selection=spin)
     expected = NonSplitPartialDensity.ref.partial_density
     Assert.allclose(actual, np.asarray(expected).T[:, :, :, 0, 0, 0])
 
 
-def test_split_bands_to_numpy(
-    NonPolarizedBandSplitPartialDensity, spin, Assert, not_core
-):
+def test_split_bands_to_numpy(NonPolarizedBandSplitPartialDensity, spin, Assert):
     bands = NonPolarizedBandSplitPartialDensity.ref.bands
     for band_index, band in enumerate(bands):
         actual = NonPolarizedBandSplitPartialDensity.to_numpy(spin, band=band)
@@ -231,14 +229,14 @@ def test_split_bands_to_numpy(
     Assert.allclose(actual, np.asarray(expected).T[:, :, :, 0, band_index, 0])
 
 
-def test_to_stm_split(PolarizedAllSplitPartialDensity, not_core):
+def test_to_stm_split(PolarizedAllSplitPartialDensity):
     msg = "set LSEPK and LSEPB to .FALSE. in the INCAR file."
     with pytest.raises(NotImplemented) as excinfo:
         PolarizedAllSplitPartialDensity.to_stm(selection="constant_current")
     assert msg in str(excinfo.value)
 
 
-def test_to_stm_nonsplit_tip_to_high(NonSplitPartialDensity, not_core):
+def test_to_stm_nonsplit_tip_to_high(NonSplitPartialDensity):
     actual = NonSplitPartialDensity
     tip_height = 8.4
     error = f"""The tip position at {tip_height:.2f} is above half of the
@@ -250,7 +248,6 @@ def test_to_stm_nonsplit_tip_to_high(NonSplitPartialDensity, not_core):
 
 def test_to_stm_nonsplit_not_orthogonal_no_vacuum(
     PolarizedNonSplitPartialDensitySr2TiO4,
-    not_core,
 ):
     msg = "The vacuum region in your cell is too small for STM simulations."
     with pytest.raises(IncorrectUsage) as excinfo:
@@ -258,20 +255,20 @@ def test_to_stm_nonsplit_not_orthogonal_no_vacuum(
     assert msg in str(excinfo.value)
 
 
-def test_to_stm_wrong_spin_nonsplit(PolarizedNonSplitPartialDensity, not_core):
+def test_to_stm_wrong_spin_nonsplit(PolarizedNonSplitPartialDensity):
     msg = "'up', 'down', or 'total'"
     with pytest.raises(IncorrectUsage) as excinfo:
         PolarizedNonSplitPartialDensity.to_stm(selection="all")
     assert msg in str(excinfo.value)
 
 
-def test_to_stm_wrong_mode(PolarizedNonSplitPartialDensity, not_core):
+def test_to_stm_wrong_mode(PolarizedNonSplitPartialDensity):
     with pytest.raises(IncorrectUsage) as excinfo:
         PolarizedNonSplitPartialDensity.to_stm(selection="stm")
     assert "STM mode" in str(excinfo.value)
 
 
-def test_wrong_vacuum_direction(NonSplitPartialDensityNi_100, not_core):
+def test_wrong_vacuum_direction(NonSplitPartialDensityNi_100):
     msg = """The vacuum region in your cell is not located along
         the third lattice vector."""
     with pytest.raises(NotImplemented) as excinfo:
@@ -281,8 +278,9 @@ def test_wrong_vacuum_direction(NonSplitPartialDensityNi_100, not_core):
 
 @pytest.mark.parametrize("alias", ("constant_height", "ch", "height"))
 def test_to_stm_nonsplit_constant_height(
-    PolarizedNonSplitPartialDensity, alias, spin, Assert, not_core
+    PolarizedNonSplitPartialDensity, alias, spin, Assert
 ):
+    pytest.importorskip("scipy")
     supercell = 3
     actual = PolarizedNonSplitPartialDensity.to_stm(
         selection=f"{alias}({spin})", tip_height=2.0, supercell=supercell
@@ -304,8 +302,9 @@ def test_to_stm_nonsplit_constant_height(
 
 @pytest.mark.parametrize("alias", ("constant_current", "cc", "current"))
 def test_to_stm_nonsplit_constant_current(
-    PolarizedNonSplitPartialDensity, alias, spin, Assert, not_core
+    PolarizedNonSplitPartialDensity, alias, spin, Assert
 ):
+    pytest.importorskip("scipy")
     current = 5
     supercell = np.asarray([2, 4])
     actual = PolarizedNonSplitPartialDensity.to_stm(
@@ -330,8 +329,9 @@ def test_to_stm_nonsplit_constant_current(
 
 @pytest.mark.parametrize("alias", ("constant_current", "cc", "current"))
 def test_to_stm_nonsplit_constant_current_non_ortho(
-    NonSplitPartialDensityCaAs3_110, alias, spin, Assert, not_core
+    NonSplitPartialDensityCaAs3_110, alias, spin, Assert
 ):
+    pytest.importorskip("scipy")
     current = 5
     supercell = np.asarray([2, 4])
     actual = NonSplitPartialDensityCaAs3_110.to_stm(
@@ -354,7 +354,8 @@ def test_to_stm_nonsplit_constant_current_non_ortho(
     assert f"{current:.2f}" in actual.title
 
 
-def test_stm_default_settings(PolarizedNonSplitPartialDensity, not_core):
+def test_stm_default_settings(PolarizedNonSplitPartialDensity):
+    pytest.importorskip("scipy")
     actual = dataclasses.asdict(PolarizedNonSplitPartialDensity.stm_settings)
     defaults = {
         "sigma_xy": 4.0,
@@ -375,7 +376,8 @@ def test_stm_default_settings(PolarizedNonSplitPartialDensity, not_core):
     assert graph.series.settings == modified
 
 
-def test_smoothening_change(PolarizedNonSplitPartialDensity, not_core):
+def test_smoothening_change(PolarizedNonSplitPartialDensity):
+    pytest.importorskip("scipy")
     mod_settings = PartialDensity.STM_settings(sigma_xy=2.0, sigma_z=2.0, truncate=1.0)
     data = PolarizedNonSplitPartialDensity.to_numpy("total", band=0, kpoint=0)
     default_smoothed_density = PolarizedNonSplitPartialDensity._smooth_stm_data(
@@ -387,7 +389,8 @@ def test_smoothening_change(PolarizedNonSplitPartialDensity, not_core):
     assert not np.allclose(default_smoothed_density, new_smoothed_density)
 
 
-def test_enhancement_setting_change(PolarizedNonSplitPartialDensity, Assert, not_core):
+def test_enhancement_setting_change(PolarizedNonSplitPartialDensity, Assert):
+    pytest.importorskip("scipy")
     enhance_settings = PartialDensity.STM_settings(
         enhancement_factor=PartialDensity.STM_settings().enhancement_factor / 2.0
     )
@@ -398,7 +401,8 @@ def test_enhancement_setting_change(PolarizedNonSplitPartialDensity, Assert, not
     Assert.allclose(graph_def.series.data, graph_less_enhanced.series.data * 2)
 
 
-def test_interpolation_setting_change(PolarizedNonSplitPartialDensity, not_core):
+def test_interpolation_setting_change(PolarizedNonSplitPartialDensity):
+    pytest.importorskip("scipy")
     interp_settings = PartialDensity.STM_settings(
         interpolation_factor=PartialDensity.STM_settings().interpolation_factor / 4.0
     )
@@ -409,6 +413,6 @@ def test_interpolation_setting_change(PolarizedNonSplitPartialDensity, not_core)
     assert not np.allclose(graph_def.series.data, graph_less_interp_points.series.data)
 
 
-def test_factory_methods(raw_data, check_factory_methods, not_core):
+def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.partial_density("spin_polarized")
     check_factory_methods(PartialDensity, data)

--- a/tests/calculation/test_stoichiometry.py
+++ b/tests/calculation/test_stoichiometry.py
@@ -28,13 +28,15 @@ class Base:
             assert stoichiometry[str(i + 1)] == expected
         self.check_ion_indices(stoichiometry)
 
-    def test_to_frame(self, not_core):
+    def test_to_frame(self):
+        pytest.importorskip("pandas")
         actual = self.stoichiometry.to_frame(**self.ion_types)
         ref_data = {"name": self.names, "element": self.elements}
         reference = pd.DataFrame(ref_data)
         pdt.assert_frame_equal(reference, actual)
 
-    def test_to_mdtraj(self, not_core):
+    def test_to_mdtraj(self):
+        pytest.importorskip("mdtraj")
         actual, _ = self.stoichiometry.to_mdtraj(**self.ion_types).to_dataframe()
         num_atoms = self.stoichiometry.number_atoms()
         ref_data = {
@@ -64,7 +66,8 @@ class Base:
     def test_number_atoms(self):
         assert self.stoichiometry.number_atoms() == 7
 
-    def test_from_ase(self, not_core):
+    def test_from_ase(self):
+        pytest.importorskip("ase")
         structure = ase.Atoms("".join(self.elements))
         stoichiometry = Stoichiometry.from_ase(structure)
         assert stoichiometry.elements() == self.elements
@@ -235,7 +238,11 @@ def test_poscar_string_without_types(without_types):
 @pytest.mark.parametrize(
     "method", ("to_dict", "to_frame", "to_mdtraj", "names", "elements")
 )
-def test_ion_types_required(method, without_types, not_core):
+def test_ion_types_required(method, without_types):
+    if method == "to_frame":
+        pytest.importorskip("pandas")
+    if method == "to_mdtraj":
+        pytest.importorskip("mdtraj")
     with pytest.raises(exception.IncorrectUsage):
         getattr(without_types, method)()
 

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -278,7 +278,8 @@ Direct
     check_Sr2TiO4_structure(structure.read(), Sr2TiO4.ref, -1, Assert)
 
 
-def test_to_ase_Sr2TiO4(Sr2TiO4, Assert, not_core):
+def test_to_ase_Sr2TiO4(Sr2TiO4, Assert):
+    pytest.importorskip("ase")
     check_Sr2TiO4_ase(Sr2TiO4.to_ase(**Sr2TiO4.ion_type_arg), Sr2TiO4.ref, -1, Assert)
     check_Sr2TiO4_ase(Sr2TiO4[0].to_ase(**Sr2TiO4.ion_type_arg), Sr2TiO4.ref, 0, Assert)
     for steps in (slice(None), slice(1, 3)):
@@ -293,7 +294,8 @@ def check_Sr2TiO4_ase(structure, reference, steps, Assert):
     assert all(structure.pbc)
 
 
-def test_to_ase_Fe3O4(Fe3O4, Assert, not_core):
+def test_to_ase_Fe3O4(Fe3O4, Assert):
+    pytest.importorskip("ase")
     check_Fe3O4_ase(Fe3O4.to_ase(), Fe3O4.ref, -1, Assert)
     check_Fe3O4_ase(Fe3O4[0].to_ase(), Fe3O4.ref, 0, Assert)
 
@@ -306,7 +308,8 @@ def check_Fe3O4_ase(structure, reference, steps, Assert):
     assert all(structure.pbc)
 
 
-def test_to_ase_Ca3AsBr3(Ca3AsBr3, Assert, not_core):
+def test_to_ase_Ca3AsBr3(Ca3AsBr3, Assert):
+    pytest.importorskip("ase")
     structure = Ca3AsBr3.to_ase()
     Assert.allclose(structure.cell.array, Ca3AsBr3.ref.lattice_vectors)
     Assert.allclose(structure.get_scaled_positions(), Ca3AsBr3.ref.positions)
@@ -314,12 +317,14 @@ def test_to_ase_Ca3AsBr3(Ca3AsBr3, Assert, not_core):
     assert all(structure.pbc)
 
 
-def test_from_ase(Sr2TiO4, Assert, not_core):
+def test_from_ase(Sr2TiO4, Assert):
+    pytest.importorskip("ase")
     structure = Structure.from_ase(Sr2TiO4.to_ase(**Sr2TiO4.ion_type_arg))
     check_Sr2TiO4_structure(structure.read(), Sr2TiO4.ref, -1, Assert)
 
 
-def test_to_mdtraj(Sr2TiO4, Assert, not_core):
+def test_to_mdtraj(Sr2TiO4, Assert):
+    pytest.importorskip("mdtraj")
     for steps in (slice(None), slice(1, 3)):
         trajectory = Sr2TiO4[steps].to_mdtraj(**Sr2TiO4.ion_type_arg)
         check_Sr2TiO4_mdtraj(trajectory, Sr2TiO4.ref, steps, Assert)
@@ -340,7 +345,8 @@ def check_Sr2TiO4_mdtraj(trajectory, reference, steps, Assert):
     Assert.allclose(trajectory.unitcell_vectors, unitcell_vectors)
 
 
-def test_supercell_scale_all(Sr2TiO4, Assert, not_core):
+def test_supercell_scale_all(Sr2TiO4, Assert):
+    pytest.importorskip("ase")
     number_atoms = 7
     scale = 2
     supercell = Sr2TiO4.to_ase(supercell=scale, **Sr2TiO4.ion_type_arg)
@@ -349,7 +355,8 @@ def test_supercell_scale_all(Sr2TiO4, Assert, not_core):
     assert list(supercell.symbols) == 16 * ["Sr"] + 8 * ["Ti"] + 32 * ["O"]
 
 
-def test_supercell_scale_individual(Sr2TiO4, Assert, not_core):
+def test_supercell_scale_individual(Sr2TiO4, Assert):
+    pytest.importorskip("ase")
     number_atoms = 7
     scale = (2, 1, 3)
     supercell = Sr2TiO4.to_ase(supercell=scale, **Sr2TiO4.ion_type_arg)
@@ -357,7 +364,8 @@ def test_supercell_scale_individual(Sr2TiO4, Assert, not_core):
     Assert.allclose(supercell.cell.array, np.diag(scale) @ Sr2TiO4.ref.lattice_vectors)
 
 
-def test_supercell_wrong_size(Sr2TiO4, not_a_supercell, not_core):
+def test_supercell_wrong_size(Sr2TiO4, not_a_supercell):
+    pytest.importorskip("ase")
     with pytest.raises(exception.IncorrectUsage):
         Sr2TiO4.to_ase(not_a_supercell)
 
@@ -374,12 +382,14 @@ def test_positions(Sr2TiO4, steps, Assert):
     Assert.allclose(structure.positions(), Sr2TiO4.ref.positions[steps])
 
 
-def test_Sr2TiO4_cartesian_positions(Sr2TiO4, Assert, not_core):
+def test_Sr2TiO4_cartesian_positions(Sr2TiO4, Assert):
+    pytest.importorskip("ase")
     expected = Sr2TiO4.to_ase(**Sr2TiO4.ion_type_arg).get_positions()
     Assert.allclose(Sr2TiO4.cartesian_positions(), expected)
 
 
-def test_cartesian_positions(Fe3O4, Ca3AsBr3, Assert, not_core):
+def test_cartesian_positions(Fe3O4, Ca3AsBr3, Assert):
+    pytest.importorskip("ase")
     check_cartesian_positions(Fe3O4, Assert)
     check_cartesian_positions(Fe3O4[0], Assert)
     check_cartesian_positions(Ca3AsBr3, Assert)
@@ -472,13 +482,15 @@ def test_incorrect_step(Sr2TiO4, Ca3AsBr3):
         Ca3AsBr3[0]
 
 
-def test_Sr2TiO4_to_lammps(Sr2TiO4, not_core):
+def test_Sr2TiO4_to_lammps(Sr2TiO4):
+    pytest.importorskip("ase")
     assert re.match(REF_LAMMPS, Sr2TiO4.to_lammps())
     with pytest.raises(exception.NotImplemented):
         Sr2TiO4[:].to_lammps()
 
 
-def test_ZnS_to_lammps(ZnS, not_core):
+def test_ZnS_to_lammps(ZnS):
+    pytest.importorskip("ase")
     assert re.match(REF_LAMMPS_ZnS, ZnS.to_lammps())
     assert ZnS.to_lammps(standard_form=False) == REF_LAMMPS_ZnS_general
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import dataclasses
-import importlib.metadata
 
 import numpy as np
 import pytest
@@ -9,26 +8,6 @@ from numpy.testing import assert_allclose
 
 from py4vasp import _demo, exception
 from py4vasp._util import check
-
-
-@pytest.fixture(scope="session")
-def only_core():
-    if not _is_core():
-        pytest.skip("This test checks py4vasp-core functionality not used by py4vasp.")
-
-
-@pytest.fixture(scope="session")
-def not_core():
-    if _is_core():
-        pytest.skip("This test requires features not present in py4vasp-core.")
-
-
-def _is_core():
-    try:
-        importlib.metadata.distribution("py4vasp-core")
-        return True
-    except importlib.metadata.PackageNotFoundError:
-        return False
 
 
 class _Assert:

--- a/tests/scripts/test_error_analysis.py
+++ b/tests/scripts/test_error_analysis.py
@@ -1,6 +1,11 @@
 import os
+import shutil
+
+import pytest
 
 
-def test_error_analysis(not_core):
+def test_error_analysis():
+    if shutil.which("error-analysis") is None:
+        pytest.skip("error-analysis entry point not installed (py4vasp-core)")
     errcode = os.system("error-analysis --help")
     assert errcode == 0

--- a/tests/sphinx/test_autodoc.py
+++ b/tests/sphinx/test_autodoc.py
@@ -8,7 +8,7 @@ application = pytest.importorskip("sphinx.application")
 
 
 @pytest.fixture(scope="module")
-def sphinx_app(tmp_path_factory, not_core):
+def sphinx_app(tmp_path_factory):
     if sys.version_info < (3, 12):
         pytest.skip("Sphinx autodoc tests require Python 3.12 or higher.")
     tmp_path = tmp_path_factory.mktemp("sphinx")

--- a/tests/sphinx/test_core.py
+++ b/tests/sphinx/test_core.py
@@ -8,7 +8,7 @@ application = pytest.importorskip("sphinx.application")
 
 
 @pytest.fixture(scope="module")
-def sphinx_app(tmp_path_factory, not_core):
+def sphinx_app(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("sphinx")
     srcdir = "tests/sphinx/core"
     confdir = "tests/sphinx/core"

--- a/tests/sphinx/test_examples.py
+++ b/tests/sphinx/test_examples.py
@@ -8,7 +8,7 @@ application = pytest.importorskip("sphinx.application")
 
 
 @pytest.fixture(scope="module")
-def sphinx_app(tmp_path_factory, not_core):
+def sphinx_app(tmp_path_factory):
     if sys.version_info < (3, 12):
         pytest.skip("Sphinx example tests require Python 3.12 or higher.")
     tmp_path = tmp_path_factory.mktemp("sphinx")

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -54,8 +54,8 @@ def _all_calculation_examples():
 
 
 # Examples that rely on an optional package (e.g. scipy for the color pipeline) which is
-# not part of the py4vasp-core installation. They run in test_calculation_full guarded by
-# the not_core fixture; everything else runs in test_calculation.
+# not part of the py4vasp-core installation. They run in test_calculation_full which skips
+# via importorskip when the package is missing; everything else runs in test_calculation.
 _FULL_INSTALL_EXAMPLES = ("py4vasp._calculation.optics.Optics.color",)
 
 
@@ -103,7 +103,8 @@ def test_calculation(example: doctest.DocTest, tmp_path: pathlib.Path):
 @pytest.mark.parametrize(
     "example", get_full_calculation_examples(), ids=lambda example: example.name
 )
-def test_calculation_full(example: doctest.DocTest, tmp_path: pathlib.Path, not_core):
+def test_calculation_full(example: doctest.DocTest, tmp_path: pathlib.Path):
+    pytest.importorskip("scipy")
     _run_calculation_example(example, tmp_path)
 
 
@@ -135,7 +136,8 @@ def get_graph_examples():
 @pytest.mark.parametrize(
     "example", get_graph_examples(), ids=lambda example: example.name
 )
-def test_graph_functions(example: doctest.DocTest, tmp_path: pathlib.Path, not_core):
+def test_graph_functions(example: doctest.DocTest, tmp_path: pathlib.Path):
+    pytest.importorskip("plotly")
     optionflags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
     runner = doctest.DocTestRunner(optionflags=optionflags)
     example.globs["np"] = np

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -141,7 +141,8 @@ def complex_quiver():
         "negative",
     ],
 )
-def test_contour_color_scheme(color_scheme, not_core):
+def test_contour_color_scheme(color_scheme):
+    pytest.importorskip("plotly")
     contour = Contour(
         data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
         lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
@@ -189,7 +190,8 @@ def test_contour_color_scheme(color_scheme, not_core):
 
 @pytest.mark.xfail
 @pytest.mark.parametrize("contrast_mode", [True, False])
-def test_contour_contrast_mode(contrast_mode, not_core):
+def test_contour_contrast_mode(contrast_mode):
+    pytest.importorskip("plotly")
     contour = Contour(
         data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
         lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
@@ -205,7 +207,8 @@ def test_contour_contrast_mode(contrast_mode, not_core):
 @pytest.mark.parametrize(
     "color_limits", [None, (None, None), (-9, None), (None, 9), (-11, 11)]
 )
-def test_contour_color_limits(color_limits, not_core):
+def test_contour_color_limits(color_limits):
+    pytest.importorskip("plotly")
     contour = Contour(
         data=np.linspace(-10, 10, 20 * 18).reshape((20, 18)),
         lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
@@ -229,7 +232,8 @@ def test_contour_color_limits(color_limits, not_core):
 
 
 @pytest.mark.parametrize("units", ["", None, "px", "m/s"])
-def test_contour_colorbar_label(units, not_core):
+def test_contour_colorbar_label(units):
+    pytest.importorskip("plotly")
     contour = Contour(
         data=np.linspace(0, 10, 20 * 18).reshape((20, 18)),
         lattice=slicing.Plane(np.diag([4.0, 3.6]), cut="c"),
@@ -246,14 +250,16 @@ def test_contour_colorbar_label(units, not_core):
         assert fig.data[0].colorbar.title.text == None
 
 
-def test_basic_graph(parabola, Assert, not_core):
+def test_basic_graph(parabola, Assert):
+    pytest.importorskip("plotly")
     graph = Graph(parabola)
     fig = graph.to_plotly()
     assert len(fig.data) == 1
     compare_series(fig.data[0], parabola, Assert)
 
 
-def test_two_series(parabola, sine, Assert, not_core):
+def test_two_series(parabola, sine, Assert):
+    pytest.importorskip("plotly")
     for graph in (Graph([parabola, sine]), Graph(parabola) + Graph(sine)):
         fig = graph.to_plotly()
         assert len(fig.data) == 2
@@ -267,7 +273,8 @@ def compare_series(converted, original, Assert):
     assert converted.name == original.label
 
 
-def test_axis_label(parabola, not_core):
+def test_axis_label(parabola):
+    pytest.importorskip("plotly")
     graph = Graph(parabola)
     graph.xlabel = "xaxis label"
     graph.ylabel = "yaxis label"
@@ -276,7 +283,8 @@ def test_axis_label(parabola, not_core):
     assert fig.layout.yaxis.title.text == graph.ylabel
 
 
-def test_secondary_yaxis(parabola, sine, Assert, not_core):
+def test_secondary_yaxis(parabola, sine, Assert):
+    pytest.importorskip("plotly")
     sine.y2 = True
     graph = Graph([parabola, sine])
     graph.y2label = "secondary yaxis label"
@@ -291,7 +299,8 @@ def check_legend_group(converted, original, first_trace):
     assert converted.showlegend == first_trace
 
 
-def test_two_lines(two_lines, Assert, not_core):
+def test_two_lines(two_lines, Assert):
+    pytest.importorskip("plotly")
     graph = Graph(two_lines)
     fig = graph.to_plotly()
     assert len(fig.data) == 2
@@ -324,13 +333,15 @@ def compare_series_with_weight(converted, original, Assert):
     assert converted.opacity == 0.5
 
 
-def test_fatband(fatband, Assert, not_core):
+def test_fatband(fatband, Assert):
+    pytest.importorskip("plotly")
     graph = Graph(fatband)
     fig = graph.to_plotly()
     compare_series_with_weight(fig.data[0], fatband, Assert)
 
 
-def test_two_fatbands(two_fatbands, Assert, not_core):
+def test_two_fatbands(two_fatbands, Assert):
+    pytest.importorskip("plotly")
     graph = Graph(two_fatbands)
     fig = graph.to_plotly()
     assert len(fig.data) == 2
@@ -346,7 +357,8 @@ def test_two_fatbands(two_fatbands, Assert, not_core):
         first_trace = False
 
 
-def test_simple_with_marker(sine, not_core):
+def test_simple_with_marker(sine):
+    pytest.importorskip("plotly")
     graph = Graph(sine)
     fig = graph.to_plotly()
     assert len(fig.data) == 1
@@ -354,7 +366,8 @@ def test_simple_with_marker(sine, not_core):
     assert fig.data[0].marker.size is None
 
 
-def test_fatband_with_marker(fatband, Assert, not_core):
+def test_fatband_with_marker(fatband, Assert):
+    pytest.importorskip("plotly")
     with_marker = dataclasses.replace(fatband, marker="o")
     graph = Graph(with_marker)
     fig = graph.to_plotly()
@@ -366,7 +379,8 @@ def test_fatband_with_marker(fatband, Assert, not_core):
     Assert.allclose(fig.data[0].marker.size, fatband.weight)
 
 
-def test_two_fatband_with_marker(two_fatbands, Assert, not_core):
+def test_two_fatband_with_marker(two_fatbands, Assert):
+    pytest.importorskip("plotly")
     with_marker = dataclasses.replace(two_fatbands, marker="o")
     graph = Graph(with_marker)
     fig = graph.to_plotly()
@@ -379,7 +393,8 @@ def test_two_fatband_with_marker(two_fatbands, Assert, not_core):
         Assert.allclose(converted.marker.size, w)
 
 
-def test_weight_mode_color(two_fatbands, Assert, not_core):
+def test_weight_mode_color(two_fatbands, Assert):
+    pytest.importorskip("plotly")
     fatbands = dataclasses.replace(two_fatbands, marker="o", weight_mode="color")
     graph = Graph(fatbands)
     fig = graph.to_plotly()
@@ -393,7 +408,8 @@ def test_weight_mode_color(two_fatbands, Assert, not_core):
         assert converted.marker.coloraxis == "coloraxis"
 
 
-def test_custom_xticks(parabola, not_core):
+def test_custom_xticks(parabola):
+    pytest.importorskip("plotly")
     graph = Graph(parabola)
     graph.xticks = {0.1: "X", 0.3: "Y", 0.4: "", 0.8: "Z"}
     fig = graph.to_plotly()
@@ -403,7 +419,8 @@ def test_custom_xticks(parabola, not_core):
     # empty ticks should be replace by " " because otherwise plotly will replace them
 
 
-def test_title(parabola, not_core):
+def test_title(parabola):
+    pytest.importorskip("plotly")
     graph = Graph(parabola)
     graph.title = "title"
     fig = graph.to_plotly()
@@ -447,7 +464,8 @@ def test_merging_of_numpy_field_values(parabola):
         graph1 + Graph(parabola, xrange=np.array([0.0, 2.0]))
 
 
-def test_subplot(subplot, not_core):
+def test_subplot(subplot):
+    pytest.importorskip("plotly")
     graph = Graph(subplot)
     graph.xlabel = ("first x-axis", "second x-axis")
     graph.ylabel = ("first y-axis", "second y-axis")
@@ -474,7 +492,8 @@ def test_mixture_subplot_raises_error(parabola, subplot):
         Graph((parabola,) + subplot)
 
 
-def test_non_numpy_data(non_numpy, Assert, not_core):
+def test_non_numpy_data(non_numpy, Assert):
+    pytest.importorskip("plotly")
     graph = Graph(non_numpy)
     fig = graph.to_plotly()
     assert len(fig.data) == len(non_numpy)
@@ -503,7 +522,8 @@ def test_add_label_to_multiple_lines(parabola, sine, Assert):
     assert graph.series[1].label == "new label sine"
 
 
-def test_annotations(parabola, Assert, not_core):
+def test_annotations(parabola, Assert):
+    pytest.importorskip("plotly")
     num_points = len(parabola.x)
     metadata = np.linspace(-1, 1, num_points)
     parabola.annotations = {
@@ -527,14 +547,16 @@ def test_incorrect_annotations_length():
         Series(x, y, annotations=annotations)
 
 
-def test_convert_parabola_to_frame(parabola, Assert, not_core):
+def test_convert_parabola_to_frame(parabola, Assert):
+    pytest.importorskip("pandas")
     graph = Graph(parabola)
     df = graph.to_frame()
     Assert.allclose(df["parabola.x"], parabola.x)
     Assert.allclose(df["parabola.y"], parabola.y)
 
 
-def test_convert_sequence_parabola_to_frame(parabola, sine, Assert, not_core):
+def test_convert_sequence_parabola_to_frame(parabola, sine, Assert):
+    pytest.importorskip("pandas")
     sequence = [parabola, sine]
     graph = Graph(sequence)
     df = graph.to_frame()
@@ -544,7 +566,8 @@ def test_convert_sequence_parabola_to_frame(parabola, sine, Assert, not_core):
     Assert.allclose(df["sine.y"], sine.y)
 
 
-def test_convert_multiple_lines(two_lines, Assert, not_core):
+def test_convert_multiple_lines(two_lines, Assert):
+    pytest.importorskip("pandas")
     graph = Graph(two_lines)
     df = graph.to_frame()
     assert len(df.columns) == 3
@@ -553,7 +576,8 @@ def test_convert_multiple_lines(two_lines, Assert, not_core):
     Assert.allclose(df["two_lines.y1"], two_lines.y[1])
 
 
-def test_convert_two_fatbands_to_frame(two_fatbands, Assert, not_core):
+def test_convert_two_fatbands_to_frame(two_fatbands, Assert):
+    pytest.importorskip("pandas")
     graph = Graph(two_fatbands)
     df = graph.to_frame()
     Assert.allclose(df["two_fatbands.x"], two_fatbands.x)
@@ -563,7 +587,8 @@ def test_convert_two_fatbands_to_frame(two_fatbands, Assert, not_core):
     Assert.allclose(df["two_fatbands.weight1"], two_fatbands.weight[1])
 
 
-def test_write_csv(tmp_path, two_fatbands, non_numpy, Assert, not_core):
+def test_write_csv(tmp_path, two_fatbands, non_numpy, Assert):
+    pytest.importorskip("pandas")
     import pandas as pd
 
     sequence = [two_fatbands, *non_numpy]
@@ -576,9 +601,8 @@ def test_write_csv(tmp_path, two_fatbands, non_numpy, Assert, not_core):
     Assert.allclose(ref_rounded, actual_rounded)
 
 
-def test_convert_different_length_series_to_frame(
-    parabola, two_lines, Assert, not_core
-):
+def test_convert_different_length_series_to_frame(parabola, two_lines, Assert):
+    pytest.importorskip("pandas")
     sequence = [two_lines, parabola]
     graph = Graph(sequence)
     df = graph.to_frame()
@@ -594,18 +618,20 @@ def test_convert_different_length_series_to_frame(
     Assert.allclose(df["two_lines.y1"], padded_two_lines_y[1])
 
 
-@patch("plotly.graph_objs.Figure._ipython_display_")
-def test_ipython_display(mock_display, parabola, not_core):
-    graph = Graph(parabola)
-    graph._ipython_display_()
-    mock_display.assert_called_once()
+def test_ipython_display(parabola):
+    pytest.importorskip("plotly")
+    with patch("plotly.graph_objs.Figure._ipython_display_") as mock_display:
+        graph = Graph(parabola)
+        graph._ipython_display_()
+        mock_display.assert_called_once()
 
 
-@patch("plotly.graph_objs.Figure.show")
-def test_show(mock_show, parabola, not_core):
-    graph = Graph(parabola)
-    graph.show()
-    mock_show.assert_called_once()
+def test_show(parabola):
+    pytest.importorskip("plotly")
+    with patch("plotly.graph_objs.Figure.show") as mock_show:
+        graph = Graph(parabola)
+        graph.show()
+        mock_show.assert_called_once()
 
 
 def test_nonexisting_attribute_raises_error(parabola):
@@ -616,7 +642,8 @@ def test_nonexisting_attribute_raises_error(parabola):
         graph.nonexisting = "not possible"
 
 
-def test_normal_series_does_not_set_contour_layout(parabola, not_core):
+def test_normal_series_does_not_set_contour_layout(parabola):
+    pytest.importorskip("plotly")
     graph = Graph(parabola)
     fig = graph.to_plotly()
     assert fig.layout.xaxis.visible is None
@@ -624,7 +651,8 @@ def test_normal_series_does_not_set_contour_layout(parabola, not_core):
     assert fig.layout.yaxis.scaleanchor is None
 
 
-def test_contour(rectangle_contour, Assert, not_core):
+def test_contour(rectangle_contour, Assert):
+    pytest.importorskip("plotly")
     graph = Graph(rectangle_contour)
     fig = graph.to_plotly()
     assert len(fig.data) == 1
@@ -644,7 +672,8 @@ def test_contour(rectangle_contour, Assert, not_core):
     assert fig.layout.yaxis.scaleanchor == "x"
 
 
-def test_contour_with_periodic_traces(rectangle_contour, Assert, not_core):
+def test_contour_with_periodic_traces(rectangle_contour, Assert):
+    pytest.importorskip("plotly")
     rectangle_contour.traces_as_periodic = True
     graph = Graph(rectangle_contour)
     fig = graph.to_plotly()
@@ -662,7 +691,8 @@ def test_contour_with_periodic_traces(rectangle_contour, Assert, not_core):
     check_annotations(rectangle_contour.lattice, fig.layout.annotations, Assert)
 
 
-def test_contour_supercell(rectangle_contour, Assert, not_core):
+def test_contour_supercell(rectangle_contour, Assert):
+    pytest.importorskip("plotly")
     supercell = np.asarray((3, 5))
     rectangle_contour.supercell = supercell
     graph = Graph(rectangle_contour)
@@ -677,7 +707,8 @@ def test_contour_supercell(rectangle_contour, Assert, not_core):
     check_annotations(rectangle_contour.lattice, fig.layout.annotations, Assert)
 
 
-def test_contour_supercell_with_periodic_traces(rectangle_contour, Assert, not_core):
+def test_contour_supercell_with_periodic_traces(rectangle_contour, Assert):
+    pytest.importorskip("plotly")
     supercell = np.asarray((3, 5))
     rectangle_contour.traces_as_periodic = True
     rectangle_contour.supercell = supercell
@@ -697,7 +728,8 @@ def test_contour_supercell_with_periodic_traces(rectangle_contour, Assert, not_c
 
 
 @pytest.mark.parametrize("show_contour_values", [True, False, None])
-def test_contour_show_contour_values(rectangle_contour, show_contour_values, not_core):
+def test_contour_show_contour_values(rectangle_contour, show_contour_values):
+    pytest.importorskip("plotly")
     rectangle_contour.show_contour_values = show_contour_values
     graph = Graph(rectangle_contour)
     fig = graph.to_plotly()
@@ -705,7 +737,8 @@ def test_contour_show_contour_values(rectangle_contour, show_contour_values, not
     assert fig.data[0].contours.showlabels == show_contour_values
 
 
-def test_legend_positioning(parabola, sine, Assert, not_core):
+def test_legend_positioning(parabola, sine, Assert):
+    pytest.importorskip("plotly")
     graph = Graph([sine, parabola])
     fig = graph.to_plotly()
     assert len(fig.data) == 2
@@ -714,7 +747,8 @@ def test_legend_positioning(parabola, sine, Assert, not_core):
     )  # actually at 1.02, but plotly does not expose this until set explicitly
 
 
-def test_contour_legend_with_colorbar(rectangle_contour, parabola, Assert, not_core):
+def test_contour_legend_with_colorbar(rectangle_contour, parabola, Assert):
+    pytest.importorskip("plotly")
     graph = Graph([rectangle_contour, parabola])
     fig = graph.to_plotly()
     assert len(fig.data) == 2
@@ -743,7 +777,7 @@ def check_annotations(lattice, annotations, Assert):
         sign *= -1
 
 
-def check_colorscale(fig, data, expect_diverging, Assert, not_core):
+def check_colorscale(fig, data, expect_diverging, Assert):
     tolerance = 1e-10
     if expect_diverging:
         expected_colorscale = px.colors.diverging.RdBu_r
@@ -768,7 +802,7 @@ def check_colorscale(fig, data, expect_diverging, Assert, not_core):
 
 
 def check_basic_tilted_contour(
-    curr_contour, with_periodic_traces: bool, Assert, not_core, expected_lengths=[]
+    curr_contour, with_periodic_traces: bool, Assert, expected_lengths=[]
 ) -> Graph:
     curr_contour.traces_as_periodic = with_periodic_traces
     curr_contour.color_scheme = "auto"
@@ -811,40 +845,43 @@ def check_basic_tilted_contour(
     return fig, expected_data
 
 
-def test_contour_interpolate(tilted_contour, Assert, not_core):
+def test_contour_interpolate(tilted_contour, Assert):
+    pytest.importorskip("plotly")
     fig, expected_data = check_basic_tilted_contour(
-        tilted_contour, False, Assert, not_core, expected_lengths=[6, 9]
+        tilted_contour, False, Assert, expected_lengths=[6, 9]
     )
-    check_colorscale(fig, expected_data, False, Assert, not_core)
+    check_colorscale(fig, expected_data, False, Assert)
 
 
 # @pytest.mark.xfail
-def test_contour_interpolate_with_periodic_traces(tilted_contour, Assert, not_core):
-    fig, expected_data = check_basic_tilted_contour(
-        tilted_contour, True, Assert, not_core
-    )
-    check_colorscale(fig, expected_data, False, Assert, not_core)
+def test_contour_interpolate_with_periodic_traces(tilted_contour, Assert):
+    pytest.importorskip("plotly")
+    fig, expected_data = check_basic_tilted_contour(tilted_contour, True, Assert)
+    check_colorscale(fig, expected_data, False, Assert)
 
 
 def test_contour_interpolate_with_periodic_function(
-    tilted_contour_with_sin_cos, Assert, not_core
+    tilted_contour_with_sin_cos, Assert
 ):
+    pytest.importorskip("plotly")
     fig, expected_data = check_basic_tilted_contour(
-        tilted_contour_with_sin_cos, False, Assert, not_core, expected_lengths=[8, 16]
+        tilted_contour_with_sin_cos, False, Assert, expected_lengths=[8, 16]
     )
-    check_colorscale(fig, expected_data, False, Assert, not_core)
+    check_colorscale(fig, expected_data, False, Assert)
 
 
 def test_contour_interpolate_with_periodic_function_and_traces(
-    tilted_contour_with_sin_cos, Assert, not_core
+    tilted_contour_with_sin_cos, Assert
 ):
+    pytest.importorskip("plotly")
     fig, expected_data = check_basic_tilted_contour(
-        tilted_contour_with_sin_cos, True, Assert, not_core
+        tilted_contour_with_sin_cos, True, Assert
     )
-    check_colorscale(fig, expected_data, False, Assert, not_core)
+    check_colorscale(fig, expected_data, False, Assert)
 
 
-def test_mix_contour_and_series(two_lines, rectangle_contour, not_core):
+def test_mix_contour_and_series(two_lines, rectangle_contour):
+    pytest.importorskip("plotly")
     graph = Graph([rectangle_contour, two_lines])
     fig = graph.to_plotly()
     assert len(fig.data) == 3
@@ -853,7 +890,8 @@ def test_mix_contour_and_series(two_lines, rectangle_contour, not_core):
     assert fig.layout.yaxis.scaleanchor == "x"
 
 
-def test_simple_quiver(simple_quiver, Assert, not_core):
+def test_simple_quiver(simple_quiver, Assert):
+    pytest.importorskip("plotly")
     graph = Graph(simple_quiver)
     assert simple_quiver.max_number_arrows is None
     expected_positions, dx, dy = compute_positions(simple_quiver)
@@ -877,7 +915,8 @@ def test_simple_quiver(simple_quiver, Assert, not_core):
     Assert.allclose(actual.barb_length, expected_barb_length)
 
 
-def test_simple_quiver_with_periodic_traces(simple_quiver, Assert, not_core):
+def test_simple_quiver_with_periodic_traces(simple_quiver, Assert):
+    pytest.importorskip("plotly")
     simple_quiver.traces_as_periodic = True
     graph = Graph(simple_quiver)
     assert simple_quiver.max_number_arrows is None
@@ -907,7 +946,8 @@ def test_simple_quiver_with_periodic_traces(simple_quiver, Assert, not_core):
 
 
 @pytest.mark.parametrize("max_number_arrows", (1025, 1024, 680))
-def test_dense_quiver(dense_quiver, max_number_arrows, Assert, not_core):
+def test_dense_quiver(dense_quiver, max_number_arrows, Assert):
+    pytest.importorskip("plotly")
     dense_quiver.max_number_arrows = max_number_arrows
     if max_number_arrows == 1024:
         expected_shape = (28, 25)
@@ -941,9 +981,8 @@ def test_dense_quiver(dense_quiver, max_number_arrows, Assert, not_core):
 
 
 @pytest.mark.parametrize("max_number_arrows", (1025, 1024, 680))
-def test_dense_quiver_with_periodic_traces(
-    dense_quiver, max_number_arrows, Assert, not_core
-):
+def test_dense_quiver_with_periodic_traces(dense_quiver, max_number_arrows, Assert):
+    pytest.importorskip("plotly")
     dense_quiver.traces_as_periodic = True
     dense_quiver.max_number_arrows = max_number_arrows
     if max_number_arrows == 1024:
@@ -985,7 +1024,8 @@ def test_dense_quiver_with_periodic_traces(
     Assert.allclose(actual.barb_length, expected_barb_length)
 
 
-def test_complex_quiver(complex_quiver, Assert, not_core):
+def test_complex_quiver(complex_quiver, Assert):
+    pytest.importorskip("plotly")
     graph = Graph(complex_quiver)
     expected_scale = 0.10015332542313245
     work = expected_scale * complex_quiver.data
@@ -1006,7 +1046,8 @@ def test_complex_quiver(complex_quiver, Assert, not_core):
     assert len(fig.layout.annotations) == 0
 
 
-def test_complex_quiver_with_periodic_traces(complex_quiver, Assert, not_core):
+def test_complex_quiver_with_periodic_traces(complex_quiver, Assert):
+    pytest.importorskip("plotly")
     complex_quiver.traces_as_periodic = True
     graph = Graph(complex_quiver)
     expected_scale = 0.10015332542313245
@@ -1036,7 +1077,8 @@ def test_complex_quiver_with_periodic_traces(complex_quiver, Assert, not_core):
     assert len(fig.layout.annotations) == 0
 
 
-def test_width_and_height(parabola, not_core):
+def test_width_and_height(parabola):
+    pytest.importorskip("plotly")
     fig = Graph(parabola).to_plotly()
     assert fig.layout.width == 720
     assert fig.layout.height == 540
@@ -1045,7 +1087,8 @@ def test_width_and_height(parabola, not_core):
     assert fig.layout.height == 600
 
 
-def test_range_for_x_and_y_axis(parabola, Assert, not_core):
+def test_range_for_x_and_y_axis(parabola, Assert):
+    pytest.importorskip("plotly")
     fig = Graph(parabola).to_plotly()
     assert fig.layout.xaxis.range is None
     assert fig.layout.yaxis.range is None

--- a/tests/third_party/graph/test_plot.py
+++ b/tests/third_party/graph/test_plot.py
@@ -45,7 +45,8 @@ def test_fatband_inconsistent_length():
         plot(x, y, weight=weight)
 
 
-def test_many_colors(not_core):
+def test_many_colors():
+    pytest.importorskip("plotly")
     data = np.random.random((10, 2, 50))
     plots = (plot(x, y) for x, y in data)
     graph = sum(plots, start=Graph([]))

--- a/tests/third_party/test_interactive.py
+++ b/tests/third_party/test_interactive.py
@@ -11,8 +11,9 @@ from py4vasp._calculation.dos import Dos
 
 
 @pytest.fixture
-def ipython(not_core):
+def ipython():
     """Mock IPython for testing purposes."""
+    pytest.importorskip("IPython")
     import IPython
 
     shell = IPython.terminal.interactiveshell.TerminalInteractiveShell()
@@ -47,7 +48,8 @@ def test_py4vasp_inherits_error_handling(ipython):
     assert ipython.custom_exceptions == ()
 
 
-def test_py4vasp_error_handling(raw_data, capsys, not_core):
+def test_py4vasp_error_handling(raw_data, capsys):
+    pytest.importorskip("IPython")
     interactive.set_error_handling("Plain")
     raw_dos = raw_data.dos("Sr2TiO4 with_projectors")
     try:

--- a/tests/third_party/test_numeric.py
+++ b/tests/third_party/test_numeric.py
@@ -3,12 +3,14 @@
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from py4vasp import interpolate
 from py4vasp._third_party import numeric
 
 
-def test_analytic_continuation_for_lorentzian(not_core, Assert):
+def test_analytic_continuation_for_lorentzian(Assert):
+    pytest.importorskip("scipy")
     z_in = 1j * np.array([0.1, 1.0, 10.0])
     f_in = lorentzian(z_in)
     z_out = np.linspace(0.0, 2.5, 6)
@@ -23,7 +25,8 @@ def lorentzian(z):
     return 1 / (z - z0 + 1j * gamma)
 
 
-def test_analytic_continuation_for_higher_dimensions(not_core, Assert):
+def test_analytic_continuation_for_higher_dimensions(Assert):
+    pytest.importorskip("scipy")
     z_in = np.random.rand(3)
     f_in = np.random.rand(5, 4, 3)
     z_out = z_in
@@ -31,7 +34,8 @@ def test_analytic_continuation_for_higher_dimensions(not_core, Assert):
     Assert.allclose(f_out, f_in, tolerance=10)
 
 
-def test_pass_parameters_to_analytic_continuation(not_core, Assert):
+def test_pass_parameters_to_analytic_continuation(Assert):
+    pytest.importorskip("scipy")
     config = interpolate.AAAConfig(
         rtol=1e-5, max_terms=50, clean_up=False, clean_up_tol=1e-6
     )
@@ -51,7 +55,8 @@ def test_pass_parameters_to_analytic_continuation(not_core, Assert):
         Assert.allclose(f_out, f_expected)
 
 
-def test_interpolate_with_function(not_core, Assert):
+def test_interpolate_with_function(Assert):
+    pytest.importorskip("scipy")
     x_in = np.array([0.1, 0.5, 1.0, 2.0])
     amplitude = 3.0
     stddev = 0.5
@@ -72,7 +77,8 @@ def gaussian(x, amplitude=1.0, mean=0.0, stddev=1.0):
     return coeff * np.exp(exponent)
 
 
-def test_interpolate_with_function_higher_dimensions(not_core, Assert):
+def test_interpolate_with_function_higher_dimensions(Assert):
+    pytest.importorskip("scipy")
     x_in = np.random.rand(5)
     amplitude = np.random.rand(3, 2)
     mean = np.random.rand(3, 2)

--- a/tests/third_party/view/test_vaspviewer.py
+++ b/tests/third_party/view/test_vaspviewer.py
@@ -72,7 +72,7 @@ def base_input_view(is_structure):
 
 
 @pytest.fixture(params=[True, False])
-def view(request, not_core):
+def view(request):
     is_structure = request.param
     inputs = base_input_view(is_structure)
     view = View(**inputs)
@@ -80,7 +80,7 @@ def view(request, not_core):
 
 
 @hasVaspView
-def test_structure_to_view(view: View, Assert, not_core):
+def test_structure_to_view(view: View, Assert):
     state = view.to_vasp_viewer().get_state()
     # check positions, lattice and element types
     assert np.allclose(
@@ -96,21 +96,21 @@ def test_structure_to_view(view: View, Assert, not_core):
 
 @hasVaspView
 @patch("vasp.viewer.Widget", autospec=True)
-def test_ipython(mock_display, view, not_core):
+def test_ipython(mock_display, view):
     display = view._ipython_display_(mode="vasp_viewer")
     mock_display.assert_called_once()
 
 
 @hasVaspView
 @patch("vasp.viewer.Widget", autospec=True)
-def test_ipython_auto(mock_display, view, not_core):
+def test_ipython_auto(mock_display, view):
     display = view._ipython_display_(mode="auto")
     mock_display.assert_called_once()
 
 
 @hasVaspView
 @pytest.mark.parametrize("camera", ("orthographic", "perspective"))
-def test_camera(view, camera, not_core):
+def test_camera(view, camera):
     view.camera = camera
     state = view.to_vasp_viewer().get_state()
     assert camera == state["_selections_camera_mode"]
@@ -118,25 +118,25 @@ def test_camera(view, camera, not_core):
 
 @hasVaspView
 @pytest.mark.skip(reason="Not yet implemented")
-def test_isosurface(view, not_core):
+def test_isosurface(view):
     assert False
 
 
 @hasVaspView
 @pytest.mark.skip(reason="Not yet implemented")
-def test_shifted_isosurface(view, not_core):
+def test_shifted_isosurface(view):
     assert False
 
 
 @hasVaspView
 @pytest.mark.skip(reason="Not yet implemented")
-def test_fail_isosurface(view, not_core):
+def test_fail_isosurface(view):
     assert False
 
 
 @hasVaspView
 @pytest.mark.parametrize("is_structure", [True, False])
-def test_ion_arrows(is_structure, Assert, not_core):
+def test_ion_arrows(is_structure, Assert):
     inputs = base_input_view(is_structure)
     view = View(
         **inputs,
@@ -179,7 +179,7 @@ def test_ion_arrows(is_structure, Assert, not_core):
 
 @hasVaspView
 @pytest.mark.parametrize("is_structure", [True, False])
-def test_supercell(is_structure, Assert, not_core):
+def test_supercell(is_structure, Assert):
     view = View(**base_input_view(is_structure), supercell=(2, 2, 2))
     state = view.to_vasp_viewer().get_state()
     assert np.allclose(
@@ -193,7 +193,7 @@ def test_supercell(is_structure, Assert, not_core):
     ["is_structure", "is_show_cell"],
     [[True, True], [False, True], [True, False], [False, False]],
 )
-def test_showcell(is_structure, is_show_cell, not_core):
+def test_showcell(is_structure, is_show_cell):
     view = View(**base_input_view(is_structure), show_cell=is_show_cell)
     state = view.to_vasp_viewer().get_state()
     assert state["_selections_show_lattice"] == is_show_cell
@@ -204,7 +204,7 @@ def test_showcell(is_structure, is_show_cell, not_core):
     ["is_structure", "is_show_axes"],
     [[True, True], [False, True], [True, False], [False, False]],
 )
-def test_showaxes(is_structure, is_show_axes, not_core):
+def test_showaxes(is_structure, is_show_axes):
     view = View(**base_input_view(is_structure), show_axes=is_show_axes)
     state = view.to_vasp_viewer().get_state()
     assert state["_selections_show_abc"] == is_show_axes
@@ -212,7 +212,7 @@ def test_showaxes(is_structure, is_show_axes, not_core):
 
 @hasVaspView
 @pytest.mark.parametrize("is_structure", [True, False])
-def test_showaxes_different_origin(is_structure, Assert, not_core):
+def test_showaxes_different_origin(is_structure, Assert):
     axes_offset = np.array([0.2, 0.2, 0.2])
     view = View(
         **base_input_view(is_structure), show_axes=True, show_axes_at=axes_offset
@@ -224,14 +224,14 @@ def test_showaxes_different_origin(is_structure, Assert, not_core):
 
 @hasVaspView
 @pytest.mark.parametrize("atom_radius", [0.1, 0.5, 1.0])
-def test_atom_radius(atom_radius, not_core):
+def test_atom_radius(atom_radius):
     view = View(**base_input_view(is_structure=True), atom_radius=atom_radius)
     state = view.to_vasp_viewer().get_state()
     assert state["_selections_atom_radius"] == atom_radius
 
 
 @hasVaspView
-def test_structure_title(not_core):
+def test_structure_title():
     view = View(
         **base_input_view(is_structure=True), structure_title="My Structure Title"
     )
@@ -240,7 +240,7 @@ def test_structure_title(not_core):
 
 
 @hasVaspView
-def test_different_number_of_steps_raises_error(view, not_core):
+def test_different_number_of_steps_raises_error(view):
     too_many_elements = [element for element in view.elements] + [view.elements[0]]
     with pytest.raises(exception.IncorrectUsage):
         View(too_many_elements, view.lattice_vectors, view.positions)
@@ -267,7 +267,7 @@ def test_different_number_of_steps_raises_error(view, not_core):
 
 
 @hasVaspView
-def test_incorrect_shape_raises_error(view, not_core):
+def test_incorrect_shape_raises_error(view):
     different_number_atoms = np.zeros((len(view.positions), 7, 3))
     with pytest.raises(exception.IncorrectUsage):
         View(view.elements, view.lattice_vectors, different_number_atoms)

--- a/tests/third_party/view/test_view.py
+++ b/tests/third_party/view/test_view.py
@@ -56,7 +56,8 @@ def base_input_view(is_structure):
 
 
 @pytest.fixture(params=[True, False])
-def view(request, not_core):
+def view(request):
+    pytest.importorskip("nglview")
     is_structure = request.param
     inputs = base_input_view(is_structure)
     if is_structure:
@@ -85,7 +86,8 @@ ENDMDL
 
 
 @pytest.fixture(params=[True, False])
-def view3d(request, not_core):
+def view3d(request):
+    pytest.importorskip("nglview")
     is_structure = request.param
     inputs = base_input_view(is_structure)
     isosurface1 = Isosurface(isolevel=0.1, color="#2FB5AB", opacity=0.6)
@@ -108,7 +110,8 @@ def view3d(request, not_core):
 
 
 @pytest.fixture
-def view_multiple_grid_scalars(not_core):
+def view_multiple_grid_scalars():
+    pytest.importorskip("nglview")
     inputs = base_input_view(is_structure=False)
     isosurface = Isosurface(isolevel=0.1, color="#2FB5AB", opacity=0.6)
     charge_grid_scalar = GridQuantity(np.random.rand(2, 12, 10, 8), "charge")
@@ -119,7 +122,8 @@ def view_multiple_grid_scalars(not_core):
 
 
 @pytest.fixture(params=[True, False])
-def view_arrow(request, not_core):
+def view_arrow(request):
+    pytest.importorskip("nglview")
     is_structure = request.param
     inputs = base_input_view(is_structure)
     number_atoms = len(inputs["elements"][0])
@@ -317,7 +321,8 @@ def test_shifted_ion_arrows(view_arrow, Assert):
 
 
 @pytest.mark.parametrize("is_structure", [True, False])
-def test_supercell(is_structure, not_core):
+def test_supercell(is_structure):
+    pytest.importorskip("nglview")
     inputs = base_input_view(is_structure)
     supercell = (2, 2, 2)
     inputs["supercell"] = supercell
@@ -337,7 +342,8 @@ def test_supercell(is_structure, not_core):
 
 
 @pytest.mark.parametrize("is_structure", [True, False])
-def test_showcell(is_structure, not_core):
+def test_showcell(is_structure):
+    pytest.importorskip("nglview")
     inputs = base_input_view(is_structure)
     inputs["show_cell"] = True
     view = View(**inputs)
@@ -346,7 +352,8 @@ def test_showcell(is_structure, not_core):
 
 
 @pytest.mark.parametrize("is_structure", [True, False])
-def test_showaxes(is_structure, not_core):
+def test_showaxes(is_structure):
+    pytest.importorskip("nglview")
     inputs = base_input_view(is_structure)
     inputs["show_axes"] = True
     view = View(**inputs)
@@ -359,7 +366,8 @@ def test_showaxes(is_structure, not_core):
 
 
 @pytest.mark.parametrize("is_structure", [True, False])
-def test_showaxes_different_origin(is_structure, not_core):
+def test_showaxes_different_origin(is_structure):
+    pytest.importorskip("nglview")
     inputs = base_input_view(is_structure)
     inputs["show_axes"] = True
     inputs["show_axes_at"] = np.array([0.2, 0.2, 0.2])
@@ -419,7 +427,7 @@ def test_incorrect_shape_raises_error(view):
         View(view.elements, incorrect_unit_cell, view.positions)
 
 
-def test_add_requires_compatible_trajectory_fields(not_core):
+def test_add_requires_compatible_trajectory_fields():
     left = View(**base_input_view(is_structure=False))
     right = View(**base_input_view(is_structure=False))
 
@@ -433,7 +441,7 @@ def test_add_requires_compatible_trajectory_fields(not_core):
         left + View(**base_input_view(is_structure=True))
 
 
-def test_add_merges_scalar_fields_and_raises_on_conflict(not_core):
+def test_add_merges_scalar_fields_and_raises_on_conflict():
     left = View(structure_title="left title", atom_radius=0.8, **base_input_view(False))
     right = View(structure_title=None, atom_radius=0.8, **base_input_view(False))
 
@@ -446,7 +454,7 @@ def test_add_merges_scalar_fields_and_raises_on_conflict(not_core):
         left + View(camera="perspective", **base_input_view(False))
 
 
-def test_add_combines_grid_scalars_and_ion_arrows(not_core):
+def test_add_combines_grid_scalars_and_ion_arrows():
     number_atoms = len(base_input_view(False)["elements"][0])
     shared_grid = GridQuantity(np.arange(8, dtype=float).reshape(1, 2, 2, 2), "shared")
     extra_grid = GridQuantity(np.ones((1, 2, 2, 2)), "extra")
@@ -484,7 +492,7 @@ def test_add_combines_grid_scalars_and_ion_arrows(not_core):
     assert combined.ion_arrows[1].label == "moments"
 
 
-def test_add_combines_special_sequences_as_sequences(not_core):
+def test_add_combines_special_sequences_as_sequences():
     number_atoms = len(base_input_view(False)["elements"][0])
     grid_left = GridQuantity(np.arange(8, dtype=float).reshape(1, 2, 2, 2), "left")
     grid_right = GridQuantity(np.ones((1, 2, 2, 2)), "right")
@@ -520,7 +528,7 @@ def test_add_combines_special_sequences_as_sequences(not_core):
     assert tuple(arrow.label for arrow in combined.ion_arrows) == ("left", "right")
 
 
-def test_add_special_sequence_preserves_left_sequence_type(not_core):
+def test_add_special_sequence_preserves_left_sequence_type():
     number_atoms = len(base_input_view(False)["elements"][0])
     left_grid = [GridQuantity(np.arange(8, dtype=float).reshape(1, 2, 2, 2), "left")]
     right_grid = (
@@ -565,7 +573,7 @@ def test_add_special_sequence_preserves_left_sequence_type(not_core):
     assert [arrow.label for arrow in combined.ion_arrows] == ["left", "right"]
 
 
-def test_add_does_not_trigger_validation(not_core, monkeypatch):
+def test_add_does_not_trigger_validation(monkeypatch):
     left = View(**base_input_view(False))
     right = View(**base_input_view(False))
 


### PR DESCRIPTION
Tests previously gated optional-dependency tests with a session-scoped `not_core` fixture that skipped whenever the installed distribution was named `py4vasp-core`. This was coarse: it keyed on the distribution name rather than the actual package a test needs, made it impossible to grep which test depends on which package, and skipped tests even when the required package happened to be available.

Each `not_core` usage is replaced with an explicit `pytest.importorskip("<package>")` keyed on the test's real runtime dependency (or an equivalent guard where the dependency is not an importable package). The unused `only_core`/`_is_core` machinery and the stale `importlib.metadata` import are removed.

The generic `check_factory_methods` helper now tolerates `exception.ModuleNotInstalled`, so factory tests run in the core environment and verify the numpy/h5py-only methods instead of being skipped wholesale.

Dependency labels were verified empirically in a core-like environment (numpy + h5py only), correcting the over-broad original gating: e.g. only the STM-computing partial_density tests actually require scipy, and the graph dataframe tests require pandas rather than plotly.

Notes:
- error_analysis gates on the presence of the `error-analysis` entry point via shutil.which (it is a script, not an importable package).
- sphinx and vaspviewer tests were already gated (module-level importorskip / @hasVaspView marker), so not_core was simply removed.