### PR TITLE
Feat: agent workflow skills

### DIFF
--- a/.claude/skills/push-py4vasp/SKILL.md
+++ b/.claude/skills/push-py4vasp/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: push-py4vasp
+description: >-
+  Push py4vasp changes to origin and open a PR. Use when asked to push, publish
+  the branch, ship the changes, or open a pull request for py4vasp. Reviews code
+  changes first (dispatches /review-py4vasp to a subagent unless already done),
+  applies black + isort, pushes a fresh descriptive branch to origin, and hands
+  back a PR compare link plus a draft PR message.
+---
+
+# Push py4vasp to origin
+
+Orchestrates the last mile: review → format → push → PR link. The deterministic
+prep (classify changes, decide if review is needed, suggest a branch name, build
+the PR URL and draft message) is done by the read-only driver
+`.claude/skills/push-py4vasp/push_prep.py`; the side-effecting steps (dispatch
+review, apply fixes, format, push) are orchestrated here. `origin` is the **main**
+repo `vasp-dev/py4vasp`, so pushing publishes to upstream. Paths are relative to
+the repo/worktree root.
+
+## Step 0 — prep (run the driver)
+
+```bash
+python .claude/skills/push-py4vasp/push_prep.py
+```
+
+It prints: changed files split into **CODE** (`*.py` under `src/` or `tests/`) vs
+non-code (docs/CI/tooling); whether a review is required; a suggested branch
+name; the PR compare URL; and a draft PR message. Read this first — it drives
+every decision below.
+
+## Step 1 — review gate (only if CODE changed)
+
+If the driver reports **no** code changes (only docs/CI/tooling), skip to Step 3.
+
+If code changed, a py4vasp review must exist for this diff:
+- If you already ran `/review-py4vasp` on this diff earlier in the session and
+  its findings were addressed, skip re-running it.
+- If you **cannot tell** whether a review was done, ask the user before
+  dispatching.
+- Otherwise dispatch a subagent to review: use the **Agent** tool
+  (`subagent_type: general-purpose`) and instruct it to follow the
+  `/review-py4vasp` skill on the current diff and return the findings.
+
+Then **address the findings** — fix the code, or record why a finding is a
+non-issue. Re-run the affected tests (see `/review-py4vasp` for the invocation).
+
+## Step 2 — confirm (hard stop before publishing)
+
+STOP and ask the user to confirm before formatting and pushing. Pushing
+publishes the branch to `origin` (`vasp-dev/py4vasp`) — do not proceed without
+an explicit go-ahead.
+
+## Step 3 — format
+
+Apply the project's formatters to `src` and `tests` (no-op if pre-commit already
+ran):
+
+```bash
+uv run --active black src tests
+```
+
+```bash
+uv run --active isort src tests
+```
+
+Then look at the reformatted diff: black sometimes introduces awkward line breaks
+(a long call or expression wrapped across several lines). Where that hurts
+readability, extract a well-named helper variable so the line fits naturally, and
+re-run black to confirm it stays put.
+
+If either step changed files, commit that:
+
+```bash
+git commit -am "Apply black and isort"
+```
+
+## Step 4 — branch + push
+
+Create a **fresh descriptive** branch (start from the driver's suggestion, refine
+if it misses the point), then push it and set upstream:
+
+```bash
+git switch -c feat/<descriptive-name>
+```
+
+```bash
+git push -u origin feat/<descriptive-name>
+```
+
+## Step 5 — PR link + message
+
+Give the user the compare URL and the draft message from Step 0 (the driver
+already built both, using the real branch name if you kept its suggestion — else
+swap the branch segment). The URL opens GitHub's "Open a pull request" page:
+
+```
+https://github.com/vasp-dev/py4vasp/compare/master...<branch>?expand=1
+```
+
+Present the draft PR message in a copy-paste block.
+
+## Gotchas
+
+- **`origin` is upstream, not a fork.** `git@github.com:vasp-dev/py4vasp.git`.
+  Pushing goes straight to the main repo (the user is a maintainer). A fork
+  remote `private` (`martin-schlipf/py4vasp`) also exists — only use it if the
+  user asks.
+- **`gh` is not installed** here (only `glab`). Do not reach for `gh pr create`;
+  hand over the constructed compare URL instead — the driver builds it from
+  `remote.origin.url`.
+- **Non-code = review-skipped, but still formatted + pushed.** A docs/CI/tooling
+  change goes straight from Step 0 to Step 3.
+- **The driver is read-only.** `push_prep.py` never pushes, commits, or edits;
+  re-run it freely. The only publishing action is `git push` in Step 4.
+- **Worktree note:** run inside the worktree you actually changed; the driver
+  reports the checkout path so you can confirm.
+
+## Human path
+
+A developer does the same by hand: review the diff, `uv run --active black src
+tests && uv run --active isort src tests`, `git push -u origin <branch>`, then
+open the compare URL in a browser.

