### PR TITLE
Feat: Add symmetry quantity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "ipython>=8.26",
     "scipy>=1.12.0",
     "click>=8.1.8",
+    "spglib>=2.1",
 ]
 
 [project.urls]

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -2,13 +2,37 @@
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import numpy as np
 
-from py4vasp import raw
+from py4vasp import exception, raw
 from py4vasp._calculation.dispatch import (
     DataSource,
     merge_default,
     quantity,
 )
-from py4vasp._util import check
+from py4vasp._util import check, import_
+
+spglib = import_.optional("spglib")
+
+# Tolerance used by spglib when classifying the symmetry operations.
+_SYMPREC = 1e-5
+
+# Upper space-group-number boundary of each crystal system.
+_CRYSTAL_SYSTEMS = (
+    (2, "triclinic"),
+    (15, "monoclinic"),
+    (74, "orthorhombic"),
+    (142, "tetragonal"),
+    (167, "trigonal"),
+    (194, "hexagonal"),
+    (230, "cubic"),
+)
+
+
+def _crystal_system(space_group_number):
+    for boundary, name in _CRYSTAL_SYSTEMS:
+        if space_group_number <= boundary:
+            return name
+    message = f"The space group number {space_group_number} is not in the range 1-230."
+    raise exception.IncorrectUsage(message)
 
 
 class SymmetryHandler:
@@ -62,6 +86,79 @@ class SymmetryHandler:
         """Public alias for read()."""
         return self.read()
 
+    def has_inversion_symmetry(self) -> bool:
+        """Return whether the inversion operation is part of the symmetry group."""
+        inversion = -np.eye(3, dtype=int)
+        rotations = np.array(self._raw_symmetry.rotations)
+        return any(np.array_equal(rotation, inversion) for rotation in rotations)
+
+    def is_symmorphic(self) -> bool:
+        """Return whether the space group is symmorphic.
+
+        A space group is symmorphic if an origin exists for which all operations have
+        no fractional translation. We use the practical criterion that none of the
+        stored operations carries a fractional translation.
+        """
+        translations = np.array(self._raw_symmetry.translations)
+        return bool(np.allclose(translations, 0.0))
+
+    def space_group(self) -> dict:
+        """Determine the space group of the crystal from the symmetry operations.
+
+        The space group is deduced with spglib from the symmetry operations VASP
+        stored. This requires the optional dependency spglib to be installed.
+
+        Returns
+        -------
+        dict
+            The international space-group number and Hermann-Mauguin symbol, the
+            point group, the crystal system, and whether the group is symmorphic.
+        """
+        space_group_type = self._space_group_type()
+        number = space_group_type.number
+        return {
+            "number": number,
+            "international_symbol": space_group_type.international_short,
+            "point_group": space_group_type.pointgroup_international,
+            "crystal_system": _crystal_system(number),
+            "is_symmorphic": self.is_symmorphic(),
+        }
+
+    def _space_group_type(self):
+        rotations, translations = self._all_operations()
+        return spglib.get_spacegroup_type_from_symmetry(
+            rotations, translations, lattice=self._lattice(), symprec=_SYMPREC
+        )
+
+    def _all_operations(self):
+        """Combine the rotations with the pure translations of the primitive cell.
+
+        VASP stores the rotations in the basis of the computational cell. When the
+        computational cell contains more than one primitive cell, the pure lattice
+        translations relating them are symmetry operations as well and have to be
+        added so that spglib classifies the space group correctly.
+        """
+        rotations = np.array(self._raw_symmetry.rotations)
+        translations = np.array(self._raw_symmetry.translations)
+        primitive_translations = np.array(self._raw_symmetry.primitive_translations)
+        all_rotations = []
+        all_translations = []
+        for rotation, translation in zip(rotations, translations):
+            for primitive_translation in primitive_translations:
+                all_rotations.append(rotation)
+                all_translations.append((translation + primitive_translation) % 1.0)
+        return np.array(all_rotations), np.array(all_translations)
+
+    def _lattice(self):
+        cell = self._raw_symmetry.cell
+        return self._scale(cell) * np.array(cell.lattice_vectors)
+
+    @staticmethod
+    def _scale(cell):
+        if check.is_none(cell.scale):
+            return 1.0
+        return np.array(cell.scale)
+
 
 @quantity("symmetry")
 class Symmetry:
@@ -106,3 +203,27 @@ class Symmetry:
     def to_dict(self, selection: str | None = None) -> dict:
         """Public alias for read(). Check that method for the returned data."""
         return self.read()
+
+    def space_group(self) -> dict:
+        """Determine the space group of the crystal from the symmetry operations.
+
+        Check :meth:`SymmetryHandler.space_group` for the description of the returned
+        data. Requires the optional dependency spglib.
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            SymmetryHandler.space_group,
+        )
+
+    def has_inversion_symmetry(self) -> bool:
+        """Return whether the inversion operation is part of the symmetry group."""
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            SymmetryHandler.has_inversion_symmetry,
+        )

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -7,8 +7,10 @@ from py4vasp._calculation.dispatch import (
     DataSource,
     merge_default,
     merge_strings,
+    merge_to_database,
     quantity,
 )
+from py4vasp._raw.data_db import Symmetry_DB
 from py4vasp._util import check, import_
 
 spglib = import_.optional("spglib")
@@ -124,6 +126,26 @@ class SymmetryHandler:
             "crystal_system": _crystal_system(number),
             "is_symmorphic": self.is_symmorphic(),
         }
+
+    def to_database(self) -> Symmetry_DB:
+        """Serialize the symmetry data for database storage.
+
+        The stored quantities deliberately reduce the symmetry operations to a few
+        scalars that make it easy to search for a calculation (space group, crystal
+        system, presence of inversion symmetry, ...). Space-group information requires
+        spglib; if it is not installed those fields are left empty.
+        """
+        space_group = self.space_group() if import_.is_imported(spglib) else None
+        return Symmetry_DB(
+            space_group=space_group["number"] if space_group else None,
+            space_group_symbol=(
+                space_group["international_symbol"] if space_group else None
+            ),
+            crystal_system=space_group["crystal_system"] if space_group else None,
+            has_inversion_symmetry=self.has_inversion_symmetry(),
+            number_of_operations=int(self._raw_symmetry.number_of_operations),
+            is_symmorphic=self.is_symmorphic(),
+        )
 
     def _space_group_type(self):
         rotations, translations = self._all_operations()
@@ -260,3 +282,12 @@ class Symmetry:
 
     def _repr_pretty_(self, p, cycle):
         p.text(str(self))
+
+    def _to_database(self) -> dict:
+        """Return {quantity[_selection]: handler_result} for database storage."""
+        return merge_to_database(
+            self._source,
+            self._quantity_name,
+            SymmetryHandler.from_data,
+            SymmetryHandler.to_database,
+        )

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -29,6 +29,20 @@ _CRYSTAL_SYSTEMS = (
     (230, "cubic"),
 )
 
+# Crystal-family letter of the Pearson symbol for each crystal system.
+_FAMILY_LETTER = {
+    "triclinic": "a",
+    "monoclinic": "m",
+    "orthorhombic": "o",
+    "tetragonal": "t",
+    "trigonal": "h",
+    "hexagonal": "h",
+    "cubic": "c",
+}
+
+# Number of lattice points in the conventional cell for each centering.
+_CENTERING_MULTIPLICITY = {"P": 1, "S": 2, "I": 2, "F": 4, "R": 3}
+
 
 def _crystal_system(space_group_number):
     for boundary, name in _CRYSTAL_SYSTEMS:
@@ -36,6 +50,15 @@ def _crystal_system(space_group_number):
             return name
     message = f"The space group number {space_group_number} is not in the range 1-230."
     raise exception.IncorrectUsage(message)
+
+
+def _centering(space_group_type):
+    """Return the centering letter (P, S, I, F, R) of the conventional cell.
+
+    The base-centered lattices (A, B, C) are unified into the single symbol S.
+    """
+    letter = space_group_type.international_short[0]
+    return "S" if letter in "ABC" else letter
 
 
 class SymmetryHandler:
@@ -135,17 +158,67 @@ class SymmetryHandler:
         system, presence of inversion symmetry, ...). Space-group information requires
         spglib; if it is not installed those fields are left empty.
         """
-        space_group = self.space_group() if import_.is_imported(spglib) else None
+        if import_.is_imported(spglib):
+            space_group_type = self._space_group_type()
+            number = space_group_type.number
+            space_group = number
+            space_group_symbol = space_group_type.international_short
+            crystal_system = _crystal_system(number)
+            point_group_schoenflies = space_group_type.pointgroup_schoenflies
+            bravais_lattice = self._bravais_lattice(space_group_type)
+            pearson_symbol = f"{bravais_lattice}{self._number_of_conventional_atoms(bravais_lattice)}"
+        else:
+            space_group = space_group_symbol = crystal_system = None
+            point_group_schoenflies = bravais_lattice = pearson_symbol = None
         return Symmetry_DB(
-            space_group=space_group["number"] if space_group else None,
-            space_group_symbol=(
-                space_group["international_symbol"] if space_group else None
-            ),
-            crystal_system=space_group["crystal_system"] if space_group else None,
+            space_group=space_group,
+            space_group_symbol=space_group_symbol,
+            crystal_system=crystal_system,
+            point_group_schoenflies=point_group_schoenflies,
+            bravais_lattice=bravais_lattice,
+            pearson_symbol=pearson_symbol,
             has_inversion_symmetry=self.has_inversion_symmetry(),
             number_of_operations=int(self._raw_symmetry.number_of_operations),
             is_symmorphic=self.is_symmorphic(),
         )
