### PR TITLE
Feat: Add symmetry-derived structure properties

### DIFF
--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -269,7 +269,9 @@ Atoms # atomic
         dataset = self._symmetry_dataset()
         element_of_orbit = {
             int(orbit): element
-            for orbit, element in zip(self._orbit_labels(), self._stoichiometry().elements())
+            for orbit, element in zip(
+                self._orbit_labels(), self._stoichiometry().elements()
+            )
         }
         elements = [element_of_orbit[int(type_)] for type_ in dataset.std_types]
         return StandardizedCell(

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -19,6 +19,7 @@ from py4vasp._calculation.dispatch import (
     merge_strings,
     quantity,
 )
+from py4vasp._calculation.symmetry import _SYMPREC
 from py4vasp._raw.definition import unique_selections as _schema_unique_selections
 from py4vasp._raw.models import StoichiometryModel, StructureModel
 from py4vasp._third_party import view
@@ -42,6 +43,16 @@ _TO_DATABASE_SUPPRESSED_EXCEPTIONS = (
     # reading them can raise a low-level RuntimeError which we treat as "no data"
     RuntimeError,
 )
+
+
+@dataclass
+class Wyckoff:
+    """The Wyckoff positions of the atoms, consistent with the symmetry VASP found."""
+
+    letters: list
+    "The Wyckoff letter of every atom, e.g. ``['a', 'b', 'c', 'c', 'c']``."
+    site_symmetries: list
+    "The site-symmetry symbol of every atom in international notation, e.g. ``m-3m``."
 
 
 class StructureHandler:
@@ -229,6 +240,30 @@ Atoms # atomic
     def equivalent_atoms(self) -> np.ndarray:
         """Return the orbit index of every atom under VASP's symmetry operations."""
         return self._orbit_labels()
+
+    def wyckoff_positions(self) -> "Wyckoff":
+        """Return the Wyckoff positions of the atoms consistent with VASP's symmetry."""
+        dataset = self._symmetry_dataset()
+        return Wyckoff(
+            letters=list(dataset.wyckoffs),
+            site_symmetries=list(dataset.site_symmetry_symbols),
+        )
+
+    def _symmetry_dataset(self):
+        """Classify the crystal with spglib using VASP's symmetry.
+
+        The atoms are labeled by their orbit under VASP's operations before spglib
+        analyzes the cell. This prevents spglib from relating atoms that VASP treats
+        as inequivalent, so the resulting dataset reflects the symmetry VASP found
+        rather than the possibly higher symmetry of the bare geometry.
+        """
+        orbits = self._orbit_labels()
+        positions = self.positions()
+        if positions.ndim == 3:
+            message = "Computing the symmetry properties of multiple steps is not implemented."
+            raise exception.NotImplemented(message)
+        cell = (self.lattice_vectors(), positions, orbits)
+        return spglib.get_symmetry_dataset(cell, symprec=_SYMPREC)
 
     def _raw_symmetry(self):
         """Return the raw symmetry, raising if the structure does not provide it."""
@@ -1252,6 +1287,40 @@ class Structure(view.Mixin):
             None,
             self._handler_factory,
             StructureHandler.equivalent_atoms,
+        )
+
+    def wyckoff_positions(self):
+        """Determine the Wyckoff positions of the atoms in the crystal.
+
+        The atoms are classified into Wyckoff positions using the symmetry VASP
+        recognized for the crystal. Each atom is labeled by its orbit before the
+        classification, so the assignment reflects VASP's symmetry rather than the
+        possibly higher symmetry the geometry alone would suggest. This requires the
+        structure to carry symmetry information (VASP 6.6 or later) and the spglib
+        package to be installed.
+
+        Returns
+        -------
+        Wyckoff
+            The Wyckoff letter and the site-symmetry symbol of every atom.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path, "perovskite")
+
+        In cubic perovskite SrTiO3 strontium occupies the Wyckoff position a,
+        titanium the position b, and the three oxygen atoms the position c.
+
+        >>> calculation.structure.wyckoff_positions()
+        Wyckoff(letters=['a', 'b', 'c', 'c', 'c'], site_symmetries=['m-3m', 'm-3m', '4/mm.m', '4/mm.m', '4/mm.m'])
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            StructureHandler.wyckoff_positions,
         )
 
     def _to_database(self) -> dict:

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -1,8 +1,11 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import copy
+import math
+from collections import Counter
 from contextlib import suppress
 from dataclasses import dataclass
+from functools import reduce
 from typing import Union
 
 import numpy as np
@@ -19,7 +22,7 @@ from py4vasp._calculation.dispatch import (
     merge_strings,
     quantity,
 )
-from py4vasp._calculation.symmetry import _SYMPREC
+from py4vasp._calculation.symmetry import _SYMPREC, SymmetryHandler
 from py4vasp._raw.definition import unique_selections as _schema_unique_selections
 from py4vasp._raw.models import StoichiometryModel, StructureModel
 from py4vasp._third_party import view
@@ -274,6 +277,26 @@ Atoms # atomic
             positions=np.array(dataset.std_positions),
             elements=elements,
         )
+
+    def prototype(self) -> str:
+        """Return the AFLOW prototype label of the crystal, e.g. ``ABC3_cP5_221_a_b_c``.
+
+        The label combines the reduced stoichiometry, the Pearson symbol, the space
+        group number, and the Wyckoff sequence per species. The Wyckoff letters come
+        from spglib's standard setting; no affine-normalizer relabeling is applied, so
+        the label may use an equivalent letter choice for space groups whose normalizer
+        permutes Wyckoff letters.
+        """
+        symmetry = SymmetryHandler.from_data(self._raw_symmetry())
+        dataset = self._symmetry_dataset()
+        elements = self._stoichiometry().elements()
+        stoichiometry = _stoichiometry_prefix(elements)
+        wyckoff = _wyckoff_sequence(
+            elements, dataset.crystallographic_orbits, dataset.wyckoffs
+        )
+        pearson = symmetry.pearson_symbol()
+        number = symmetry.space_group().number
+        return f"{stoichiometry}_{pearson}_{number}_{wyckoff}"
 
     def _symmetry_dataset(self):
         """Classify the crystal with spglib using VASP's symmetry.