--- a/.claude/skills/push-py4vasp/push_prep.py
+++ b/.claude/skills/push-py4vasp/push_prep.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+"""Prepare a py4vasp branch for pushing to origin. READ-ONLY: no push, no edits.
+
+Run from anywhere inside the checkout (plain system python is fine):
+
+    python .claude/skills/push-py4vasp/push_prep.py            # base = master
+    python .claude/skills/push-py4vasp/push_prep.py main       # different base
+
+It prints the decisions the push workflow needs:
+  1. Changed files, classified into CODE (*.py under src/ or tests/) vs
+     non-code (docs / CI / tooling).
+  2. Whether a code review is required (any code changes present).
+  3. A suggested descriptive branch name derived from the commit subjects.
+  4. The GitHub PR "compare" URL for origin.
+  5. A draft PR message (title + summary bullets) to copy/paste.
+
+This tool decides nothing side-effectful. The agent orchestrates review,
+formatting, and the actual push per SKILL.md.
+"""
+import pathlib
+import re
+import subprocess
+import sys
+
+
+def git(root, *args):
+    return subprocess.run(
+        ["git", "-C", str(root), *args], text=True, capture_output=True
+    ).stdout.strip()
+
+
+def find_root(start):
+    for parent in [start, *start.parents]:
+        if (parent / ".git").exists() and (parent / "src" / "py4vasp").is_dir():
+            return parent
+        # worktrees keep a .git file, not dir; also accept src/py4vasp presence
+        if (parent / "src" / "py4vasp").is_dir():
+            return parent
+    sys.exit("error: could not find a py4vasp checkout above " + str(start))
+
+
+def changed_files(root, base):
+    out = git(root, "diff", "--name-only", base, "HEAD")
+    out += "\n" + git(root, "diff", "--name-only")
+    out += "\n" + git(root, "diff", "--name-only", "--cached")
+    return sorted({l.strip() for l in out.splitlines() if l.strip()})
+
+
+def is_code(path):
+    return path.endswith(".py") and (
+        path.startswith("src/") or path.startswith("tests/")
+    )
+
+
+def classify(files):
+    code, noncode = [], []
+    for f in files:
+        (code if is_code(f) else noncode).append(f)
+    return code, noncode
+
+
+def commit_subjects(root, base):
+    log = git(root, "log", "--format=%s", f"{base}..HEAD")
+    return [l for l in log.splitlines() if l.strip()]
+
+
+def slugify(text):
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+    return re.sub(r"-+", "-", text)[:50]
+
+
+def suggest_branch(subjects, code, noncode):
+    prefix_map = {"feat": "feat", "fix": "fix", "refactor": "refactor",
+                  "docs": "docs", "test": "test", "chore": "chore"}
+    if subjects:
+        first = subjects[0]
+        m = re.match(r"\s*(\w+)\s*:\s*(.*)", first)
+        if m and m.group(1).lower() in prefix_map:
+            return f"{prefix_map[m.group(1).lower()]}/{slugify(m.group(2))}"
+        return slugify(first)
+    # no commits ahead — name from the touched area
+    sample = (code or noncode or ["changes"])[0]
+    return "update/" + slugify(pathlib.Path(sample).stem)
+
+
+def origin_https(url):
+    url = url.strip()
+    if url.endswith(".git"):
+        url = url[:-4]
+    m = re.match(r"git@([^:]+):(.+)", url)          # scp-like: git@host:owner/repo
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    m = re.match(r"ssh://git@([^/:]+)(?::\d+)?/(.+)", url)  # ssh://git@host[:port]/owner/repo
+    if m:
+        return f"https://{m.group(1)}/{m.group(2)}"
+    if url.startswith("https://"):
+        return url
+    return url
+
+
+def main():
+    base = sys.argv[1] if len(sys.argv) > 1 else "master"
+    root = find_root(pathlib.Path.cwd())
+    files = changed_files(root, base)
+    code, noncode = classify(files)
+    subjects = commit_subjects(root, base)
+    branch = suggest_branch(subjects, code, noncode)
+    https = origin_https(git(root, "config", "--get", "remote.origin.url"))
+    compare_url = f"{https}/compare/{base}...{branch}?expand=1"
+
+    print(f"[push_prep] checkout: {root}")
+    print(f"[push_prep] base    : {base}")
+
+    print("\n" + "=" * 60 + "\n1. CHANGED FILES\n" + "=" * 60)
+    print("CODE (*.py in src/ or tests/):", *(["\n  " + f for f in code] or ["  (none)"]))
+    print("non-code (docs/CI/tooling)   :", *(["\n  " + f for f in noncode] or ["  (none)"]))
+
+    print("\n" + "=" * 60 + "\n2. REVIEW REQUIRED?\n" + "=" * 60)
+    if code:
+        print("YES - code changed. Dispatch /review-py4vasp to a subagent unless a")
+        print("review was already conducted this session (ask the user if unsure).")
+    else:
+        print("NO - only docs/CI/tooling changed. Skip the review; go straight to push.")
+
+    print("\n" + "=" * 60 + "\n3. SUGGESTED BRANCH NAME\n" + "=" * 60)
+    print(f"  {branch}")
+    print("  (Derive a fresh descriptive name; refine this if it misses the point.)")
+
+    print("\n" + "=" * 60 + "\n4. PR COMPARE URL (origin)\n" + "=" * 60)
+    print(f"  {compare_url}")
+    print("  (Replace the branch segment if you push under a different name.)")
+
+    print("\n" + "=" * 60 + "\n5. DRAFT PR MESSAGE\n" + "=" * 60)
+    title = subjects[0] if subjects else branch
+    print(f"Title: {title}\n")
+    print("## Summary")
+    for s in subjects or ["(no commits ahead of base — describe the change)"]:
+        print(f"- {s}")
+    print("\n## Notes")
+    print("- Mention the related issue (e.g. \"Fixes #123\").")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/review-py4vasp/SKILL.md
+++ b/.claude/skills/review-py4vasp/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: review-py4vasp
+description: >-
+  Code review for py4vasp changes. Use when asked to review, code-review, or
+  critique py4vasp code, a branch, or a diff. Does the usual bug / edge-case
+  review AND enforces four py4vasp-specific rules: exceptions come from
+  py4vasp.exception, user selections use select.Tree / index.Selector, public
+  methods have numpy-style docstrings with runnable doctest examples, and tests
+  give >95% coverage. Runs doctests and coverage to substantiate findings, then
+  reports via the ReportFindings tool.
+---
+
+# Reviewing py4vasp code
+
+Standalone reviewer for the changes on the current branch (working tree +
+commits) **relative to `master`**. It combines a normal correctness review with
+four py4vasp house rules, and it *runs* the doctests and coverage rather than
+guessing. Evidence is gathered by `.claude/skills/review-py4vasp/review.py`;
+you read that evidence, read the diff, and file findings with **ReportFindings**
+(most-severe first). Paths below are relative to the repo/worktree root.
+
+## Step 1 — gather evidence (run the driver)
+
+Run it with the **venv** interpreter (it needs `pytest-cov`, which the system
+python lacks):
+
+```bash
+.venv/Scripts/python.exe .claude/skills/review-py4vasp/review.py
+```
+
+Pass a different base ref as the first arg if needed (`... review.py main`).
+The driver prints five sections: changed files; coverage of each changed src
+module with uncovered line numbers; doctest pass/fail for those modules; a
+raise-convention scan; and selection-API hints. It takes ~15 s (a coverage run
+over the touched test files). If a changed src module has no auto-mapped test
+file, the driver says so — locate and run its tests manually (Step 3).
+
+## Step 2 — review against the four py4vasp rules
+
+Read the diff alongside the driver output and judge each rule. The driver gives
+you leads; you decide what is a finding.
+
+1. **Exceptions come from `py4vasp.exception`.** The contract (see the
+   `exception.py` module docstring): *a py4vasp exception means the user made a
+   mistake; any other exception is a bug to report.* So user-facing code must
+   raise a `Py4VaspError` subclass (`IncorrectUsage`, `NoData`, `DataMismatch`,
+   `NotImplemented`, …), not a bare `ValueError`/`KeyError`/`RuntimeError`.
+   Section 4 lists every `raise X` in changed src where `X` is not
+   `exception.*`. **Legit exceptions** (not findings): re-raising a caught error
+   (`raise err`), and framework code — `src/py4vasp/_sphinx/` (docutils
+   `SkipNode`) and `cli.py` (`click` errors). Flag the rest.
+
+2. **User selections use `select.Tree` / `index.Selector`.** If a method lets
+   the user pick among options, the argument is named `selection` and is parsed
+   with `py4vasp._util.select.Tree.from_selection(...)` so every quantity
+   behaves consistently. When those selections index into an array, extraction
+   goes through `py4vasp._util.index.Selector`. Section 5 shows where the changed
+   files mention `selection` / `select.Tree` / `index.Selector`. Flag a new
+   user-facing option arg that is named something else, hand-rolls its own
+   parsing, or indexes arrays manually instead of via `Selector`.
+
+3. **Public methods have numpy-style docstrings with runnable examples.** Every
+   public method (no leading underscore) needs a numpy-style docstring, and
+   user-facing quantity methods carry a `>>>` example that the doctest suite
+   executes. Section 3 shows the doctest result for the changed modules — a
+   failure or "no tests ran" for a module that gained a public method is a
+   finding. A public method with no docstring, or a docstring with no example
+   where siblings have one, is a finding the driver can't see — read the diff.
+
+4. **Tests cover the important behavior (>95%).** Section 2 gives each changed
+   module's coverage % and the exact uncovered lines. Below ~95% is a finding
+   unless the only misses are trivial (e.g. an `else` that raises
+   `exception.NotImplemented`). Point findings at the specific uncovered lines
+   and the behavior they represent.
+
+Also do the **normal review**: correctness bugs, missing edge cases, wrong
+results, resource/logic errors — the same scrutiny as a general code review.
+
+## Step 3 — manual commands (when the driver can't map a test)
+
+Same invocations the driver uses, for a module it couldn't auto-map. Set
+`PYTHONPATH` to this checkout's `src` so a worktree measures its own edits, and
+use `--cov=py4vasp` (whole package), never a dotted submodule (see Gotchas):
+
+```bash
+PYTHONPATH="$PWD/src" .venv/Scripts/python.exe -m pytest tests/calculation/test_symmetry.py --cov=py4vasp --cov-report=term-missing -q
+```
+
+```bash
+PYTHONPATH="$PWD/src" .venv/Scripts/python.exe -m pytest tests/test_doctest.py -k symmetry -q
+```
+
+## Step 4 — report
+
+Call **ReportFindings** with the verified findings, most-severe first (empty
+array if the change is clean). Give each a concrete failure scenario and a
+`file:line`. Prefer confirmed issues over speculation; the coverage/doctest
+sections let you confirm rather than guess.
+
+## Gotchas
+
+- **Use the venv python, not `uv run`, not system python.** `uv run pytest
+  --cov` and the venv python *both* crash on numpy under coverage **only** when
+  you scope with a dotted module (`--cov=py4vasp._calculation.symmetry`):
+  `ImportError: cannot load module more than once per process` (numpy 2 +
+  Python 3.14). `--cov=py4vasp` (whole package) is fine — the driver always uses
+  that and filters the report to the changed files. System python has no
+  `pytest-cov` at all.
+- **Worktree measures the wrong src without `PYTHONPATH`.** py4vasp is installed
+  editable via a `.pth` pointing at the *main* repo `src`, so inside a
+  `.claude/worktrees/<name>` worktree a bare run silently reviews the main repo.
+  The driver forces `PYTHONPATH`; do the same in manual runs. Verify with
+  `python -c "import py4vasp; print(py4vasp.__file__)"`.
+- **Doctests need the project's runner.** They rely on globs injected by
+  `tests/test_doctest.py` (`py4vasp`, `path`, `np`), so `pytest --doctest-modules`
+  won't work — filter `tests/test_doctest.py` with `-k <module-stem>` instead.
+- **The raise scan over-reports.** It is a plain grep; always apply the carve-outs
+  in rule 1 before turning a hit into a finding.
+
+## Human path
+
+There is no app to launch — this is a review workflow. A developer reviews by
+reading the diff and running the same `pytest --cov` / doctest commands above.
+```

--- a/.claude/skills/review-py4vasp/review.py
+++ b/.claude/skills/review-py4vasp/review.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""Gather review evidence for the py4vasp changes on this branch.
+
+Run this with the project's *venv* interpreter (it needs pytest-cov), from
+anywhere inside the checkout:
+
+    .venv/Scripts/python.exe .claude/skills/review-py4vasp/review.py            # vs master
+    .venv/Scripts/python.exe .claude/skills/review-py4vasp/review.py main       # vs another base
+
+What it prints, for the diff between <base> (default: master) and the working tree:
+  1. Changed files, split into src modules / test files / other.
+  2. Coverage of each changed src module (whole-package run over the mapped
+     test files, filtered to the changed files) + the uncovered line numbers.
+  3. Doctest pass/fail for the changed modules.
+  4. A raise-convention scan: `raise X` in changed src files where X is not a
+     py4vasp `exception.*` (candidates only — the reviewer judges them).
+  5. Selection-API hints: where changed files mention `selection`, `select.Tree`,
+     or `index.Selector`.
+
+Everything here is *evidence*, not verdicts. The reviewer reads it, reads the
+diff, and files findings via ReportFindings. See SKILL.md.
+
+Why the odd pytest flags: py4vasp is installed editable via a `.pth` pointing at
+the *main* repo src, so PYTHONPATH is forced to this checkout's src (else a
+worktree silently measures the main repo). And coverage is requested as
+`--cov=py4vasp` (whole package) NOT `--cov=py4vasp._calculation.foo`: the dotted
+form trips a numpy-2 "cannot load module more than once" crash under Python 3.14.
+"""
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+
+def sh(*args, **kwargs):
+    return subprocess.run(args, text=True, capture_output=True, **kwargs)
+
+
+def find_root(start):
+    for parent in [start, *start.parents]:
+        if (parent / "src" / "py4vasp").is_dir() and (parent / "tests").is_dir():
+            return parent
+    sys.exit("error: could not find a py4vasp checkout (src/py4vasp + tests) above " + str(start))
+
+
+def changed_files(root, base):
+    # committed changes base..HEAD plus anything dirty in the working tree
+    out = sh("git", "-C", str(root), "diff", "--name-only", base, "HEAD").stdout
+    out += sh("git", "-C", str(root), "diff", "--name-only").stdout
+    out += sh("git", "-C", str(root), "diff", "--name-only", "--cached").stdout
+    files = sorted({line.strip() for line in out.splitlines() if line.strip()})
+    return [f for f in files if (root / f).exists()]
+
+
+def map_src_to_tests(root, src_rel):
+    """Best-effort: src/py4vasp/_calculation/symmetry.py -> tests/**/test_symmetry.py"""
+    stem = pathlib.Path(src_rel).stem.lstrip("_")
+    return sorted(str(p.relative_to(root)) for p in root.glob(f"tests/**/test_{stem}.py"))
+
+
+def run_pytest(root, env, extra):
+    cmd = [sys.executable, "-m", "pytest", *extra, "-q"]
+    return subprocess.run(cmd, cwd=str(root), env=env, text=True, capture_output=True)
+
+
+def coverage_rows(stdout, src_files):
+    wanted = {f.replace("/", os.sep) for f in src_files}
+    rows = []
+    for line in stdout.splitlines():
+        for w in wanted:
+            if w in line.replace("/", os.sep) and "%" in line:
+                rows.append(line.strip())
+    return rows
+
+
+def scan_raises(root, src_files):
+    hits = []
+    pattern = re.compile(r"^\s*raise\s+(\S+)")
+    for f in src_files:
+        for n, line in enumerate((root / f).read_text(encoding="utf-8").splitlines(), 1):
+            m = pattern.match(line)
+            if not m:
+                continue
+            token = m.group(1)
+            if token.startswith("exception."):
+                continue
+            hits.append(f"{f}:{n}: {line.strip()}")
+    return hits
+
+
+def scan_selection(root, src_files):
+    hits = []
+    needles = ("selection", "select.Tree", "index.Selector")
+    for f in src_files:
+        for n, line in enumerate((root / f).read_text(encoding="utf-8").splitlines(), 1):
+            if any(needle in line for needle in needles):
+                hits.append(f"{f}:{n}: {line.strip()}")
+    return hits
+
+
+def section(title):
+    print("\n" + "=" * 70 + f"\n{title}\n" + "=" * 70)
+
+
+def main():
+    base = sys.argv[1] if len(sys.argv) > 1 else "master"
+    root = find_root(pathlib.Path.cwd())
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(root / "src") + (os.pathsep + env.get("PYTHONPATH", ""))
+    print(f"[review] checkout : {root}")
+    print(f"[review] base ref : {base}")
+    print(f"[review] python   : {sys.executable}")
+
+    files = changed_files(root, base)
+    src = [f for f in files if f.startswith("src/py4vasp/") and f.endswith(".py")]
+    tests = [f for f in files if f.startswith("tests/") and f.endswith(".py")]
+    other = [f for f in files if f not in src and f not in tests]
+
+    section("1. CHANGED FILES")
+    print("src modules:", *(["\n  " + f for f in src] or [" (none)"]))
+    print("test files :", *(["\n  " + f for f in tests] or [" (none)"]))
+    print("other      :", *(["\n  " + f for f in other] or [" (none)"]))
+
+    if not src:
+        print("\nNo changed py4vasp src modules — coverage/doctest/style scans skipped.")
+        return 0
+
+    # collect test files: those in the diff + mapped from changed src
+    test_targets = list(tests)
+    unmapped = []
+    for s in src:
+        mapped = map_src_to_tests(root, s)
+        if mapped:
+            test_targets.extend(mapped)
+        else:
+            unmapped.append(s)
+    test_targets = sorted(set(test_targets))
+
+    section("2. COVERAGE OF CHANGED SRC (whole-package run, filtered)")
+    if test_targets:
+        print("running:", " ".join(["pytest", *test_targets, "--cov=py4vasp", "--cov-report=term-missing"]))
+        result = run_pytest(root, env, [*test_targets, "--cov=py4vasp", "--cov-report=term-missing"])
+        rows = coverage_rows(result.stdout, src)
+        print("\nName                                          Stmts   Miss   Cover   Missing")
+        for row in rows or ["  (no coverage rows matched the changed src files)"]:
+            print("  " + row)
+        tail = [l for l in result.stdout.splitlines() if " passed" in l or " failed" in l or " error" in l]
+        print("\npytest:", tail[-1].strip() if tail else "(see full output)")
+        if result.returncode != 0:
+            print("!! tests did not all pass — coverage numbers may be unreliable")
+    if unmapped:
+        print("\n!! no test file auto-mapped for (locate & run manually):", *("\n  " + u for u in unmapped))
+
+    section("3. DOCTESTS FOR CHANGED MODULES")
+    stems = " or ".join(sorted({pathlib.Path(s).stem for s in src}))
+    print(f"running: pytest tests/test_doctest.py -k \"{stems}\"")
+    result = run_pytest(root, env, ["tests/test_doctest.py", "-k", stems])
+    tail = [l for l in result.stdout.splitlines() if "passed" in l or "failed" in l or "error" in l or "no tests ran" in l]
+    print(tail[-1].strip() if tail else result.stdout[-400:])
+
+    section("4. RAISE-CONVENTION SCAN (candidates - reviewer judges)")
+    print("Rule: user-facing raises should be py4vasp `exception.*`. Legit exceptions:")
+    print("re-raising a caught error, plus framework code (_sphinx/ docutils, cli.py click).")
+    raises = scan_raises(root, src)
+    for h in raises or ["  (no non-exception.* raises in changed src)"]:
+        print("  " + h)
+
+    section("5. SELECTION-API HINTS")
+    print("Rule: user option args are named `selection`, parsed via select.Tree,")
+    print("and indexed via index.Selector when they map to array indices.")
+    hits = scan_selection(root, src)
+    for h in hits or ["  (no selection/Tree/Selector mentions in changed src)"]:
+        print("  " + h)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/tdd-py4vasp/SKILL.md
+++ b/.claude/skills/tdd-py4vasp/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: tdd-py4vasp
+description: >-
+  Test-driven development workflow for py4vasp. Use when adding or changing a
+  feature, quantity, class, or method in py4vasp and you want tests written
+  first. Triggers: "TDD", "test-driven", "write the tests first", "add a method
+  with tests", "implement <quantity>", "red-green-refactor". Splits work into
+  one-method chunks, watches each test fail, implements to green, refactors,
+  and commits one chunk at a time.
+---
+
+# Test-driven development for py4vasp
+
+Build py4vasp features test-first, one small chunk at a time. A **chunk** is
+normally **one method of one class** (or one narrow behavior). You write its
+tests, watch them fail for the right reason, implement until they pass, refactor
+away duplication, and commit — then and only then move to the next chunk.
+
+Tests are run with the wrapper `.claude/skills/tdd-py4vasp/run_tests.py`, which
+imports py4vasp from *this* checkout's `src` (see [Gotchas](#gotchas)). All paths
+below are relative to the repo/worktree root.
+
+## The loop (follow in order)
+
+### 0. Plan, then STOP for approval
+Break the request into an ordered list of chunks, each ≈ one method/behavior.
+Record it in the todo list, present it to the user, and **wait for their
+sign-off before writing any code.** Do not start chunk 1 until they approve.
+Keep chunks small — the project caps a PR at ~200 lines and asks for splits.
+
+Then, for **each** chunk in turn:
+
+### 1. RED — write the test(s) and watch them fail
+Write the test(s) for this chunk only, following the conventions below. Run
+just those tests and confirm they **fail for the right reason** — a real
+`AssertionError` or the missing-method `AttributeError`, *not* a typo, bad
+import, or wrong fixture. A test that errors before reaching its assertion is
+not a valid RED; fix the test first.
+
+```bash
+python .claude/skills/tdd-py4vasp/run_tests.py tests/calculation/test_symmetry.py::test_read -q
+```
+
+Run only the tests you expect to fail. If your change may have side effects
+elsewhere, add those specific untouched tests to the same run to watch them
+stay green — but do **not** run the full suite here.
+
+### 2. GREEN — implement the minimum to pass
+Write the simplest implementation that makes the RED tests pass. Re-run the same
+selection until green.
+
+```bash
+python .claude/skills/tdd-py4vasp/run_tests.py tests/calculation/test_symmetry.py -q
+```
+
+### 3. REFACTOR — remove duplication (code AND tests)
+With tests green, remove duplication introduced by this chunk **and** against
+existing code the new code now overlaps with. Apply the same to the tests: pull
+shared setup into fixtures and use `@pytest.mark.parametrize` — this codebase is
+fixture-heavy, mirror it. Re-run the chunk's tests to confirm still green.
+
+### 4. COMMIT — one commit per passing chunk
+Commit the tests + implementation + refactor together, locally, on the current
+branch. Match the repo's message style (`Feat:`, `Fix:`, `Refactor:` prefix):
+
+```bash
+git add -A && git commit -m "Feat: add Symmetry.multiplicity"
+```
+
+Do **not** push or open a PR — that is a separate, later step. For a multi-line
+message use `git commit -F <file>` or a heredoc, never `git commit -m @'...'@`
+in the Bash tool (it wraps the message in literal `@`).
+
+Only after the commit lands do you start the next chunk at step 1.
+
+### 5. After ALL chunks — full suite, then report
+When every chunk is committed, run the whole suite once. Only report the work as
+done to the user if it is green.
+
+```bash
+python .claude/skills/tdd-py4vasp/run_tests.py -q
+```
+
+## py4vasp test & implementation conventions
+
+Read a sibling test before writing yours — `tests/calculation/test_symmetry.py`
+is a good template. Key patterns:
+
+- **Fixtures from `tests/conftest.py`:** `raw_data` (a `RawDataFactory`),
+  `Assert` (use `Assert.allclose(actual, desired)` for arrays/dataclasses),
+  `format_`, `check_factory_methods`.
+- **Construction:** calculation classes are built with
+  `SomeClass.from_data(raw_data.<quantity>("Sr2TiO4"))`. Tests attach a
+  reference namespace (`obj.ref = types.SimpleNamespace(); obj.ref.raw = ...`)
+  and assert against it.
+- **Standard method tests:** `read`/`to_dict` (with a
+  `test_to_dict_is_alias_of_read`), `print`/`_repr_`, and
+  `test_factory_methods(raw_data, check_factory_methods)`.
+- **New raw quantity?** You usually must extend **two** places besides the
+  calculation class: add a producer under `src/py4vasp/_demo/` and register a
+  method on `RawDataFactory` in `tests/conftest.py`, so `raw_data.<quantity>()`
+  exists for your test.
+- **Optional deps:** guard tests needing extras with
+  `pytest.importorskip("spglib")` as existing tests do.
+
+## Gotchas
+
+- **Worktree imports the wrong src.** py4vasp is installed editable via a `.pth`
+  file pointing at the *main* repo's `src`. Inside a `.claude/worktrees/<name>`
+  worktree, a bare `pytest` silently tests the main repo and ignores your edits.
+  Always run tests through `run_tests.py` (it prepends the correct `src` to
+  `PYTHONPATH` and prints which one it used) — or set `PYTHONPATH` to the
+  worktree `src` yourself. Verify with:
+  ```bash
+  python -c "import py4vasp; print(py4vasp.__file__)"
+  ```
+- **Don't run the full suite mid-loop.** It is slow and dilutes the RED signal.
+  Full suite runs once, at the end (step 5).
+- **A weak RED is a bug.** If the test passes on the first run, or errors before
+  its assertion, it isn't testing what you think — fix the test before implementing.
+
+## Human path
+
+There is no app to launch — this is a workflow skill. Developers run the same
+tests directly with the project's tooling:
+
+```bash
+uv run --active pytest tests/calculation/test_symmetry.py
+```
+
+Use `run_tests.py` (or set `PYTHONPATH`) instead when working inside a worktree,
+so the tests exercise your edits rather than the main checkout.

--- a/.claude/skills/tdd-py4vasp/SKILL.md
+++ b/.claude/skills/tdd-py4vasp/SKILL.md
@@ -26,7 +26,7 @@ below are relative to the repo/worktree root.
 Break the request into an ordered list of chunks, each ≈ one method/behavior.
 Record it in the todo list, present it to the user, and **wait for their
 sign-off before writing any code.** Do not start chunk 1 until they approve.
-Keep chunks small — the project caps a PR at ~200 lines and asks for splits.
+Keep chunks small — one method/behavior each, so every commit stays reviewable.
 
 Then, for **each** chunk in turn:
 

--- a/.claude/skills/tdd-py4vasp/run_tests.py
+++ b/.claude/skills/tdd-py4vasp/run_tests.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+"""Run pytest against THIS checkout's src, then pass through any pytest args.
+
+py4vasp is installed editable via a plain `.pth` file that points at the *main*
+repo's `src`. Inside a `.claude/worktrees/<name>` worktree that means a bare
+`pytest` silently imports the main repo and ignores your edits. This wrapper
+finds the nearest `src/py4vasp` above the current directory, puts it first on
+PYTHONPATH so it wins over the `.pth` entry, prints which one it picked, and
+hands the rest of argv to pytest.
+
+Usage (from anywhere inside the checkout):
+    python .claude/skills/tdd-py4vasp/run_tests.py tests/calculation/test_symmetry.py::test_read
+    python .claude/skills/tdd-py4vasp/run_tests.py tests/calculation/test_symmetry.py -q
+    python .claude/skills/tdd-py4vasp/run_tests.py            # whole suite
+"""
+import os
+import pathlib
+import subprocess
+import sys
+
+
+def find_src(start: pathlib.Path) -> pathlib.Path:
+    for parent in [start, *start.parents]:
+        candidate = parent / "src" / "py4vasp"
+        if candidate.is_dir():
+            return parent / "src"
+    sys.exit("error: could not find a src/py4vasp above " + str(start))
+
+
+def main() -> int:
+    src = find_src(pathlib.Path.cwd())
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(src) + (os.pathsep + existing if existing else "")
+    print(f"[run_tests] importing py4vasp from: {src}", flush=True)
+    cmd = [sys.executable, "-m", "pytest", *sys.argv[1:]]
+    return subprocess.call(cmd, env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -83,7 +83,3 @@ We welcome contributions to py4vasp. To improve the code please follow this work
 * In the message to your merge request mention the issue the code attempts to solve.
 * We will try to include your merge request rapidly when all the tests pass and your
   code is covered by tests.
-
-Please limit the size of a pull request to approximately 200 lines of code
-otherwise reviewing the changes gets unwieldy. Prefer splitting the work into
-multiple smaller chunks if necessary.


### PR DESCRIPTION
## Summary
- Add test-driven-development skill (tdd-py4vasp): plan → red → green → refactor
  → one commit per chunk, with a worktree-aware pytest wrapper.
- Add code-review skill (review-py4vasp): standalone reviewer over the working
  diff that enforces the four py4vasp house rules (exceptions from
  py4vasp.exception, selection/Tree/Selector, numpy-docstrings-with-doctests,
  >95% coverage) and runs doctests + scoped coverage to substantiate findings.
- Add push-to-origin skill (push-py4vasp): classify changes, gate on review,
  apply black + isort, push a descriptive branch, and hand back a PR link + draft.
- Remove the 200-line pull request limit from the README.