+
+    def point_group_schoenflies(self) -> str:
+        """Return the point group of the crystal in Schoenflies notation, e.g. Td.
+
+        Requires the optional dependency spglib.
+        """
+        return self._space_group_type().pointgroup_schoenflies
+
+    def bravais_lattice(self) -> str:
+        """Return the two-letter Bravais-lattice symbol, e.g. cF, oS, or hP.
+
+        The first letter denotes the crystal family (a, m, o, t, h, c) and the second
+        the centering (P, S, I, F, R). There are 14 possible combinations. Requires the
+        optional dependency spglib.
+        """
+        return self._bravais_lattice(self._space_group_type())
+
+    def pearson_symbol(self) -> str:
+        """Return the Pearson symbol, e.g. cF8.
+
+        The Pearson symbol combines the Bravais-lattice symbol with the number of atoms
+        in the conventional cell. Requires the optional dependency spglib.
+        """
+        bravais_lattice = self._bravais_lattice(self._space_group_type())
+        number_atoms = self._number_of_conventional_atoms(bravais_lattice)
+        return f"{bravais_lattice}{number_atoms}"
+
+    def _bravais_lattice(self, space_group_type):
+        family = _FAMILY_LETTER[_crystal_system(space_group_type.number)]
+        return family + _centering(space_group_type)
+
+    def _number_of_conventional_atoms(self, bravais_lattice):
+        multiplicity = _CENTERING_MULTIPLICITY[bravais_lattice[1]]
+        number_atoms = np.array(self._raw_symmetry.atom_permutations).shape[-1]
+        number_primitive_atoms = number_atoms // int(
+            self._raw_symmetry.number_of_primitive_cells
+        )
+        return number_primitive_atoms * multiplicity
 
     def _space_group_type(self):
         rotations, translations = self._all_operations()
@@ -269,6 +342,45 @@ class Symmetry:
             None,
             self._handler_factory,
             SymmetryHandler.has_inversion_symmetry,
+        )
+
+    def point_group_schoenflies(self) -> str:
+        """Return the point group of the crystal in Schoenflies notation, e.g. Td.
+
+        Requires the optional dependency spglib.
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            SymmetryHandler.point_group_schoenflies,
+        )
+
+    def bravais_lattice(self) -> str:
+        """Return the two-letter Bravais-lattice symbol, e.g. cF, oS, or hP.
+
+        Requires the optional dependency spglib.
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            SymmetryHandler.bravais_lattice,
+        )
+
+    def pearson_symbol(self) -> str:
+        """Return the Pearson symbol, e.g. cF8.
+
+        Requires the optional dependency spglib.
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            SymmetryHandler.pearson_symbol,
         )
 
     def __str__(self, selection=None) -> str:

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -1,5 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import dataclasses
+
 import numpy as np
 
 from py4vasp import exception, raw
@@ -14,6 +16,23 @@ from py4vasp._raw.data_db import Symmetry_DB
 from py4vasp._util import check, import_
 
 spglib = import_.optional("spglib")
+
+
+@dataclasses.dataclass
+class SpaceGroup:
+    """The space group of a crystal and related classification."""
+
+    number: int
+    "The international space-group number (1-230)."
+    international_symbol: str
+    "The Hermann-Mauguin (international short) symbol, e.g. F-43m."
+    point_group: str
+    "The point group in international notation, e.g. -43m."
+    crystal_system: str
+    "The crystal system, e.g. cubic or orthorhombic."
+    is_symmorphic: bool
+    "Whether the space group is symmorphic."
+
 
 # Tolerance used by spglib when classifying the symmetry operations.
 _SYMPREC = 1e-5
@@ -128,7 +147,7 @@ class SymmetryHandler:
         translations = np.array(self._raw_symmetry.translations)
         return bool(np.allclose(translations, 0.0))
 
-    def space_group(self) -> dict:
+    def space_group(self) -> SpaceGroup:
         """Determine the space group of the crystal from the symmetry operations.
 
         The space group is deduced with spglib from the symmetry operations VASP
@@ -136,19 +155,19 @@ class SymmetryHandler:
 
         Returns
         -------
-        dict
+        SpaceGroup
             The international space-group number and Hermann-Mauguin symbol, the
             point group, the crystal system, and whether the group is symmorphic.
         """
         space_group_type = self._space_group_type()
         number = space_group_type.number
-        return {
-            "number": number,
-            "international_symbol": space_group_type.international_short,
-            "point_group": space_group_type.pointgroup_international,
-            "crystal_system": _crystal_system(number),
-            "is_symmorphic": self.is_symmorphic(),
-        }
+        return SpaceGroup(
+            number=number,
+            international_symbol=space_group_type.international_short,
+            point_group=space_group_type.pointgroup_international,
+            crystal_system=_crystal_system(number),
+            is_symmorphic=self.is_symmorphic(),
+        )
 
     def to_database(self) -> Symmetry_DB:
         """Serialize the symmetry data for database storage.
@@ -259,9 +278,9 @@ class SymmetryHandler:
         ]
         if import_.is_imported(spglib):
             space_group = self.space_group()
-            symbol = space_group["international_symbol"]
-            lines.append(f"    space group: {symbol} ({space_group['number']})")
-            lines.append(f"    crystal system: {space_group['crystal_system']}")
+            symbol = space_group.international_symbol
+            lines.append(f"    space group: {symbol} ({space_group.number})")
+            lines.append(f"    crystal system: {space_group.crystal_system}")
         else:
             lines.append("    space group: not available (requires spglib)")
         inversion = "yes" if self.has_inversion_symmetry() else "no"
@@ -361,7 +380,7 @@ class Symmetry:
         """Convenient alias for :py:meth:`read`. Please read the documentation there."""
         return self.read()
 
-    def space_group(self) -> dict:
+    def space_group(self) -> SpaceGroup:
         """Determine the space group of the crystal from its symmetry operations.
 
         The symmetry operations are classified with spglib to identify the space group
@@ -369,7 +388,7 @@ class Symmetry:
 
         Returns
         -------
-        dict
+        SpaceGroup
             The international space-group number and Hermann-Mauguin symbol, the point
             group, the crystal system, and whether the space group is symmorphic.
 
@@ -379,7 +398,7 @@ class Symmetry:
         >>> calculation = demo.calculation(path)
 
         >>> calculation.symmetry.space_group()
-        {'number': 216, 'international_symbol': 'F-43m', 'point_group': '-43m', 'crystal_system': 'cubic', 'is_symmorphic': True}
+        SpaceGroup(number=216, international_symbol='F-43m', point_group='-43m', crystal_system='cubic', is_symmorphic=True)
         """
         return merge_default(
             self._source,

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -64,18 +64,15 @@ class SymmetryHandler:
             Contains the real- and reciprocal-space rotations, translations, the inverse
             operation of each operation, the atom permutations, the primitive cell
             information, and scalar metadata (number of operations, number of primitive
-            cells, ISYM). ``spin_flips`` is ``None`` unless the calculation was
-            spin-polarized.
+            cells, ISYM). ``spin_flips`` is only present for spin-polarized calculations.
         """
         raw_symmetry = self._raw_symmetry
-        spin_flips = raw_symmetry.spin_flips
-        return {
+        result = {
             "rotations": np.array(raw_symmetry.rotations),
             "reciprocal_rotations": np.array(raw_symmetry.reciprocal_rotations),
             "translations": np.array(raw_symmetry.translations),
             "inverse_operations": np.array(raw_symmetry.inverse_operations) - 1,
             "atom_permutations": np.array(raw_symmetry.atom_permutations) - 1,
-            "spin_flips": None if check.is_none(spin_flips) else np.array(spin_flips),
             "primitive_lattice_vectors": np.array(
                 raw_symmetry.primitive_lattice_vectors
             ),
@@ -84,6 +81,9 @@ class SymmetryHandler:
             "number_of_primitive_cells": int(raw_symmetry.number_of_primitive_cells),
             "isym": int(raw_symmetry.isym),
         }
+        if not check.is_none(raw_symmetry.spin_flips):
+            result["spin_flips"] = np.array(raw_symmetry.spin_flips)
+        return result
 
     def to_dict(self) -> dict:
         """Public alias for read()."""

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -6,6 +6,7 @@ from py4vasp import exception, raw
 from py4vasp._calculation.dispatch import (
     DataSource,
     merge_default,
+    merge_strings,
     quantity,
 )
 from py4vasp._util import check, import_
@@ -159,6 +160,26 @@ class SymmetryHandler:
             return 1.0
         return np.array(cell.scale)
 
+    def __str__(self) -> str:
+        raw_symmetry = self._raw_symmetry
+        lines = [
+            f"symmetry group with {int(raw_symmetry.number_of_operations)} operations:"
+        ]
+        if import_.is_imported(spglib):
+            space_group = self.space_group()
+            symbol = space_group["international_symbol"]
+            lines.append(f"    space group: {symbol} ({space_group['number']})")
+            lines.append(f"    crystal system: {space_group['crystal_system']}")
+        else:
+            lines.append("    space group: not available (requires spglib)")
+        inversion = "yes" if self.has_inversion_symmetry() else "no"
+        lines.append(f"    inversion symmetry: {inversion}")
+        lines.append(
+            f"    primitive cells: {int(raw_symmetry.number_of_primitive_cells)}"
+        )
+        lines.append(f"    ISYM: {int(raw_symmetry.isym)}")
+        return "\n".join(lines)
+
 
 @quantity("symmetry")
 class Symmetry:
@@ -227,3 +248,15 @@ class Symmetry:
             self._handler_factory,
             SymmetryHandler.has_inversion_symmetry,
         )
+
+    def __str__(self, selection=None) -> str:
+        return merge_strings(
+            self._source,
+            self._quantity_name,
+            selection,
+            self._handler_factory,
+            SymmetryHandler.__str__,
+        )
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -179,6 +179,7 @@ class SymmetryHandler:
             pearson_symbol=pearson_symbol,
             has_inversion_symmetry=self.has_inversion_symmetry(),
             number_of_operations=int(self._raw_symmetry.number_of_operations),
+            number_of_primitive_cells=int(self._raw_symmetry.number_of_primitive_cells),
             is_symmorphic=self.is_symmorphic(),
         )
 

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -132,7 +132,7 @@ class SymmetryHandler:
         """Determine the space group of the crystal from the symmetry operations.
 
         The space group is deduced with spglib from the symmetry operations VASP