@@ -1383,6 +1406,45 @@ class Structure(view.Mixin):
             StructureHandler.standardized_cell,
         )
 
+    def prototype(self):
+        """Determine the AFLOW prototype label of the crystal.
+
+        The prototype label is a compact fingerprint of the structure type combining
+        the reduced stoichiometry, the Pearson symbol, the space group number, and the
+        Wyckoff positions occupied by each species, e.g. ``ABC3_cP5_221_a_b_c`` for
+        cubic perovskite. It is derived from the symmetry VASP recognized, so any
+        symmetry lowering is reflected. This requires the structure to carry symmetry
+        information (VASP 6.6 or later) and the spglib package.
+
+        The Wyckoff letters follow spglib's standard setting. For space groups whose
+        affine normalizer permutes Wyckoff letters, the label may use an equivalent
+        letter choice rather than the AFLOW-canonical one (e.g. zinc blende comes out
+        as ``AB_cF8_216_a_d`` instead of ``a_c``).
+
+        Returns
+        -------
+        str
+            The AFLOW prototype label of the crystal.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path, "perovskite")
+
+        Cubic perovskite SrTiO3 has one strontium (Wyckoff a), one titanium (b), and
+        three oxygen atoms (c) in a primitive cubic cell of five atoms.
+
+        >>> calculation.structure.prototype()
+        'ABC3_cP5_221_a_b_c'
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            StructureHandler.prototype,
+        )
+
     def _to_database(self) -> dict:
         """Return ``{"structure": {selection: StructureModel}}`` for the database.
 
@@ -1481,6 +1543,41 @@ def _same_geometry(first, second):
 def _cell_from_ase(structure):
     lattice_vectors = np.array([structure.get_cell()])
     return raw.Cell(lattice_vectors, scale=raw.VaspData(1.0))
+
+
+def _stoichiometry_prefix(elements):
+    """Build the stoichiometry part of the prototype label, e.g. ``ABC3`` for SrTiO3."""
+    order = list(dict.fromkeys(elements))
+    counts = [elements.count(element) for element in order]
+    divisor = reduce(math.gcd, counts)
+    return "".join(
+        chr(ord("A") + index) + ("" if count // divisor == 1 else str(count // divisor))
+        for index, count in enumerate(counts)
+    )
+
+
+def _wyckoff_sequence(elements, orbits, letters):
+    """Build the Wyckoff part of the prototype label, one group per species.
+
+    Each species contributes its occupied Wyckoff letters (one per orbit), sorted and
+    prefixed with the count when a letter is occupied by more than one orbit. Groups
+    for the different species are separated by an underscore, e.g. ``a_b_c``.
+    """
+    parts = []
+    for species in dict.fromkeys(elements):
+        letter_of_orbit = {
+            int(orbit): letter
+            for element, orbit, letter in zip(elements, orbits, letters)
+            if element == species
+        }
+        counts = Counter(letter_of_orbit.values())
+        parts.append(
+            "".join(
+                (str(count) if count > 1 else "") + letter
+                for letter, count in sorted(counts.items())
+            )
+        )
+    return "_".join(parts)
 
 
 def _replace_or_set_elements(poscar, elements):

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -419,6 +419,11 @@ Atoms # atomic
         with suppress(*_TO_DATABASE_SUPPRESSED_EXCEPTIONS):
             stoichiometry = self._stoichiometry().to_database()
 
+        # the prototype needs symmetry and spglib; leave it empty when unavailable
+        prototype = None
+        with suppress(*_TO_DATABASE_SUPPRESSED_EXCEPTIONS):
+            prototype = self.prototype()
+
         return StructureModel(
             num_ions=num_atoms,
             dimensionality=dimensionality,
@@ -427,6 +432,7 @@ Atoms # atomic
             num_ion_types_primitive=stoichiometry.num_ion_types_primitive,
             formula=stoichiometry.formula,
             compound=stoichiometry.compound,
+            prototype=prototype,
             cell_volume=volume,
             cell_area_2d=cell_area_2d,
             cell_area_2d_span=cell_area_2d_span,

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -27,6 +27,7 @@ from py4vasp._util import check, import_, parse
 ase = import_.optional("ase")
 ase_io = import_.optional("ase.io")
 mdtraj = import_.optional("mdtraj")
+spglib = import_.optional("spglib")
 
 __all__ = ["Structure"]
 
@@ -224,6 +225,47 @@ Atoms # atomic
             return len(range_[self._slice])
         else:
             return 1
+
+    def equivalent_atoms(self) -> np.ndarray:
+        """Return the orbit index of every atom under VASP's symmetry operations."""
+        return self._orbit_labels()
+
+    def _raw_symmetry(self):
+        """Return the raw symmetry, raising if the structure does not provide it."""
+        symmetry = self._raw_structure.symmetry
+        if check.is_none(symmetry):
+            message = (
+                "The structure does not provide symmetry information; it requires VASP "
+                "6.6 or later. Symmetry-derived properties such as the Wyckoff "
+                "positions or the equivalent atoms cannot be computed."
+            )
+            raise exception.NoData(message)
+        return symmetry
+
+    def _orbit_labels(self) -> np.ndarray:
+        """Group the atoms into orbits (equivalence classes) of VASP's operations.
+
+        Two atoms belong to the same orbit if some symmetry operation maps one onto
+        the other. The classes are computed from ``atom_permutations`` with a union-find
+        pass and relabeled to consecutive indices starting at 0.
+        """
+        symmetry = self._raw_symmetry()
+        permutations = np.array(symmetry.atom_permutations) - 1  # Fortran to 0-based
+        permutations = permutations.reshape(-1, permutations.shape[-1])
+        number_atoms = permutations.shape[-1]
+        if number_atoms != self.number_atoms():
+            message = (
+                f"The symmetry describes {number_atoms} atoms but the structure has "
+                f"{self.number_atoms()}; the structure and its symmetry are inconsistent."
+            )
+            raise exception.DataMismatch(message)
+        labels = np.arange(number_atoms)
+        for permutation in permutations:
+            for atom, image in enumerate(permutation):
+                low, high = sorted((labels[atom], labels[image]))
+                labels[labels == high] = low
+        _, orbits = np.unique(labels, return_inverse=True)
+        return orbits
 
     def to_database(self, steps=-1) -> StructureModel:
         """Return database-ready data for a single structure geometry.
@@ -1177,6 +1219,39 @@ class Structure(view.Mixin):
             None,
             self._handler_factory,
             StructureHandler.number_steps,
+        )
+
+    def equivalent_atoms(self):
+        """Group the atoms into orbits of the symmetry operations VASP determined.
+
+        Atoms that some symmetry operation maps onto each other are equivalent and
+        share an orbit index. This uses the symmetry VASP recognized for the crystal,
+        so any symmetry lowering (e.g. from magnetic order) is reflected here. It
+        requires the structure to carry symmetry information (VASP 6.6 or later).
+
+        Returns
+        -------
+        np.ndarray
+            The orbit index of every atom. Atoms with the same index are equivalent
+            under the symmetry operations.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path, "perovskite")
+
+        In cubic perovskite SrTiO3 the strontium and titanium atoms each sit on their
+        own site while the three oxygen atoms are equivalent.
+
+        >>> calculation.structure.equivalent_atoms()
+        array([0, 1, 2, 2, 2]...)
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            StructureHandler.equivalent_atoms,
         )
 
     def _to_database(self) -> dict:

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -55,6 +55,18 @@ class Wyckoff:
     "The site-symmetry symbol of every atom in international notation, e.g. ``m-3m``."
 
 
+@dataclass
+class StandardizedCell:
+    """The standardized (conventional) cell spglib derives from VASP's symmetry."""
+
+    lattice_vectors: np.ndarray
+    "The lattice vectors of the standardized conventional cell in Å."
+    positions: np.ndarray
+    "The direct coordinates of the atoms in the standardized cell."
+    elements: list
+    "The chemical element of every atom in the standardized cell."
+
+
 class StructureHandler:
     """Processes structural data from a single raw.Structure object."""
 
@@ -247,6 +259,20 @@ Atoms # atomic
         return Wyckoff(
             letters=list(dataset.wyckoffs),
             site_symmetries=list(dataset.site_symmetry_symbols),
+        )
+
+    def standardized_cell(self) -> "StandardizedCell":
+        """Return the standardized conventional cell consistent with VASP's symmetry."""
+        dataset = self._symmetry_dataset()
+        element_of_orbit = {
+            int(orbit): element
+            for orbit, element in zip(self._orbit_labels(), self._stoichiometry().elements())
+        }
+        elements = [element_of_orbit[int(type_)] for type_ in dataset.std_types]
+        return StandardizedCell(
+            lattice_vectors=np.array(dataset.std_lattice),
+            positions=np.array(dataset.std_positions),
+            elements=elements,
         )
 
     def _symmetry_dataset(self):
@@ -1321,6 +1347,40 @@ class Structure(view.Mixin):
             None,
             self._handler_factory,
             StructureHandler.wyckoff_positions,