-        stored. This requires the optional dependency spglib to be installed.
+        stored.
 
         Returns
         -------
@@ -184,18 +184,14 @@ class SymmetryHandler:
         )
 
     def point_group_schoenflies(self) -> str:
-        """Return the point group of the crystal in Schoenflies notation, e.g. Td.
-
-        Requires the optional dependency spglib.
-        """
+        """Return the point group of the crystal in Schoenflies notation, e.g. Td."""
         return self._space_group_type().pointgroup_schoenflies
 
     def bravais_lattice(self) -> str:
         """Return the two-letter Bravais-lattice symbol, e.g. cF, oS, or hP.
 
         The first letter denotes the crystal family (a, m, o, t, h, c) and the second
-        the centering (P, S, I, F, R). There are 14 possible combinations. Requires the
-        optional dependency spglib.
+        the centering (P, S, I, F, R). There are 14 possible combinations.
         """
         return self._bravais_lattice(self._space_group_type())
 
@@ -203,7 +199,7 @@ class SymmetryHandler:
         """Return the Pearson symbol, e.g. cF8.
 
         The Pearson symbol combines the Bravais-lattice symbol with the number of atoms
-        in the conventional cell. Requires the optional dependency spglib.
+        in the conventional cell.
         """
         bravais_lattice = self._bravais_lattice(self._space_group_type())
         number_atoms = self._number_of_conventional_atoms(bravais_lattice)
@@ -281,10 +277,30 @@ class SymmetryHandler:
 class Symmetry:
     """The symmetry operations of the crystal determined by VASP.
 
-    VASP analyzes the crystal structure and stores the set of symmetry operations
-    (rotations and translations) it uses to reduce the computational effort. This
-    class exposes those operations for further processing and can derive the space
-    group of the crystal from them using spglib.
+    VASP analyzes the crystal structure and determines the symmetry operations
+    (rotations and translations) that leave it invariant. This class exposes those
+    operations for further processing and derives common crystallographic descriptors
+    such as the space group, the Bravais lattice, and the Pearson symbol from them
+    using spglib.
+
+    Examples
+    --------
+    First, we create some example data so that you can follow along. Please define a
+    variable `path` with the path to a directory that does not contain any VASP
+    calculation data. Alternatively, use your own data if you have run VASP.
+
+    >>> from py4vasp import demo
+    >>> calculation = demo.calculation(path)
+
+    Read the symmetry operations into a Python dictionary for further processing
+
+    >>> calculation.symmetry.read()
+    {'rotations': array(...), ..., 'isym': 2, 'spin_flips': array(...)}
+
+    Check whether the crystal is centrosymmetric
+
+    >>> calculation.symmetry.has_inversion_symmetry()
+    False
     """
 
     def __init__(self, source, quantity_name: str = "symmetry"):
@@ -305,9 +321,33 @@ class Symmetry:
         return SymmetryHandler.from_data(raw_data)
 
     def read(self) -> dict:
-        """Return the symmetry operations and related data as a dictionary.
+        """Read the symmetry operations into a dictionary.
 
-        Check :meth:`SymmetryHandler.read` for the description of the returned data.
+        The dictionary provides the complete set of symmetry operations as NumPy
+        arrays for convenient postprocessing. The rotation matrices act on fractional
+        coordinates of the computational cell and the translations are given in the
+        same basis. The index arrays ``inverse_operations`` and ``atom_permutations``
+        are converted from the Fortran 1-based convention used in the file to 0-based,
+        so that they index NumPy arrays directly. ``spin_flips`` is only present for
+        spin-polarized calculations.
+
+        Returns
+        -------
+        dict
+            The real- and reciprocal-space rotations, the translations, the inverse of
+            each operation, the atom permutations, the primitive-cell lattice vectors
+            and translations, and scalar metadata (number of operations, number of
+            primitive cells, and the ISYM setting).
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        Read the symmetry operations into a Python dictionary
+
+        >>> calculation.symmetry.read()
+        {'rotations': array(...), ..., 'isym': 2, 'spin_flips': array(...)}
         """
         return merge_default(
             self._source,
@@ -318,14 +358,28 @@ class Symmetry:
         )
 
     def to_dict(self, selection: str | None = None) -> dict:
-        """Public alias for read(). Check that method for the returned data."""
+        """Convenient alias for :py:meth:`read`. Please read the documentation there."""
         return self.read()
 
     def space_group(self) -> dict:
-        """Determine the space group of the crystal from the symmetry operations.
+        """Determine the space group of the crystal from its symmetry operations.
 
-        Check :meth:`SymmetryHandler.space_group` for the description of the returned
-        data. Requires the optional dependency spglib.
+        The symmetry operations are classified with spglib to identify the space group
+        the crystal belongs to.
+
+        Returns
+        -------
+        dict
+            The international space-group number and Hermann-Mauguin symbol, the point
+            group, the crystal system, and whether the space group is symmorphic.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        >>> calculation.symmetry.space_group()
+        {'number': 216, 'international_symbol': 'F-43m', 'point_group': '-43m', 'crystal_system': 'cubic', 'is_symmorphic': True}
         """
         return merge_default(
             self._source,
@@ -336,7 +390,22 @@ class Symmetry:
         )
 
     def has_inversion_symmetry(self) -> bool:
-        """Return whether the inversion operation is part of the symmetry group."""
+        """Check whether the inversion operation is part of the symmetry group.
+
+        Returns
+        -------
+        bool
+            True if the crystal is centrosymmetric, i.e. the inversion maps the crystal
+            onto itself.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        >>> calculation.symmetry.has_inversion_symmetry()
+        False
+        """
         return merge_default(
             self._source,
             self._quantity_name,
@@ -346,9 +415,20 @@ class Symmetry:
         )
 
     def point_group_schoenflies(self) -> str:
-        """Return the point group of the crystal in Schoenflies notation, e.g. Td.
+        """Determine the point group of the crystal in Schoenflies notation.
 
-        Requires the optional dependency spglib.
+        Returns
+        -------
+        str
+            The point group in Schoenflies notation, e.g. Td.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        >>> calculation.symmetry.point_group_schoenflies()
+        'Td'
         """
         return merge_default(
             self._source,
@@ -359,9 +439,21 @@ class Symmetry:
         )
 
     def bravais_lattice(self) -> str:
-        """Return the two-letter Bravais-lattice symbol, e.g. cF, oS, or hP.
+        """Determine the Bravais lattice of the crystal.
 
-        Requires the optional dependency spglib.
+        Returns
+        -------
+        str
+            The two-letter Bravais-lattice symbol, one of the 14 possible combinations
+            of crystal family (a, m, o, t, h, c) and centering (P, S, I, F, R), e.g. cF.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        >>> calculation.symmetry.bravais_lattice()
+        'cF'
         """
         return merge_default(
             self._source,
@@ -372,9 +464,21 @@ class Symmetry:
         )
 
     def pearson_symbol(self) -> str:
-        """Return the Pearson symbol, e.g. cF8.
+        """Determine the Pearson symbol of the crystal.
 
-        Requires the optional dependency spglib.
+        Returns
+        -------
+        str
+            The Pearson symbol, combining the Bravais-lattice symbol with the number of
+            atoms in the conventional cell, e.g. cF8.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        >>> calculation.symmetry.pearson_symbol()
+        'cF8'
         """
         return merge_default(
             self._source,

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -1,0 +1,108 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import numpy as np
+
+from py4vasp import raw
+from py4vasp._calculation.dispatch import (
+    DataSource,
+    merge_default,
+    quantity,
+)
+from py4vasp._util import check
+
+
+class SymmetryHandler:
+    """Handler for the symmetry quantity. Works with exactly one raw.Symmetry object."""
+
+    def __init__(self, raw_symmetry: raw.Symmetry):
+        self._raw_symmetry = raw_symmetry
+
+    @classmethod
+    def from_data(cls, raw_symmetry: raw.Symmetry) -> "SymmetryHandler":
+        return cls(raw_symmetry)
+
+    def read(self) -> dict:
+        """Return the symmetry operations and related data as a dictionary.
+
+        The dictionary contains the raw symmetry operations of the crystal in a form
+        that is convenient for further processing in Python. The rotation matrices act
+        on fractional coordinates of the computational cell; the associated translations
+        are given in the same fractional coordinates. Indices (``inverse_operations`` and
+        ``atom_permutations``) are converted from the Fortran 1-based convention used in
+        the file to 0-based so that they can be used directly to index NumPy arrays.
+
+        Returns
+        -------
+        dict
+            Contains the real- and reciprocal-space rotations, translations, the inverse
+            operation of each operation, the atom permutations, the primitive cell
+            information, and scalar metadata (number of operations, number of primitive
+            cells, ISYM). ``spin_flips`` is ``None`` unless the calculation was
+            spin-polarized.
+        """
+        raw_symmetry = self._raw_symmetry
+        spin_flips = raw_symmetry.spin_flips
+        return {
+            "rotations": np.array(raw_symmetry.rotations),
+            "reciprocal_rotations": np.array(raw_symmetry.reciprocal_rotations),
+            "translations": np.array(raw_symmetry.translations),
+            "inverse_operations": np.array(raw_symmetry.inverse_operations) - 1,
+            "atom_permutations": np.array(raw_symmetry.atom_permutations) - 1,
+            "spin_flips": None if check.is_none(spin_flips) else np.array(spin_flips),
+            "primitive_lattice_vectors": np.array(
+                raw_symmetry.primitive_lattice_vectors
+            ),
+            "primitive_translations": np.array(raw_symmetry.primitive_translations),
+            "number_of_operations": int(raw_symmetry.number_of_operations),
+            "number_of_primitive_cells": int(raw_symmetry.number_of_primitive_cells),
+            "isym": int(raw_symmetry.isym),
+        }
+
+    def to_dict(self) -> dict:
+        """Public alias for read()."""
+        return self.read()
+
+
+@quantity("symmetry")
+class Symmetry:
+    """The symmetry operations of the crystal determined by VASP.
+
+    VASP analyzes the crystal structure and stores the set of symmetry operations
+    (rotations and translations) it uses to reduce the computational effort. This
+    class exposes those operations for further processing and can derive the space
+    group of the crystal from them using spglib.
+    """
+
+    def __init__(self, source, quantity_name: str = "symmetry"):
+        self._source = source
+        self._quantity_name = quantity_name
+
+    @classmethod
+    def from_data(cls, raw_symmetry: raw.Symmetry) -> "Symmetry":
+        """Create a Symmetry dispatcher from raw data (convenience for testing)."""
+        return cls(source=DataSource(raw_symmetry))
+
+    @property
+    def path(self):
+        """Returns the path from which the output is obtained."""
+        return self._path
+
+    def _handler_factory(self, raw_data):
+        return SymmetryHandler.from_data(raw_data)
+
+    def read(self) -> dict:
+        """Return the symmetry operations and related data as a dictionary.
+
+        Check :meth:`SymmetryHandler.read` for the description of the returned data.
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            SymmetryHandler.read,
+        )
+
+    def to_dict(self, selection: str | None = None) -> dict:
+        """Public alias for read(). Check that method for the returned data."""
+        return self.read()