+        )
+
+    def standardized_cell(self):
+        """Determine the standardized conventional cell of the crystal.
+
+        spglib maps the crystal onto a standardized conventional cell. The atoms are
+        labeled by their orbit under VASP's operations first, so the standardization
+        respects the symmetry VASP recognized. This requires the structure to carry
+        symmetry information (VASP 6.6 or later) and the spglib package.
+
+        Returns
+        -------
+        StandardizedCell
+            The lattice vectors, direct coordinates, and elements of the atoms in the
+            standardized conventional cell.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path, "perovskite")
+
+        For cubic perovskite SrTiO3 the conventional cell coincides with the primitive
+        cell, so it contains one strontium, one titanium, and three oxygen atoms.
+
+        >>> cell = calculation.structure.standardized_cell()
+        >>> cell.elements
+        ['Sr', 'Ti', 'O', 'O', 'O']
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            StructureHandler.standardized_cell,
         )
 
     def _to_database(self) -> dict:

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -119,8 +119,8 @@ class SymmetryHandler:
                 raw_symmetry.primitive_lattice_vectors
             ),
             "primitive_translations": np.array(raw_symmetry.primitive_translations),
-            "number_of_operations": int(raw_symmetry.number_of_operations[()]),
-            "number_of_primitive_cells": int(raw_symmetry.number_of_primitive_cells[()]),
+            "number_of_operations": int(raw_symmetry.number_of_operations),
+            "number_of_primitive_cells": int(raw_symmetry.number_of_primitive_cells),
             "isym": int(raw_symmetry.isym),
         }
         if not check.is_none(raw_symmetry.spin_flips):

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -119,8 +119,8 @@ class SymmetryHandler:
                 raw_symmetry.primitive_lattice_vectors
             ),
             "primitive_translations": np.array(raw_symmetry.primitive_translations),
-            "number_of_operations": int(raw_symmetry.number_of_operations),
-            "number_of_primitive_cells": int(raw_symmetry.number_of_primitive_cells),
+            "number_of_operations": int(raw_symmetry.number_of_operations[()]),
+            "number_of_primitive_cells": int(raw_symmetry.number_of_primitive_cells[()]),
             "isym": int(raw_symmetry.isym),
         }
         if not check.is_none(raw_symmetry.spin_flips):

--- a/src/py4vasp/_demo/structure.py
+++ b/src/py4vasp/_demo/structure.py
@@ -82,6 +82,7 @@ def SrTiO3():
                 [0.5, 0.5, 0.0],
             ]
         ),
+        symmetry=_demo.symmetry.SrTiO3(),
     )
 
 

--- a/src/py4vasp/_demo/symmetry.py
+++ b/src/py4vasp/_demo/symmetry.py
@@ -1,5 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import itertools
+
 import numpy as np
 
 from py4vasp import _demo, raw
@@ -8,6 +10,7 @@ from py4vasp import _demo, raw
 # derived space groups match crystallographic expectation:
 #   CoO (antiferromagnetic, ISPIN=2): F-43m (#216), 24 operations, no inversion
 #   AlP (bulk):                       Amm2  (#38),  4 operations, no inversion
+# The SrTiO3 symmetry (Pm-3m, #221) is generated from the cubic point group.
 
 
 def CoO():
@@ -154,3 +157,85 @@ def AlP():
         isym=2,
         spin_flips=raw.VaspData(None),
     )
+
+
+# Fractional positions of cubic perovskite SrTiO3 in its (primitive = conventional)
+# cell: Sr on 1a, Ti on 1b, and three symmetry-equivalent O on 3c.
+_SRTIO3_POSITIONS = np.array(
+    [
+        [0.0, 0.0, 0.0],  # Sr (1a)
+        [0.5, 0.5, 0.5],  # Ti (1b)
+        [0.0, 0.5, 0.5],  # O  (3c)
+        [0.5, 0.0, 0.5],  # O  (3c)
+        [0.5, 0.5, 0.0],  # O  (3c)
+    ]
+)
+
+
+def SrTiO3():
+    """Cubic perovskite SrTiO3 in its conventional cell, space group Pm-3m (#221).
+
+    The full cubic point group (48 signed permutation matrices, all symmorphic) is
+    generated and the remaining fields are derived from it, so the data is a
+    self-consistent stand-in for the symmetry VASP would report."""
+    rotations = _cubic_point_group()
+    translations = np.zeros((len(rotations), 3))
+    cell = raw.Cell(lattice_vectors=_demo.wrap_data(np.eye(3)), scale=raw.VaspData(4.0))
+    return raw.Symmetry(
+        cell=cell,
+        rotations=_demo.wrap_data(rotations),
+        reciprocal_rotations=_demo.wrap_data(_reciprocal_rotations(rotations)),
+        translations=_demo.wrap_data(translations),
+        inverse_operations=_demo.wrap_data(_inverse_operations(rotations)),
+        atom_permutations=_demo.wrap_data(
+            [_atom_permutations(rotations, translations, _SRTIO3_POSITIONS)]
+        ),
+        primitive_lattice_vectors=_demo.wrap_data(4.0 * np.eye(3)),
+        primitive_translations=_demo.wrap_data([[0.0, 0.0, 0.0]]),
+        number_of_operations=len(rotations),
+        number_of_primitive_cells=1,
+        isym=2,
+        spin_flips=raw.VaspData(None),
+    )
+
+
+def _cubic_point_group():
+    """The 48 operations of the cubic point group m-3m as signed permutation matrices."""
+    rotations = []
+    for permutation in itertools.permutations(range(3)):
+        matrix = np.zeros((3, 3), dtype=int)
+        for row, column in enumerate(permutation):
+            matrix[row, column] = 1
+        for signs in itertools.product((1, -1), repeat=3):
+            rotations.append(np.diag(signs) @ matrix)
+    return np.array(rotations)
+
+
+def _reciprocal_rotations(rotations):
+    """Reciprocal-space rotations, (R^-1)^T for each real-space rotation R."""
+    return np.array([np.rint(np.linalg.inv(r).T).astype(int) for r in rotations])
+
+
+def _inverse_operations(rotations):
+    """Fortran 1-based index of the inverse of each (translation-free) operation."""
+    inverse = []
+    for rotation in rotations:
+        target = np.rint(np.linalg.inv(rotation)).astype(int)
+        match = next(
+            index for index, other in enumerate(rotations) if np.array_equal(other, target)
+        )
+        inverse.append(match + 1)
+    return inverse
+
+
+def _atom_permutations(rotations, translations, positions):
+    """Fortran 1-based image of each atom under each operation x -> R x + t (mod 1)."""
+    permutations = []
+    for rotation, translation in zip(rotations, translations):
+        images = (positions @ rotation.T + translation) % 1.0
+        row = []
+        for image in images:
+            difference = (positions - image + 0.5) % 1.0 - 0.5
+            row.append(int(np.argmin(np.linalg.norm(difference, axis=1))) + 1)
+        permutations.append(row)
+    return permutations

--- a/src/py4vasp/_demo/symmetry.py
+++ b/src/py4vasp/_demo/symmetry.py
@@ -222,7 +222,9 @@ def _inverse_operations(rotations):
     for rotation in rotations:
         target = np.rint(np.linalg.inv(rotation)).astype(int)
         match = next(
-            index for index, other in enumerate(rotations) if np.array_equal(other, target)
+            index
+            for index, other in enumerate(rotations)
+            if np.array_equal(other, target)
         )
         inverse.append(match + 1)
     return inverse

--- a/src/py4vasp/_raw/access.py
+++ b/src/py4vasp/_raw/access.py
@@ -112,11 +112,17 @@ class _State:
     def _check_version(self, h5f, required, quantity):
         if not required:
             return
-        version = raw.Version(
-            major=h5f[schema.version.major][()],
-            minor=h5f[schema.version.minor][()],
-            patch=h5f[schema.version.patch][()],
-        )
+        try:
+            version = raw.Version(
+                major=h5f[schema.version.major][()],
+                minor=h5f[schema.version.minor][()],
+                patch=h5f[schema.version.patch][()],
+            )
+        except KeyError:
+            # A file without version datasets cannot satisfy a version requirement;
+            # treat it as an outdated version so optional links degrade to no data.
+            message = f"The {quantity} is not available because {h5f.filename} does not specify a VASP version. It requires at least {required}."
+            raise exception.OutdatedVaspVersion(message) from None
         if version < required:
             message = f"The {quantity} is not available in VASP {version}. It requires at least {required}."
             raise exception.OutdatedVaspVersion(message)

--- a/src/py4vasp/_raw/data.py
+++ b/src/py4vasp/_raw/data.py
@@ -838,6 +838,8 @@ class Structure:
     "The direction along which dipole correction is applied, if any."
     ldipol: Optional[int] = NONE()
     "Whether dipole correction is applied."
+    symmetry: Optional[Symmetry] = NONE()
+    "Symmetry operations VASP detected for the structure (VASP 6.6 and later)."
 
 
 @dataclasses.dataclass

--- a/src/py4vasp/_raw/definition.py
+++ b/src/py4vasp/_raw/definition.py
@@ -699,6 +699,7 @@ schema.add(
     positions="intermediate/ion_dynamics/position_ions",
     idipol="input/incar/IDIPOL",
     ldipol="input/incar/LDIPOL",
+    symmetry=Link("symmetry", DEFAULT_SOURCE),
 )
 schema.add(
     raw.Structure,
@@ -709,6 +710,7 @@ schema.add(
     positions="results/positions/position_ions",
     idipol="input/incar/IDIPOL",
     ldipol="input/incar/LDIPOL",
+    symmetry=Link("symmetry", DEFAULT_SOURCE),
 )
 schema.add(
     raw.Structure,

--- a/src/py4vasp/_raw/models.py
+++ b/src/py4vasp/_raw/models.py
@@ -30,7 +30,7 @@ VoigtMatrix = Tuple[Voigt, Voigt, Voigt, Voigt, Voigt, Voigt]
 # series, e.g. "0.11". Increment it whenever any model below changes between releases
 # (a test enforces this, see tests/raw/test_schema_version.py); the version then reads
 # "0.11+db.1", "0.11+db.2", ... Reset it back to 0 on every new py4vasp minor release.
-__DB_SCHEMA__ = 1
+__DB_SCHEMA__ = 2
 
 
 def schema_version() -> str:
@@ -1104,6 +1104,8 @@ class StructureModel(_DatabaseModel):
     """The chemical formula of the system, in the format {element}{count if count > 1 else ''}, e.g. A3B2CD4."""
     compound: Optional[str] = None
     """The name of the compound, in the format {element1}-{element2}-..., e.g. A-B-C."""
+    prototype: Optional[str] = None
+    """The AFLOW prototype label, combining the reduced stoichiometry, Pearson symbol, space group number, and Wyckoff sequence, e.g. ABC3_cP5_221_a_b_c. Useful to group calculations by structure type."""
 
 
 @dataclass

--- a/src/py4vasp/demo.py
+++ b/src/py4vasp/demo.py
@@ -109,10 +109,19 @@ def _generate_spin_texture_data(h5f, waveh5f=None):
     write(h5f, _demo.band.spin_texture("x~z"), selection="kpoints_opt")
 
 
+def _generate_perovskite_data(h5f, waveh5f=None):
+    # cubic SrTiO3 with its matching Pm-3m symmetry, so the symmetry-derived
+    # structure properties (Wyckoff positions, equivalent atoms, ...) are consistent
+    write(h5f, _demo.structure.SrTiO3())
+    write(h5f, _demo.symmetry.SrTiO3())
+    write(h5f, _demo.system.Sr2TiO4())
+
+
 _DATA_GENERATORS = {
     None: _generate_default_data,
     "default": _generate_default_data,
     "collinear": _generate_collinear_data,
     "noncollinear": _generate_noncollinear_data,
     "spin_texture": _generate_spin_texture_data,
+    "perovskite": _generate_perovskite_data,
 }

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -725,7 +725,9 @@ def test_wyckoff_positions_honor_vasp_symmetry(perovskite, Assert):
     from py4vasp._calculation.symmetry import SymmetryHandler
 
     raw_structure = perovskite.ref.raw_data
-    expected_number = SymmetryHandler.from_data(raw_structure.symmetry).space_group().number
+    expected_number = (
+        SymmetryHandler.from_data(raw_structure.symmetry).space_group().number
+    )
     handler = StructureHandler.from_data(raw_structure)
     orbits = perovskite.equivalent_atoms()
     cell = (handler.lattice_vectors(), handler.positions(), orbits)

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -671,7 +671,12 @@ def test_factory_methods(raw_data, check_factory_methods):
     parameters = {"__getitem__": {"steps": slice(None)}}
     # the Sr2TiO4 trajectory carries no symmetry, so the symmetry-derived methods
     # raise NoData; they are exercised on the perovskite fixture instead
-    skip_methods = ["equivalent_atoms", "wyckoff_positions", "standardized_cell"]
+    skip_methods = [
+        "equivalent_atoms",
+        "wyckoff_positions",
+        "standardized_cell",
+        "prototype",
+    ]
     check_factory_methods(Structure, data, parameters, skip_methods=skip_methods)
 
 
@@ -753,3 +758,15 @@ def test_standardized_cell_without_symmetry(Sr2TiO4):
     pytest.importorskip("spglib")
     with pytest.raises(exception.NoData):
         Sr2TiO4.standardized_cell()
+
+
+def test_prototype(perovskite):
+    pytest.importorskip("spglib")
+    # AFLOW label: stoichiometry_Pearson_spacegroup_Wyckoff (Sr a, Ti b, O c)
+    assert perovskite.prototype() == "ABC3_cP5_221_a_b_c"
+
+
+def test_prototype_without_symmetry(Sr2TiO4):
+    pytest.importorskip("spglib")
+    with pytest.raises(exception.NoData):
+        Sr2TiO4.prototype()

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -701,3 +701,35 @@ def test_equivalent_atoms(perovskite, Assert):
 def test_equivalent_atoms_without_symmetry(Sr2TiO4):
     with pytest.raises(exception.NoData):
         Sr2TiO4.equivalent_atoms()
+
+
+def test_wyckoff_positions(perovskite):
+    pytest.importorskip("spglib")
+    from py4vasp._calculation.structure import Wyckoff
+
+    actual = perovskite.wyckoff_positions()
+    assert isinstance(actual, Wyckoff)
+    assert actual.letters == ["a", "b", "c", "c", "c"]
+    assert actual.site_symmetries == ["m-3m", "m-3m", "4/mm.m", "4/mm.m", "4/mm.m"]
+
+
+def test_wyckoff_positions_honor_vasp_symmetry(perovskite, Assert):
+    # the orbit-relabeled cell must reproduce VASP's space group (not a higher one)
+    # and spglib's equivalent atoms must match the VASP orbit partition
+    spglib = pytest.importorskip("spglib")
+    from py4vasp._calculation.symmetry import SymmetryHandler
+
+    raw_structure = perovskite.ref.raw_data
+    expected_number = SymmetryHandler.from_data(raw_structure.symmetry).space_group().number
+    handler = StructureHandler.from_data(raw_structure)
+    orbits = perovskite.equivalent_atoms()
+    cell = (handler.lattice_vectors(), handler.positions(), orbits)
+    dataset = spglib.get_symmetry_dataset(cell)
+    assert dataset.number == expected_number
+    Assert.allclose(dataset.equivalent_atoms, orbits)
+
+
+def test_wyckoff_positions_without_symmetry(Sr2TiO4):
+    pytest.importorskip("spglib")
+    with pytest.raises(exception.NoData):
+        Sr2TiO4.wyckoff_positions()

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -670,3 +670,16 @@ def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.structure("Sr2TiO4")
     parameters = {"__getitem__": {"steps": slice(None)}}
     check_factory_methods(Structure, data, parameters)
+
+
+# ---------------------------------------------------------------------------
+# Symmetry-derived properties (SrTiO3 perovskite carries a matching symmetry)
+# ---------------------------------------------------------------------------
+
+
+def test_srtio3_demo_carries_symmetry(raw_data):
+    """The SrTiO3 demo pairs the structure with its cubic Pm-3m symmetry."""
+    raw_structure = raw_data.structure("SrTiO3")
+    assert not check.is_none(raw_structure.symmetry)
+    assert raw_structure.symmetry.number_of_operations == 48
+    assert np.array(raw_structure.symmetry.atom_permutations).shape == (1, 48, 5)

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -770,3 +770,15 @@ def test_prototype_without_symmetry(Sr2TiO4):
     pytest.importorskip("spglib")
     with pytest.raises(exception.NoData):
         Sr2TiO4.prototype()
+
+
+def test_to_database_prototype(perovskite):
+    pytest.importorskip("spglib")
+    handler = StructureHandler.from_data(perovskite.ref.raw_data)
+    assert handler.to_database().prototype == "ABC3_cP5_221_a_b_c"
+
+
+def test_to_database_prototype_absent_without_symmetry(Sr2TiO4):
+    # structures without symmetry (or without spglib) leave the field empty
+    handler = StructureHandler.from_data(Sr2TiO4.ref.raw_data)
+    assert handler.to_database().prototype is None

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -733,3 +733,23 @@ def test_wyckoff_positions_without_symmetry(Sr2TiO4):
     pytest.importorskip("spglib")
     with pytest.raises(exception.NoData):
         Sr2TiO4.wyckoff_positions()
+
+
+def test_standardized_cell(perovskite, Assert):
+    pytest.importorskip("spglib")
+    from py4vasp._calculation.structure import StandardizedCell
+
+    actual = perovskite.standardized_cell()
+    assert isinstance(actual, StandardizedCell)
+    Assert.allclose(actual.lattice_vectors, 4.0 * np.eye(3))
+    expected_positions = np.array(
+        [[0, 0, 0], [0.5, 0.5, 0.5], [0, 0.5, 0.5], [0.5, 0, 0.5], [0.5, 0.5, 0]]
+    )
+    Assert.allclose(actual.positions, expected_positions)
+    assert actual.elements == ["Sr", "Ti", "O", "O", "O"]
+
+
+def test_standardized_cell_without_symmetry(Sr2TiO4):
+    pytest.importorskip("spglib")
+    with pytest.raises(exception.NoData):
+        Sr2TiO4.standardized_cell()

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -669,7 +669,10 @@ def test_to_database_collects_available_sources(tmp_path):
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.structure("Sr2TiO4")
     parameters = {"__getitem__": {"steps": slice(None)}}
-    check_factory_methods(Structure, data, parameters)
+    # the Sr2TiO4 trajectory carries no symmetry, so the symmetry-derived methods
+    # raise NoData; they are exercised on the perovskite fixture instead
+    skip_methods = ["equivalent_atoms", "wyckoff_positions", "standardized_cell"]
+    check_factory_methods(Structure, data, parameters, skip_methods=skip_methods)
 
 
 # ---------------------------------------------------------------------------
@@ -683,3 +686,18 @@ def test_srtio3_demo_carries_symmetry(raw_data):
     assert not check.is_none(raw_structure.symmetry)
     assert raw_structure.symmetry.number_of_operations == 48
     assert np.array(raw_structure.symmetry.atom_permutations).shape == (1, 48, 5)
+
+
+@pytest.fixture
+def perovskite(raw_data):
+    return make_structure(raw_data.structure("SrTiO3"))
+
+
+def test_equivalent_atoms(perovskite, Assert):
+    # Sr and Ti each sit on their own site, the three oxygens form one orbit
+    Assert.allclose(perovskite.equivalent_atoms(), np.array([0, 1, 2, 2, 2]))
+
+
+def test_equivalent_atoms_without_symmetry(Sr2TiO4):
+    with pytest.raises(exception.NoData):
+        Sr2TiO4.equivalent_atoms()

--- a/tests/raw/schema_snapshot.json
+++ b/tests/raw/schema_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "0.11+db.1",
+  "schema_version": "0.11+db.2",
   "models": {
     "BandModel": [
       [
@@ -1261,6 +1261,10 @@
       [
         "num_ions",
         "Optional[int]"
+      ],
+      [
+        "prototype",
+        "Optional[str]"
       ]
     ],
     "SymmetryModel": [

--- a/tests/raw/test_access.py
+++ b/tests/raw/test_access.py
@@ -192,6 +192,22 @@ def test_optional_type_become_none_instead_of_raising_error(mock_access):
     assert mock_get_version.call_count == 3
 
 
+def test_missing_version_treated_as_outdated(mock_access):
+    # A file without version datasets cannot satisfy a version requirement, so a
+    # version-gated quantity must raise OutdatedVaspVersion (which optional links
+    # then turn into the none sentinel) rather than leaking a raw KeyError.
+    mock_file, sources = mock_access
+    h5f = mock_file.return_value.__enter__.return_value
+
+    def raise_key_error(key):
+        raise KeyError(key)
+
+    h5f.__getitem__.side_effect = raise_key_error
+    with pytest.raises(exception.OutdatedVaspVersion):
+        with raw.access("with_link"):
+            pass
+
+
 def initialize_version_mock(mock_file):
     mock_get_version = mock_file.return_value.__enter__.return_value.__getitem__
     version = {

--- a/tests/raw/test_data.py
+++ b/tests/raw/test_data.py
@@ -218,3 +218,18 @@ def test_metadata_has_file_presence_flags():
     field_names = {f.name for f in dataclasses.fields(CalculationMetaData)}
     for flag in ("has_incar", "has_poscar", "has_kpoints", "has_potcar"):
         assert flag in field_names, f"Missing flag {flag!r} in CalculationMetaData"
+
+
+def test_structure_has_optional_symmetry_field():
+    """raw.Structure carries an optional symmetry field, none-sentinel by default."""
+    from py4vasp import raw
+
+    field_names = {f.name for f in dataclasses.fields(raw.Structure)}
+    assert "symmetry" in field_names
+    structure = raw.Structure(
+        stoichiometry=raw.Stoichiometry(number_ion_types=[1], ion_types=["Si"]),
+        cell=raw.Cell(lattice_vectors=np.eye(3), scale=VaspData(1.0)),
+        positions=np.zeros((1, 3)),
+    )
+    # old files that do not store symmetry leave the field at the none sentinel
+    assert structure.symmetry.is_none()

--- a/tests/raw/test_definition.py
+++ b/tests/raw/test_definition.py
@@ -19,6 +19,15 @@ def test_schema_is_valid():
     schema.verify()
 
 
+def test_structure_links_symmetry():
+    from py4vasp._raw.schema import Link
+
+    for name in ("default", "final"):
+        symmetry = schema.sources["structure"][name].data.symmetry
+        assert isinstance(symmetry, Link)
+        assert symmetry.quantity == "symmetry"
+
+
 def test_get_schema(complex_schema):
     mock_schema, _ = complex_schema
     with patch("py4vasp._raw.definition.schema", mock_schema):

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -65,6 +65,8 @@ _FULL_INSTALL_EXAMPLES = {
     "py4vasp._calculation.symmetry.Symmetry.point_group_schoenflies": "spglib",
     "py4vasp._calculation.symmetry.Symmetry.bravais_lattice": "spglib",
     "py4vasp._calculation.symmetry.Symmetry.pearson_symbol": "spglib",
+    "py4vasp._calculation.structure.Structure.wyckoff_positions": "spglib",
+    "py4vasp._calculation.structure.Structure.standardized_cell": "spglib",
 }
 
 

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -28,6 +28,13 @@ def test_creating_default_calculation(tmp_path):
     demo.calculation(tmp_path / "specific_example")
 
 
+def test_creating_perovskite_calculation(tmp_path):
+    # the "perovskite" selection pairs a structure with its symmetry so the
+    # symmetry-derived structure examples have consistent data
+    calculation = demo.calculation(tmp_path / "perovskite_example", "perovskite")
+    assert calculation.structure.number_atoms() == 5
+
+
 finder = doctest.DocTestFinder()
 
 

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -67,6 +67,7 @@ _FULL_INSTALL_EXAMPLES = {
     "py4vasp._calculation.symmetry.Symmetry.pearson_symbol": "spglib",
     "py4vasp._calculation.structure.Structure.wyckoff_positions": "spglib",
     "py4vasp._calculation.structure.Structure.standardized_cell": "spglib",
+    "py4vasp._calculation.structure.Structure.prototype": "spglib",
 }
 
 


### PR DESCRIPTION
## Summary
Extends the calculation-level `Structure` to carry the symmetry VASP determined
(new optional field on `raw.Structure`, wired via the schema so pre-6.6 files
still parse) and expose symmetry-derived crystallographic properties:

- `equivalent_atoms()` — orbit index per atom from VASP's `atom_permutations`
- `wyckoff_positions()` → `Wyckoff` (letter + site symmetry per atom)
- `standardized_cell()` → `StandardizedCell` (conventional cell)
- `prototype()` — AFLOW prototype label, e.g. `ABC3_cP5_221_a_b_c`

All honor the symmetry VASP recognized (not the higher symmetry the geometry
alone might imply) by relabeling atoms by their VASP orbit before handing the
cell to spglib. The prototype is also stored in the database `StructureModel`.

## Notes
- Wyckoff/AFLOW letters use spglib's standard setting; no affine-normalizer
  canonicalization (e.g. zinc blende reads `a_d`, not `a_c`).
- Database schema counter bumped to `+db.2`; snapshot regenerated.
- New demo: `demo.calculation(path, "perovskite")` (SrTiO₃ + Pm-3m symmetry).