--- a/src/py4vasp/_demo/__init__.py
+++ b/src/py4vasp/_demo/__init__.py
@@ -39,6 +39,7 @@ from py4vasp._demo import (
     stoichiometry,
     stress,
     structure,
+    symmetry,
     system,
     velocity,
     workfunction,

--- a/src/py4vasp/_demo/symmetry.py
+++ b/src/py4vasp/_demo/symmetry.py
@@ -1,0 +1,156 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import numpy as np
+
+from py4vasp import _demo, raw
+
+# The demo data below is copied verbatim from real VASP calculations so that the
+# derived space groups match crystallographic expectation:
+#   CoO (antiferromagnetic, ISPIN=2): F-43m (#216), 24 operations, no inversion
+#   AlP (bulk):                       Amm2  (#38),  4 operations, no inversion
+
+
+def CoO():
+    """Antiferromagnetic CoO in a single primitive (rhombohedral FCC) cell."""
+    rotations = [
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        [[0, 0, 1], [1, 0, 0], [0, 1, 0]],
+        [[0, 1, 0], [0, 0, 1], [1, 0, 0]],
+        [[-1, -1, -1], [0, 0, 1], [1, 0, 0]],
+        [[-1, -1, -1], [0, 1, 0], [0, 0, 1]],
+        [[-1, -1, -1], [1, 0, 0], [0, 1, 0]],
+        [[0, 1, 0], [1, 0, 0], [-1, -1, -1]],
+        [[1, 0, 0], [0, 0, 1], [-1, -1, -1]],
+        [[0, 0, 1], [0, 1, 0], [-1, -1, -1]],
+        [[0, 0, 1], [-1, -1, -1], [0, 1, 0]],
+        [[0, 1, 0], [-1, -1, -1], [1, 0, 0]],
+        [[1, 0, 0], [-1, -1, -1], [0, 0, 1]],
+        [[-1, -1, -1], [0, 1, 0], [1, 0, 0]],
+        [[-1, -1, -1], [1, 0, 0], [0, 0, 1]],
+        [[-1, -1, -1], [0, 0, 1], [0, 1, 0]],
+        [[0, 1, 0], [0, 0, 1], [-1, -1, -1]],
+        [[1, 0, 0], [0, 1, 0], [-1, -1, -1]],
+        [[0, 0, 1], [1, 0, 0], [-1, -1, -1]],
+        [[1, 0, 0], [-1, -1, -1], [0, 1, 0]],
+        [[0, 0, 1], [-1, -1, -1], [1, 0, 0]],
+        [[0, 1, 0], [-1, -1, -1], [0, 0, 1]],
+        [[1, 0, 0], [0, 0, 1], [0, 1, 0]],
+        [[0, 1, 0], [1, 0, 0], [0, 0, 1]],
+        [[0, 0, 1], [0, 1, 0], [1, 0, 0]],
+    ]
+    reciprocal_rotations = [
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        [[0, 0, 1], [1, 0, 0], [0, 1, 0]],
+        [[0, 1, 0], [0, 0, 1], [1, 0, 0]],
+        [[0, -1, 0], [0, -1, 1], [1, -1, 0]],
+        [[-1, 0, 0], [-1, 1, 0], [-1, 0, 1]],
+        [[0, 0, -1], [1, 0, -1], [0, 1, -1]],
+        [[0, 1, -1], [1, 0, -1], [0, 0, -1]],
+        [[1, -1, 0], [0, -1, 1], [0, -1, 0]],
+        [[-1, 0, 1], [-1, 1, 0], [-1, 0, 0]],
+        [[-1, 0, 1], [-1, 0, 0], [-1, 1, 0]],
+        [[0, 1, -1], [0, 0, -1], [1, 0, -1]],
+        [[1, -1, 0], [0, -1, 0], [0, -1, 1]],
+        [[0, 0, -1], [0, 1, -1], [1, 0, -1]],
+        [[0, -1, 0], [1, -1, 0], [0, -1, 1]],
+        [[-1, 0, 0], [-1, 0, 1], [-1, 1, 0]],
+        [[-1, 1, 0], [-1, 0, 1], [-1, 0, 0]],
+        [[1, 0, -1], [0, 1, -1], [0, 0, -1]],
+        [[0, -1, 1], [1, -1, 0], [0, -1, 0]],
+        [[1, 0, -1], [0, 0, -1], [0, 1, -1]],
+        [[0, -1, 1], [0, -1, 0], [1, -1, 0]],
+        [[-1, 1, 0], [-1, 0, 0], [-1, 0, 1]],
+        [[1, 0, 0], [0, 0, 1], [0, 1, 0]],
+        [[0, 1, 0], [1, 0, 0], [0, 0, 1]],
+        [[0, 0, 1], [0, 1, 0], [1, 0, 0]],
+    ]
+    number_of_operations = 24
+    inverse_operations = [
+        1,
+        3,
+        2,
+        10,
+        5,
+        16,
+        7,
+        19,
+        13,
+        4,
+        18,
+        12,
+        9,
+        21,
+        15,
+        6,
+        17,
+        11,
+        8,
+        20,
+        14,
+        22,
+        23,
+        24,
+    ]
+    atom_permutations = [number_of_operations * [[1, 2]]]
+    cell = raw.Cell(
+        lattice_vectors=_demo.wrap_data(
+            [[0.0, 0.5, 0.5], [0.5, 0.0, 0.5], [0.5, 0.5, 0.0]]
+        ),
+        scale=raw.VaspData(4.4479601811386305),
+    )
+    return raw.Symmetry(
+        cell=cell,
+        rotations=_demo.wrap_data(rotations),
+        reciprocal_rotations=_demo.wrap_data(reciprocal_rotations),
+        translations=_demo.wrap_data(np.zeros((number_of_operations, 3))),
+        inverse_operations=_demo.wrap_data(inverse_operations),
+        atom_permutations=_demo.wrap_data(atom_permutations),
+        primitive_lattice_vectors=_demo.wrap_data(
+            2.2239800905693152
+            * np.array([[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]])
+        ),
+        primitive_translations=_demo.wrap_data([[0.0, 0.0, 0.0]]),
+        number_of_operations=number_of_operations,
+        number_of_primitive_cells=1,
+        isym=2,
+        spin_flips=_demo.wrap_data(np.ones((1, number_of_operations))),
+    )
+
+
+def AlP():
+    """Bulk AlP in a computational cell containing two primitive cells."""
+    rotations = [
+        [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        [[1, 0, 0], [0, 1, 0], [0, 0, -1]],
+        [[1, 0, 0], [0, -1, 0], [0, 0, -1]],
+        [[1, 0, 0], [0, -1, 0], [0, 0, 1]],
+    ]
+    number_of_operations = 4
+    atom_permutations = [
+        number_of_operations * [[1, 2, 3, 4]],
+        number_of_operations * [[2, 1, 4, 3]],
+    ]
+    cell = raw.Cell(
+        lattice_vectors=_demo.wrap_data(np.eye(3)),
+        scale=raw.VaspData(4.048183),
+    )
+    return raw.Symmetry(
+        cell=cell,
+        rotations=_demo.wrap_data(rotations),
+        reciprocal_rotations=_demo.wrap_data(rotations),
+        translations=_demo.wrap_data(np.zeros((number_of_operations, 3))),
+        inverse_operations=_demo.wrap_data([1, 2, 3, 4]),
+        atom_permutations=_demo.wrap_data(atom_permutations),
+        primitive_lattice_vectors=_demo.wrap_data(
+            [
+                [2.0240915, -2.0240915, 0.0],
+                [2.0240915, 2.0240915, 0.0],
+                [0.0, 0.0, 4.048183],
+            ]
+        ),
+        primitive_translations=_demo.wrap_data([[0.0, 0.0, 0.0], [0.5, 0.5, 0.0]]),
+        number_of_operations=number_of_operations,
+        number_of_primitive_cells=2,
+        isym=2,
+        spin_flips=raw.VaspData(None),
+    )

--- a/src/py4vasp/_raw/data.py
+++ b/src/py4vasp/_raw/data.py
@@ -841,6 +841,40 @@ class Structure:
 
 
 @dataclasses.dataclass
+class Symmetry:
+    """Symmetry operations of the crystal determined by VASP.
+
+    Contains the rotation matrices and translation vectors of all symmetry
+    operations that VASP detected for the computational cell, together with the
+    primitive cell information needed to relate the operations to the crystal."""
+
+    cell: Cell
+    "Computational cell in which the symmetry operations are expressed."
+    rotations: VaspData
+    "Rotation matrices of the symmetry operations in real space (lattice basis)."
+    reciprocal_rotations: VaspData
+    "Rotation matrices of the symmetry operations in reciprocal space."
+    translations: VaspData
+    "Fractional translation vector associated with each symmetry operation."
+    inverse_operations: VaspData
+    "Index of the inverse of each symmetry operation (Fortran 1-based in the file)."
+    atom_permutations: VaspData
+    "Permutation of the atoms under each operation for every primitive cell (Fortran 1-based)."
+    primitive_lattice_vectors: VaspData
+    "Lattice vectors of the primitive cell."
+    primitive_translations: VaspData
+    "Pure translations relating the computational cell to the primitive cell."
+    number_of_operations: int
+    "Number of symmetry operations."
+    number_of_primitive_cells: int
+    "Number of primitive cells contained in the computational cell."
+    isym: int
+    "The ISYM setting used in the calculation."
+    spin_flips: Optional[VaspData] = NONE()
+    "Spin-flip factor for each operation, only present for spin-polarized calculations."
+
+
+@dataclasses.dataclass
 class System:
     "The name of the system set in the input."
 

--- a/src/py4vasp/_raw/data_db.py
+++ b/src/py4vasp/_raw/data_db.py
@@ -958,6 +958,24 @@ class Velocity_DB(_DBDataMixin):
 
 
 @dataclass
+class Symmetry_DB(_DBDataMixin):
+    """Data class for storing symmetry data in the database."""
+
+    space_group: Optional[int] = None
+    """The international space-group number (1-230) deduced from the symmetry operations. Useful to find calculations of a given crystal symmetry."""
+    space_group_symbol: Optional[str] = None
+    """The Hermann-Mauguin (international short) symbol of the space group, e.g. Fm-3m."""
+    crystal_system: Optional[str] = None
+    """The crystal system deduced from the space group, e.g. cubic or orthorhombic."""
+    has_inversion_symmetry: Optional[bool] = None
+    """Whether the crystal has inversion symmetry. Useful to filter centrosymmetric calculations."""
+    number_of_operations: Optional[int] = None
+    """The number of symmetry operations of the crystal."""
+    is_symmorphic: Optional[bool] = None
+    """Whether the space group is symmorphic, i.e. none of its operations carries a fractional translation."""
+
+
+@dataclass
 class Workfunction_DB(_DBDataMixin):
     """Data class for storing work function data in the database."""
 

--- a/src/py4vasp/_raw/data_db.py
+++ b/src/py4vasp/_raw/data_db.py
@@ -977,6 +977,8 @@ class Symmetry_DB(_DBDataMixin):
     """Whether the crystal has inversion symmetry. Useful to filter centrosymmetric calculations."""
     number_of_operations: Optional[int] = None
     """The number of symmetry operations of the crystal."""
+    number_of_primitive_cells: Optional[int] = None
+    """The number of primitive cells contained in the computational cell."""
     is_symmorphic: Optional[bool] = None
     """Whether the space group is symmorphic, i.e. none of its operations carries a fractional translation."""
 

--- a/src/py4vasp/_raw/data_db.py
+++ b/src/py4vasp/_raw/data_db.py
@@ -967,6 +967,12 @@ class Symmetry_DB(_DBDataMixin):
     """The Hermann-Mauguin (international short) symbol of the space group, e.g. Fm-3m."""
     crystal_system: Optional[str] = None
     """The crystal system deduced from the space group, e.g. cubic or orthorhombic."""
+    point_group_schoenflies: Optional[str] = None
+    """The point group of the crystal in Schoenflies notation, e.g. Td."""
+    bravais_lattice: Optional[str] = None
+    """The two-letter Bravais-lattice symbol (crystal family + centering), e.g. cF, oS, hP. One of 14 options."""
+    pearson_symbol: Optional[str] = None
+    """The Pearson symbol combining the Bravais lattice with the number of atoms in the conventional cell, e.g. cF8."""
     has_inversion_symmetry: Optional[bool] = None
     """Whether the crystal has inversion symmetry. Useful to filter centrosymmetric calculations."""
     number_of_operations: Optional[int] = None

--- a/src/py4vasp/_raw/definition.py
+++ b/src/py4vasp/_raw/definition.py
@@ -722,6 +722,23 @@ schema.add(
 )
 schema.add(raw.Structure, name="poscar", file="POSCAR", data_factory=read.structure)
 #
+schema.add(
+    raw.Symmetry,
+    required=raw.Version(6, 6),
+    cell=Link("cell", "final"),
+    rotations="results/symmetry/rotations_real_space",
+    reciprocal_rotations="results/symmetry/rotations_reciprocal_space",
+    translations="results/symmetry/translations",
+    inverse_operations="results/symmetry/inverse_operations",
+    atom_permutations="results/symmetry/cell_atom_permutations",
+    primitive_lattice_vectors="results/symmetry/primitive_lattice_vectors",
+    primitive_translations="results/symmetry/primitive_translations",
+    number_of_operations="results/symmetry/number_of_operations",
+    number_of_primitive_cells="results/symmetry/number_of_primitive_cells",
+    isym="results/symmetry/isym",
+    spin_flips="results/symmetry/cell_spin_flips",
+)
+#
 schema.add(raw.System, system="input/incar/SYSTEM")
 #
 schema.add(

--- a/src/py4vasp/demo.py
+++ b/src/py4vasp/demo.py
@@ -72,6 +72,7 @@ def _generate_default_data(h5f, waveh5f=None):
     write(h5f, _demo.force.Sr2TiO4(randomize=True))
     write(h5f, _demo.stress.Sr2TiO4(randomize=True))
     write(h5f, _demo.structure.Sr2TiO4())
+    write(h5f, _demo.symmetry.CoO())
     write(h5f, _demo.system.Sr2TiO4())
     write(h5f, _demo.dielectric_function.electron())
     write(h5f, _demo.velocity.Sr2TiO4())

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -1,10 +1,12 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import dataclasses
 import types
 
 import numpy as np
 import pytest
 
+from py4vasp import exception, raw
 from py4vasp._calculation.symmetry import Symmetry
 
 
@@ -55,3 +57,52 @@ def test_to_dict_is_alias_of_read(symmetry, Assert):
             assert from_dict[key] is None
         else:
             Assert.allclose(from_dict[key], from_read[key])
+
+
+EXPECTED_SPACE_GROUP = {
+    "CoO": dict(
+        number=216,
+        international_symbol="F-43m",
+        point_group="-43m",
+        crystal_system="cubic",
+    ),
+    "AlP": dict(
+        number=38,
+        international_symbol="Amm2",
+        point_group="mm2",
+        crystal_system="orthorhombic",
+    ),
+}
+
+
+def test_space_group(symmetry):
+    pytest.importorskip("spglib")
+    expected = EXPECTED_SPACE_GROUP[symmetry.ref.name]
+    actual = symmetry.space_group()
+    assert actual["number"] == expected["number"]
+    assert actual["international_symbol"] == expected["international_symbol"]
+    assert actual["point_group"] == expected["point_group"]
+    assert actual["crystal_system"] == expected["crystal_system"]
+    assert actual["is_symmorphic"] is True
+
+
+def test_space_group_without_spglib(symmetry, monkeypatch):
+    from py4vasp._calculation import symmetry as symmetry_module
+    from py4vasp._util import import_
+
+    placeholder = import_._ModulePlaceholder("spglib")
+    monkeypatch.setattr(symmetry_module, "spglib", placeholder)
+    with pytest.raises(exception.ModuleNotInstalled):
+        symmetry.space_group()
+
+
+def test_has_inversion_symmetry_absent(symmetry):
+    assert symmetry.has_inversion_symmetry() is False
+
+
+def test_has_inversion_symmetry_present(raw_data):
+    raw_symmetry = raw_data.symmetry("AlP")
+    rotations = np.array(raw_symmetry.rotations)
+    rotations[1] = -np.eye(3, dtype=int)
+    modified = dataclasses.replace(raw_symmetry, rotations=raw.VaspData(rotations))
+    assert Symmetry.from_data(modified).has_inversion_symmetry() is True

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -45,7 +45,7 @@ def test_read(symmetry, Assert):
     if symmetry.ref.name == "CoO":
         Assert.allclose(actual["spin_flips"], np.array(raw.spin_flips))
     else:
-        assert actual["spin_flips"] is None
+        assert "spin_flips" not in actual
 
 
 def test_to_dict_is_alias_of_read(symmetry, Assert):

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -65,14 +65,38 @@ EXPECTED_SPACE_GROUP = {
         international_symbol="F-43m",
         point_group="-43m",
         crystal_system="cubic",
+        point_group_schoenflies="Td",
+        bravais_lattice="cF",
+        pearson_symbol="cF8",
     ),
     "AlP": dict(
         number=38,
         international_symbol="Amm2",
         point_group="mm2",
         crystal_system="orthorhombic",
+        point_group_schoenflies="C2v",
+        bravais_lattice="oS",
+        pearson_symbol="oS4",
     ),
 }
+
+
+def test_bravais_lattice(symmetry):
+    pytest.importorskip("spglib")
+    expected = EXPECTED_SPACE_GROUP[symmetry.ref.name]["bravais_lattice"]
+    assert symmetry.bravais_lattice() == expected
+
+
+def test_point_group_schoenflies(symmetry):
+    pytest.importorskip("spglib")
+    expected = EXPECTED_SPACE_GROUP[symmetry.ref.name]["point_group_schoenflies"]
+    assert symmetry.point_group_schoenflies() == expected
+
+
+def test_pearson_symbol(symmetry):
+    pytest.importorskip("spglib")
+    expected = EXPECTED_SPACE_GROUP[symmetry.ref.name]["pearson_symbol"]
+    assert symmetry.pearson_symbol() == expected
 
 
 def test_space_group(symmetry):
@@ -156,6 +180,9 @@ def test_to_database(symmetry, raw_data):
     assert actual.space_group == space_group["number"]
     assert actual.space_group_symbol == space_group["international_symbol"]
     assert actual.crystal_system == space_group["crystal_system"]
+    assert actual.point_group_schoenflies == space_group["point_group_schoenflies"]
+    assert actual.bravais_lattice == space_group["bravais_lattice"]
+    assert actual.pearson_symbol == space_group["pearson_symbol"]
     assert actual.has_inversion_symmetry is False
     assert actual.number_of_operations == NUMBER_OPERATIONS[name]
     assert actual.is_symmorphic is True
@@ -172,6 +199,9 @@ def test_to_database_without_spglib(symmetry, raw_data, monkeypatch):
     assert actual.space_group is None
     assert actual.space_group_symbol is None
     assert actual.crystal_system is None
+    assert actual.point_group_schoenflies is None
+    assert actual.bravais_lattice is None
+    assert actual.pearson_symbol is None
     assert actual.has_inversion_symmetry is False
     assert actual.number_of_operations == NUMBER_OPERATIONS[name]
     assert actual.is_symmorphic is True

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -101,13 +101,16 @@ def test_pearson_symbol(symmetry):
 
 def test_space_group(symmetry):
     pytest.importorskip("spglib")
+    from py4vasp._calculation.symmetry import SpaceGroup
+
     expected = EXPECTED_SPACE_GROUP[symmetry.ref.name]
     actual = symmetry.space_group()
-    assert actual["number"] == expected["number"]
-    assert actual["international_symbol"] == expected["international_symbol"]
-    assert actual["point_group"] == expected["point_group"]
-    assert actual["crystal_system"] == expected["crystal_system"]
-    assert actual["is_symmorphic"] is True
+    assert isinstance(actual, SpaceGroup)
+    assert actual.number == expected["number"]
+    assert actual.international_symbol == expected["international_symbol"]
+    assert actual.point_group == expected["point_group"]
+    assert actual.crystal_system == expected["crystal_system"]
+    assert actual.is_symmorphic is True
 
 
 def test_space_group_without_spglib(symmetry, monkeypatch):

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -186,3 +186,8 @@ def test_to_database_dispatcher(symmetry):
     assert set(result["symmetry"]) == {"default"}
     expected = SymmetryHandler.from_data(symmetry.ref.raw).to_database()
     assert result["symmetry"]["default"] == expected
+
+
+def test_factory_methods(raw_data, check_factory_methods):
+    raw_symmetry = raw_data.symmetry("CoO")
+    check_factory_methods(Symmetry, raw_symmetry)

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -185,6 +185,7 @@ def test_to_database(symmetry, raw_data):
     assert actual.pearson_symbol == space_group["pearson_symbol"]
     assert actual.has_inversion_symmetry is False
     assert actual.number_of_operations == NUMBER_OPERATIONS[name]
+    assert actual.number_of_primitive_cells == NUMBER_PRIMITIVE_CELLS[name]
     assert actual.is_symmorphic is True
 
 
@@ -204,6 +205,7 @@ def test_to_database_without_spglib(symmetry, raw_data, monkeypatch):
     assert actual.pearson_symbol is None
     assert actual.has_inversion_symmetry is False
     assert actual.number_of_operations == NUMBER_OPERATIONS[name]
+    assert actual.number_of_primitive_cells == NUMBER_PRIMITIVE_CELLS[name]
     assert actual.is_symmorphic is True
 
 

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -106,3 +106,38 @@ def test_has_inversion_symmetry_present(raw_data):
     rotations[1] = -np.eye(3, dtype=int)
     modified = dataclasses.replace(raw_symmetry, rotations=raw.VaspData(rotations))
     assert Symmetry.from_data(modified).has_inversion_symmetry() is True
+
+
+NUMBER_OPERATIONS = {"CoO": 24, "AlP": 4}
+NUMBER_PRIMITIVE_CELLS = {"CoO": 1, "AlP": 2}
+
+
+def test_print(symmetry, format_):
+    pytest.importorskip("spglib")
+    name = symmetry.ref.name
+    space_group = EXPECTED_SPACE_GROUP[name]
+    reference = f"""\
+symmetry group with {NUMBER_OPERATIONS[name]} operations:
+    space group: {space_group['international_symbol']} ({space_group['number']})
+    crystal system: {space_group['crystal_system']}
+    inversion symmetry: no
+    primitive cells: {NUMBER_PRIMITIVE_CELLS[name]}
+    ISYM: 2"""
+    actual, _ = format_(symmetry)
+    assert actual == {"text/plain": reference}
+
+
+def test_print_without_spglib(symmetry, format_, monkeypatch):
+    from py4vasp._calculation import symmetry as symmetry_module
+    from py4vasp._util import import_
+
+    monkeypatch.setattr(symmetry_module, "spglib", import_._ModulePlaceholder("spglib"))
+    name = symmetry.ref.name
+    reference = f"""\
+symmetry group with {NUMBER_OPERATIONS[name]} operations:
+    space group: not available (requires spglib)
+    inversion symmetry: no
+    primitive cells: {NUMBER_PRIMITIVE_CELLS[name]}
+    ISYM: 2"""
+    actual, _ = format_(symmetry)
+    assert actual == {"text/plain": reference}

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -141,3 +141,48 @@ symmetry group with {NUMBER_OPERATIONS[name]} operations:
     ISYM: 2"""
     actual, _ = format_(symmetry)
     assert actual == {"text/plain": reference}
+
+
+def test_to_database(symmetry, raw_data):
+    pytest.importorskip("spglib")
+    from py4vasp._calculation.symmetry import SymmetryHandler
+    from py4vasp._raw.data_db import Symmetry_DB
+
+    name = symmetry.ref.name
+    handler = SymmetryHandler.from_data(raw_data.symmetry(name))
+    actual = handler.to_database()
+    assert isinstance(actual, Symmetry_DB)
+    space_group = EXPECTED_SPACE_GROUP[name]
+    assert actual.space_group == space_group["number"]
+    assert actual.space_group_symbol == space_group["international_symbol"]
+    assert actual.crystal_system == space_group["crystal_system"]
+    assert actual.has_inversion_symmetry is False
+    assert actual.number_of_operations == NUMBER_OPERATIONS[name]
+    assert actual.is_symmorphic is True
+
+
+def test_to_database_without_spglib(symmetry, raw_data, monkeypatch):
+    from py4vasp._calculation import symmetry as symmetry_module
+    from py4vasp._calculation.symmetry import SymmetryHandler
+    from py4vasp._util import import_
+
+    monkeypatch.setattr(symmetry_module, "spglib", import_._ModulePlaceholder("spglib"))
+    name = symmetry.ref.name
+    actual = SymmetryHandler.from_data(raw_data.symmetry(name)).to_database()
+    assert actual.space_group is None
+    assert actual.space_group_symbol is None
+    assert actual.crystal_system is None
+    assert actual.has_inversion_symmetry is False
+    assert actual.number_of_operations == NUMBER_OPERATIONS[name]
+    assert actual.is_symmorphic is True
+
+
+def test_to_database_dispatcher(symmetry):
+    pytest.importorskip("spglib")
+    from py4vasp._calculation.symmetry import SymmetryHandler
+
+    result = symmetry._to_database()
+    assert set(result) == {"symmetry"}
+    assert set(result["symmetry"]) == {"default"}
+    expected = SymmetryHandler.from_data(symmetry.ref.raw).to_database()
+    assert result["symmetry"]["default"] == expected

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -1,0 +1,57 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import types
+
+import numpy as np
+import pytest
+
+from py4vasp._calculation.symmetry import Symmetry
+
+
+@pytest.fixture(params=["CoO", "AlP"])
+def symmetry(raw_data, request):
+    raw_symmetry = raw_data.symmetry(request.param)
+    return setup_reference(raw_symmetry, request.param)
+
+
+def setup_reference(raw_symmetry, name):
+    symmetry = Symmetry.from_data(raw_symmetry)
+    symmetry.ref = types.SimpleNamespace()
+    symmetry.ref.name = name
+    symmetry.ref.raw = raw_symmetry
+    return symmetry
+
+
+def test_read(symmetry, Assert):
+    raw = symmetry.ref.raw
+    actual = symmetry.read()
+    Assert.allclose(actual["rotations"], np.array(raw.rotations))
+    Assert.allclose(actual["reciprocal_rotations"], np.array(raw.reciprocal_rotations))
+    Assert.allclose(actual["translations"], np.array(raw.translations))
+    # Fortran 1-based indices in the file are converted to 0-based for Python
+    Assert.allclose(actual["inverse_operations"], np.array(raw.inverse_operations) - 1)
+    Assert.allclose(actual["atom_permutations"], np.array(raw.atom_permutations) - 1)
+    Assert.allclose(
+        actual["primitive_lattice_vectors"], np.array(raw.primitive_lattice_vectors)
+    )
+    Assert.allclose(
+        actual["primitive_translations"], np.array(raw.primitive_translations)
+    )
+    assert actual["number_of_operations"] == raw.number_of_operations
+    assert actual["number_of_primitive_cells"] == raw.number_of_primitive_cells
+    assert actual["isym"] == raw.isym
+    if symmetry.ref.name == "CoO":
+        Assert.allclose(actual["spin_flips"], np.array(raw.spin_flips))
+    else:
+        assert actual["spin_flips"] is None
+
+
+def test_to_dict_is_alias_of_read(symmetry, Assert):
+    from_read = symmetry.read()
+    from_dict = symmetry.to_dict()
+    assert from_read.keys() == from_dict.keys()
+    for key in from_read:
+        if from_read[key] is None:
+            assert from_dict[key] is None
+        else:
+            Assert.allclose(from_dict[key], from_read[key])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -415,6 +415,15 @@ class RawDataFactory:
             raise exception.NotImplemented()
 
     @staticmethod
+    def symmetry(selection):
+        if selection == "CoO":
+            return _demo.symmetry.CoO()
+        elif selection == "AlP":
+            return _demo.symmetry.AlP()
+        else:
+            raise exception.NotImplemented()
+
+    @staticmethod
     def velocity(selection):
         if selection == "Sr2TiO4":
             return _demo.velocity.Sr2TiO4()

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -18,6 +18,7 @@ from py4vasp._calculation import (  # noqa: F401 — imports submodules as _calc
     optics,
     projector,
     structure,
+    symmetry,
     system,
 )
 from py4vasp._util import color as _util_color
@@ -48,15 +49,23 @@ def _all_calculation_examples():
         + find_examples(_calculation.optics)
         + find_examples(_calculation.projector)
         + find_examples(_calculation.structure)
+        + find_examples(_calculation.symmetry)
         + find_examples(_calculation.system)
     )
     return [example for example in examples if interesting_example(example)]
 
 
-# Examples that rely on an optional package (e.g. scipy for the color pipeline) which is
-# not part of the py4vasp-core installation. They run in test_calculation_full which skips
-# via importorskip when the package is missing; everything else runs in test_calculation.
-_FULL_INSTALL_EXAMPLES = ("py4vasp._calculation.optics.Optics.color",)
+# Examples that rely on an optional package (e.g. scipy for the color pipeline or spglib
+# for the space-group analysis) which is not part of the py4vasp-core installation. Each is
+# mapped to the package it needs; they run in test_calculation_full which skips via
+# importorskip when that package is missing. Everything else runs in test_calculation.
+_FULL_INSTALL_EXAMPLES = {
+    "py4vasp._calculation.optics.Optics.color": "scipy",
+    "py4vasp._calculation.symmetry.Symmetry.space_group": "spglib",
+    "py4vasp._calculation.symmetry.Symmetry.point_group_schoenflies": "spglib",
+    "py4vasp._calculation.symmetry.Symmetry.bravais_lattice": "spglib",
+    "py4vasp._calculation.symmetry.Symmetry.pearson_symbol": "spglib",
+}
 
 
 def _requires_full_install(example):
@@ -104,7 +113,7 @@ def test_calculation(example: doctest.DocTest, tmp_path: pathlib.Path):
     "example", get_full_calculation_examples(), ids=lambda example: example.name
 )
 def test_calculation_full(example: doctest.DocTest, tmp_path: pathlib.Path):
-    pytest.importorskip("scipy")
+    pytest.importorskip(_FULL_INSTALL_EXAMPLES[example.name])
     _run_calculation_example(example, tmp_path)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2102,7 +2102,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2325,6 +2325,7 @@ dependencies = [
     { name = "plotly" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "spglib" },
 ]
 
 [package.dev-dependencies]
@@ -2356,6 +2357,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.0" },
     { name = "plotly", specifier = ">=5.23" },
     { name = "scipy", specifier = ">=1.12.0" },
+    { name = "spglib", specifier = ">=2.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -3086,6 +3088,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "spglib"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/06/7964acb4c444191376bd87f91579475fbe7623ca943cce40cee8fb7f2c36/spglib-2.7.0.tar.gz", hash = "sha256:c40907a42c9dc45572f46740bf95412f84fb0eda30267e31665d104a4bde6627", size = 2366134, upload-time = "2025-12-29T09:48:26.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/a8/d841ae7743c58227af277f7f16aa844376fa11c426090d6ae35e7e93af76/spglib-2.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3cf0ff80c01d8631ef4b9f1b78da79ff2044834e6e2d870f7f20c8579c921136", size = 910793, upload-time = "2025-12-29T09:47:32.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/02/11baf94cf682cdaafa046b72d4b2adcf944e19e2b2741454e329dedb2fc2/spglib-2.7.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7b29d2cfca6ac53e927686ca0b91257126e47f6abfa26451723a5cd40070352", size = 944977, upload-time = "2025-12-29T09:47:33.638Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fa/6d1bc8f8cb08945ca8c37c95b42bf336b6b9a8a737eced1ce64f0cebe9ce/spglib-2.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f892ecce2dd1bc636b14a4e5bc13aabb73b008bd37a4d23636882c8971c432a0", size = 960531, upload-time = "2025-12-29T09:47:36.932Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/79/2fd5e33b431cd0afcdd441bd10704c11cdf74c09b721249297284e5bf0b2/spglib-2.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:468879702577124dcde0607a75396576e256f1cfa2d8fe48da4a928fbb27abc6", size = 669827, upload-time = "2025-12-29T09:47:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e9/4e07c9c1bda40df54e09bd686eae0dc13d46e76a5ef4d43582971a86eb32/spglib-2.7.0-cp311-cp311-win_arm64.whl", hash = "sha256:ceb6730a2324d0c83579c803f3782e28bd41e79bbfe0c3dfdbf30e3d3a6320e5", size = 649076, upload-time = "2025-12-29T09:47:40.367Z" },
+    { url = "https://files.pythonhosted.org/packages/68/0e/36720beeca8452530e50ab8a16b91e8721e34c0f97fd25e9c4ddd8b9324b/spglib-2.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ef70132e23dfcc7ab6813742e0edab3f9906e61cd11c857f014bd5610a8bc88c", size = 911009, upload-time = "2025-12-29T09:47:42.238Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a0/24df91cbde6a3237d54cfb21602cc8ebb4102cd4e3ec9497c66135c2b190/spglib-2.7.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59f134e74f7f488de4bf5579ee6a35af25cb2c478c138de664fea1e14f3efbaf", size = 946821, upload-time = "2025-12-29T09:47:44.548Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4c/75ac6f7ade28019b216c7333322f2886e1c0105202cd74506f530664bf26/spglib-2.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6913906fd9108e7bb2ce06a810513a95a82d801530f10230979bf3427bb7e771", size = 962531, upload-time = "2025-12-29T09:47:46.3Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/5f/4e283139af178bb445eedff281a90e66ceff1b814ace70a9d90a2197acc3/spglib-2.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:d5729ff0040baae764c17249302cd99f0eb4e73449612a8c69d3e60a215f062e", size = 671111, upload-time = "2025-12-29T09:47:48.14Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b9/20e52d46e33bf69ceba4fc86602f006c06ce4ab10e3c930f4722fb270b02/spglib-2.7.0-cp312-cp312-win_arm64.whl", hash = "sha256:54f4b6e789475384c62e759c618172707f261c0eae8017949fe4994b6b8cc779", size = 646679, upload-time = "2025-12-29T09:47:49.376Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1c/a0fe8c0523a0e7d608f49f09895e5c599329265c9bfacd269a21458b7564/spglib-2.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ab061ea6a3c3c25a1d0018b09c333c0458792036d3f45d892bd52793ed1f1bda", size = 911085, upload-time = "2025-12-29T09:47:51.606Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/34/cb3c522c4aaf6ce319b37bbec71d373b9e2cf0bcfe7d42c365cd6c113b4b/spglib-2.7.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be28673e90f7a6c7770f73c57e529d2bdbb373d06d26ee5e90991b548e9238aa", size = 946857, upload-time = "2025-12-29T09:47:53.059Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/64/3b1213f2f655ff143ed142292b47ec3f1f9bda8641e659a7e33c4cf0e8a9/spglib-2.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f627a4ed6f2396ed6e3e8eaf33a53ad143c8ffb8756a84a640f4569ac5ffa2a7", size = 962470, upload-time = "2025-12-29T09:47:54.878Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/3a/c51883ce739a00f9f60196f3dcb4ed91b690299a4ec64defd8ec5b2c5899/spglib-2.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:c76411bc1b96cd87c8733994747c7692512b583bb4ef89a65463ff4255221c11", size = 671073, upload-time = "2025-12-29T09:47:56.887Z" },
+    { url = "https://files.pythonhosted.org/packages/35/78/3f9ec6ae93a48527dce0eceb6eeab74e6ad1fb2977adb5cbdfc03d43193c/spglib-2.7.0-cp313-cp313-win_arm64.whl", hash = "sha256:0d8ecf030d13d67c4cc272423e5652b74eda57f86a0b118e007f6d12974cc256", size = 646711, upload-time = "2025-12-29T09:47:58.697Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/47/86e3c15c3e1c252bde40a794eea4742c142f23fc5f9c3d7551f083c1fa20/spglib-2.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95e3dd7ef992ff8a88f6ef2e5909aaa60ecb479004cc1f73c1e6285d54227960", size = 911712, upload-time = "2025-12-29T09:48:01.14Z" },
+    { url = "https://files.pythonhosted.org/packages/05/61/ab2447bb47fa69934adc2fc2d13f771dedd3b2fd3171c95307446c948f01/spglib-2.7.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97e0fcea2db3915bd973fdd2cc0a757b1f99bda71ce815da333d75ad1ffc3eb1", size = 947528, upload-time = "2025-12-29T09:48:03.258Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/898d9e005131b0b1c7e5dce2b79f36aeb20ec4d3a88cca596b522a0fa4df/spglib-2.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39b978c08ef2ebc0eaba833c488fc4c0f9b1fc0f50d4a8584f176741eea69376", size = 962474, upload-time = "2025-12-29T09:48:05.617Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/7b25ee5348722dc93ca245ed950f1a89f8a944906140629055f394c072a4/spglib-2.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:5f334b4b66c8aafd583fafab5b15a56e27efdd2dc6cb1064dfcd0fe59ae130f4", size = 679679, upload-time = "2025-12-29T09:48:15.393Z" },
+    { url = "https://files.pythonhosted.org/packages/20/37/eda9a34f25b13e47298fa1b94cc4dfd8b0fcfc46c7d63ea046aa1bf91fe7/spglib-2.7.0-cp314-cp314-win_arm64.whl", hash = "sha256:b032842fc223de46d2ef7d220459e1a61ed90329ac2e72818c605f1fc87451b8", size = 656403, upload-time = "2025-12-29T09:48:17.027Z" },
+    { url = "https://files.pythonhosted.org/packages/39/af/1c8d0f98d07969b7fa7323d522732124d88caf4ee3b680ef59120bd7b229/spglib-2.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b7e29c796cfdadcc3857aef330acc19b9bc50c83e9911fb23b28390e7c80bae5", size = 920791, upload-time = "2025-12-29T09:48:07.085Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c6/89a3f31f831efc4108a19f110873559990b72186745cd3e151de28b256cc/spglib-2.7.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b6ca88bb6e604bc8f63efe87b3b2470c2e25f56988b775bd332cefa8866f5c5", size = 946881, upload-time = "2025-12-29T09:48:09.154Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e9/1ca63db2cebd381bd6b27ae309f25d270e70928359a6f0360db09b77894e/spglib-2.7.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50629939a9cd6fa3df5a12f6f025ceb3c78534284f875371574c360e4ccaf5e1", size = 963803, upload-time = "2025-12-29T09:48:12.478Z" },
+    { url = "https://files.pythonhosted.org/packages/28/97/459b37c3802633f77c883883c75f5d4429b601ae8d930410b999c4e1dafb/spglib-2.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:cb77daaf9dd5d48d523a888f37cebd47fa63ff28dfcf1aac2b031b914f9ed55a", size = 696536, upload-time = "2025-12-29T09:48:13.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a new `symmetry` quantity that reads the `results/symmetry` group VASP writes
to `vaspout.h5` and makes it accessible through `Calculation`.

Public API (`calculation.symmetry`):
- `read()` / `to_dict()` — all symmetry operations as NumPy arrays for postprocessing
  (real- and reciprocal-space rotations, translations, inverse operations, atom
  permutations, primitive-cell info, and metadata). Fortran 1-based indices are
  converted to 0-based; `spin_flips` is present only for spin-polarized runs.
- `__str__` — a compact (<10 line) overview for Jupyter.
- `space_group()` — returns a `SpaceGroup` dataclass (number, international symbol,
  point group, crystal system, symmorphic flag), derived from the operations via spglib.
- `has_inversion_symmetry()`, `point_group_schoenflies()`, `bravais_lattice()`,
  `pearson_symbol()`.
- `_to_database()` → `Symmetry_DB` with searchable scalars: `space_group`,
  `space_group_symbol`, `crystal_system`, `point_group_schoenflies`, `bravais_lattice`,
  `pearson_symbol`, `has_inversion_symmetry`, `number_of_operations`,
  `number_of_primitive_cells`, `is_symmorphic`.
