### PR TITLE
Feat: add NeighborList quantity

### DIFF
--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -77,6 +77,12 @@ def _selection_label(selection):
     return " ".join(str(part) for part in selection)
 
 
+def _sort_by_distance(pairs):
+    """Reorder every array of the flat neighbor dict by increasing distance."""
+    order = np.argsort(pairs["distances"], kind="stable")
+    return {key: value[order] for key, value in pairs.items()}
+
+
 def _part_mask(part, elements, source, neighbor):
     """Boolean mask selecting the pairs that match one selection element."""
     if isinstance(part, select.Group) and part.separator == select.pair_separator:
@@ -114,14 +120,17 @@ class NeighborListHandler:
     def from_data(cls, raw_structure, steps=None) -> "NeighborListHandler":
         return cls(raw_structure, steps=steps)
 
-    def to_dict(self, selection=None, *, cutoff) -> dict:
+    def to_dict(self, selection=None, *, cutoff, sorted=True) -> dict:
         """Compute the neighbor list and store it in a dictionary.
 
         Without a selection the flat dictionary of all pairs is returned. When a
         selection is given, the result is keyed by the selection label and each
-        value is the flat dictionary restricted to that pair of atom types.
+        value is the flat dictionary restricted to that pair of atom types. If
+        *sorted* is set, the pairs are ordered by increasing distance.
         """
         pairs = self._all_pairs(cutoff)
+        if sorted:
+            pairs = _sort_by_distance(pairs)
         if selection is None:
             return pairs
         elements = np.array(self._structure._stoichiometry().elements())
@@ -258,7 +267,7 @@ class NeighborList:
     def _handler_factory(self, raw_data):
         return NeighborListHandler.from_data(raw_data, steps=self._steps)
 
-    def read(self, selection=None, *, cutoff) -> dict:
+    def read(self, selection=None, *, cutoff, sorted=True) -> dict:
         """Compute the neighbor list and store it in a dictionary.
 
         Parameters
@@ -270,6 +279,8 @@ class NeighborList:
         cutoff : float
             The neighbor cutoff radius in Å. Only pairs closer than this radius
             are returned.
+        sorted : bool
+            If True (default), the pairs are ordered by increasing distance.
 
         Returns
         -------
@@ -305,11 +316,12 @@ class NeighborList:
             self._handler_factory,
             NeighborListHandler.to_dict,
             cutoff=cutoff,
+            sorted=sorted,
         )
 
-    def to_dict(self, selection=None, *, cutoff) -> dict:
+    def to_dict(self, selection=None, *, cutoff, sorted=True) -> dict:
         """Convenient alias for :py:meth:`read`. Please read the documentation there."""
-        return self.read(selection, cutoff=cutoff)
+        return self.read(selection, cutoff=cutoff, sorted=sorted)
 
     def selections(self) -> list:
         """Return every pair of atom types that can be selected.

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -127,9 +127,14 @@ class NeighborListHandler:
         return f"neighbor list of {len(elements)} atoms ({atom_types})"
 
     def selections(self) -> list:
-        """Return every pair of atom types that can be selected."""
+        """Return every pair of atom types that can be selected.
+
+        Pair selection is directed (``'Si~C'`` keeps Si→C neighbors, ``'C~Si'``
+        keeps C→Si), so both orderings are listed. Iterating over the result
+        therefore partitions the complete neighbor list without omission.
+        """
         atom_types = self._structure._stoichiometry().ion_types_list()
-        pairs = itertools.combinations_with_replacement(atom_types, 2)
+        pairs = itertools.product(atom_types, repeat=2)
         return [f"{a}{select.pair_separator}{b}" for a, b in pairs]
 
     def _filter_pairs(self, pairs, selection, elements):
@@ -166,17 +171,20 @@ class NeighborListHandler:
         distance_matrix = home_tree.sparse_distance_matrix(
             image_tree, cutoff, output_type="coo_matrix"
         )
-        # distance == 0 is the atom paired with its own home image; drop it but
-        # keep the (nonzero) pairings of an atom with its own periodic replicas.
-        keep = distance_matrix.data > 0
-        source = distance_matrix.row[keep]
-        image = distance_matrix.col[keep]
+        source = distance_matrix.row
+        image = distance_matrix.col
         neighbor = image // number_offsets
+        offset = offsets[image % number_offsets]
+        # exclude only the atom paired with its own home image (same atom, zero
+        # offset); an atom still neighbors its own replicas at nonzero offsets,
+        # and two distinct atoms sharing a position remain a genuine pair.
+        keep = ~((neighbor == source) & np.all(offset == 0, axis=1))
+        source, neighbor, offset = source[keep], neighbor[keep], offset[keep]
         return {
             "indices": np.stack([source, neighbor], axis=1),
             "distances": distance_matrix.data[keep],
-            "distance_vectors": images[image] - home[source],
-            "cell_offsets": offsets[image % number_offsets],
+            "distance_vectors": images[image[keep]] - home[source],
+            "cell_offsets": offset,
         }
 
     @staticmethod
@@ -271,12 +279,14 @@ class NeighborList:
 
         Each entry is a valid ``selection`` argument for :py:meth:`read`, so you
         can iterate over the result to obtain the neighbor list of every atom-type
-        pair separately.
+        pair separately. Pair selection is directed, so both orderings of a
+        cross-type pair are listed and iterating partitions the complete neighbor
+        list without omission.
 
         Returns
         -------
         list
-            All atom-type pairs of the structure as ``'X~Y'`` strings.
+            All ordered atom-type pairs of the structure as ``'X~Y'`` strings.
 
         Examples
         --------
@@ -284,7 +294,7 @@ class NeighborList:
         >>> calculation = demo.calculation(path)
 
         >>> calculation.neighbor_list.selections()
-        ['Sr~Sr', 'Sr~Ti', 'Sr~O', 'Ti~Ti', 'Ti~O', 'O~O']
+        ['Sr~Sr', 'Sr~Ti', 'Sr~O', 'Ti~Sr', 'Ti~Ti', 'Ti~O', 'O~Sr', 'O~Ti', 'O~O']
         """
         return merge_default(
             self._source,

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -3,15 +3,24 @@
 """Neighbor list of all atom pairs within a cutoff radius, derived from a
 :class:`~py4vasp.calculation.structure`."""
 
+import copy
 import itertools
 
 import numpy as np
-from scipy.spatial import cKDTree
 
 from py4vasp import exception
-from py4vasp._calculation.dispatch import DataSource, merge_default, quantity
+from py4vasp._calculation.dispatch import (
+    DataSource,
+    merge_default,
+    merge_strings,
+    quantity,
+)
 from py4vasp._calculation.structure import StructureHandler
-from py4vasp._util import select
+from py4vasp._util import import_, select
+
+# scipy is only required for the full (not core) installation, so import it
+# lazily; the k-d tree is only touched when a neighbor list is actually computed.
+spatial = import_.optional("scipy.spatial")
 
 # NeighborList owns no raw data of its own; it derives cell, positions, and atom
 # types from the structure. Dispatch therefore accesses the "structure" schema
@@ -112,6 +121,11 @@ class NeighborListHandler:
             for sel in tree.selections()
         }
 
+    def __str__(self) -> str:
+        elements = self._structure._stoichiometry().elements()
+        atom_types = ", ".join(dict.fromkeys(elements))
+        return f"neighbor list of {len(elements)} atoms ({atom_types})"
+
     def _filter_pairs(self, pairs, selection, elements):
         source = elements[pairs["indices"][:, 0]]
         neighbor = elements[pairs["indices"][:, 1]]
@@ -129,13 +143,20 @@ class NeighborListHandler:
         periodic image that could hold a neighbor (see :func:`_replica_counts`),
         and uses a k-d tree to find the pairs within the cutoff in N log N time.
         """
+        positions = np.asarray(self._structure.positions())
+        if positions.ndim != 2:
+            message = (
+                "Computing a neighbor list for multiple steps is not implemented. "
+                "Please select a single step, e.g. neighbor_list[0]."
+            )
+            raise exception.NotImplemented(message)
         lattice_vectors = self._lattice_vectors()
-        home = (np.asarray(self._structure.positions()) % 1.0) @ lattice_vectors
+        home = (positions % 1.0) @ lattice_vectors
         offsets = self._cell_offsets(lattice_vectors, cutoff)
         images = (home[:, np.newaxis, :] + offsets @ lattice_vectors).reshape(-1, 3)
         number_offsets = len(offsets)
-        home_tree = cKDTree(home)
-        image_tree = cKDTree(images)
+        home_tree = spatial.cKDTree(home)
+        image_tree = spatial.cKDTree(images)
         distance_matrix = home_tree.sparse_distance_matrix(
             image_tree, cutoff, output_type="coo_matrix"
         )
@@ -178,6 +199,11 @@ class NeighborList:
         """Create a NeighborList dispatcher from raw structure data."""
         return cls(source=DataSource(raw_structure))
 
+    def __getitem__(self, steps) -> "NeighborList":
+        new = copy.copy(self)
+        new._steps = steps
+        return new
+
     def _handler_factory(self, raw_data):
         return NeighborListHandler.from_data(raw_data, steps=self._steps)
 
@@ -201,6 +227,25 @@ class NeighborList:
             ``distances``, the cartesian ``distance_vectors`` from i to j, and
             the integer ``cell_offsets`` locating the periodic image of j. When a
             selection is given the result is keyed by the selection label.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        Compute all atom pairs within a radius of 3 Å
+
+        >>> neighbors = calculation.neighbor_list.read(cutoff=3.0)
+        >>> sorted(neighbors)
+        ['cell_offsets', 'distance_vectors', 'distances', 'indices']
+
+        Restrict the neighbor list to Sr-Ti pairs
+
+        >>> selection = calculation.neighbor_list.read("Sr~Ti", cutoff=3.5)
+        >>> list(selection)
+        ['Sr~Ti']
+        >>> selection["Sr~Ti"]["distances"]
+        array([...])
         """
         return merge_default(
             self._source,
@@ -214,3 +259,15 @@ class NeighborList:
     def to_dict(self, selection=None, *, cutoff) -> dict:
         """Convenient alias for :py:meth:`read`. Please read the documentation there."""
         return self.read(selection, cutoff=cutoff)
+
+    def __str__(self, selection=None) -> str:
+        return merge_strings(
+            self._source,
+            _DATA_QUANTITY,
+            selection,
+            self._handler_factory,
+            NeighborListHandler.__str__,
+        )
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self) if not cycle else "...")

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -126,6 +126,12 @@ class NeighborListHandler:
         atom_types = ", ".join(dict.fromkeys(elements))
         return f"neighbor list of {len(elements)} atoms ({atom_types})"
 
+    def selections(self) -> list:
+        """Return every pair of atom types that can be selected."""
+        atom_types = self._structure._stoichiometry().ion_types_list()
+        pairs = itertools.combinations_with_replacement(atom_types, 2)
+        return [f"{a}{select.pair_separator}{b}" for a, b in pairs]
+
     def _filter_pairs(self, pairs, selection, elements):
         source = elements[pairs["indices"][:, 0]]
         neighbor = elements[pairs["indices"][:, 1]]
@@ -259,6 +265,34 @@ class NeighborList:
     def to_dict(self, selection=None, *, cutoff) -> dict:
         """Convenient alias for :py:meth:`read`. Please read the documentation there."""
         return self.read(selection, cutoff=cutoff)
+
+    def selections(self) -> list:
+        """Return every pair of atom types that can be selected.
+
+        Each entry is a valid ``selection`` argument for :py:meth:`read`, so you
+        can iterate over the result to obtain the neighbor list of every atom-type
+        pair separately.
+
+        Returns
+        -------
+        list
+            All atom-type pairs of the structure as ``'X~Y'`` strings.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        >>> calculation.neighbor_list.selections()
+        ['Sr~Sr', 'Sr~Ti', 'Sr~O', 'Ti~Ti', 'Ti~O', 'O~O']
+        """
+        return merge_default(
+            self._source,
+            _DATA_QUANTITY,
+            None,
+            self._handler_factory,
+            NeighborListHandler.selections,
+        )
 
     def __str__(self, selection=None) -> str:
         return merge_strings(

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -141,6 +141,13 @@ class NeighborListHandler:
         }
 
     def __str__(self) -> str:
+        # str()/print() run in implicit display code, so degrade gracefully for a
+        # multi-step selection instead of letting to_string raise NotImplemented.
+        if np.asarray(self._structure.positions()).ndim != 2:
+            return (
+                "neighbor list for a trajectory - select a single step to display "
+                "the table, e.g. print(neighbor_list[0])"
+            )
         return self.to_string()
 
     def to_string(self, cutoff=_DEFAULT_CUTOFF) -> str:

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -1,0 +1,86 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+"""Neighbor list of all atom pairs within a cutoff radius, derived from a
+:class:`~py4vasp.calculation.structure`."""
+
+import numpy as np
+
+from py4vasp._calculation.dispatch import DataSource, quantity
+from py4vasp._calculation.structure import StructureHandler
+
+# NeighborList owns no raw data of its own; it derives cell, positions, and atom
+# types from the structure. Dispatch therefore accesses the "structure" schema
+# entry, exactly like optics derives from "dielectric_function".
+_DATA_QUANTITY = "structure"
+
+# Relative tolerance to absorb floating-point noise when the cutoff is an exact
+# multiple of the perpendicular cell width, so ceil does not spuriously add a
+# whole extra shell of replicas. Far larger than det/norm rounding (~1e-15) and
+# far smaller than any physically meaningful fraction of a replica.
+_REPLICA_TOL = 1e-9
+
+
+def _replica_counts(lattice_vectors, cutoff):
+    """Number of periodic replicas needed along each lattice direction.
+
+    For a cutoff radius, an atom may have neighbors in any cell whose nearest
+    plane lies within the cutoff. The robust (tilted-cell safe) criterion uses
+    the *perpendicular* distance between the lattice planes stacked along each
+    direction, ``d_i = |det(A)| / |a_j x a_k|``, rather than the lattice-vector
+    lengths ``|a_i|``. The number of replicas is ``ceil(cutoff / d_i)``.
+
+    Parameters
+    ----------
+    lattice_vectors : np.ndarray
+        The (3, 3) matrix whose rows are the lattice vectors in Å.
+    cutoff : float
+        The neighbor cutoff radius in Å.
+
+    Returns
+    -------
+    np.ndarray
+        Three integers, the replica count along each lattice direction.
+    """
+    lattice_vectors = np.asarray(lattice_vectors)
+    volume = np.abs(np.linalg.det(lattice_vectors))
+    # cross products of the other two vectors: a1xa2, a2xa0, a0xa1
+    cross = np.cross(lattice_vectors[[1, 2, 0]], lattice_vectors[[2, 0, 1]])
+    perpendicular_width = volume / np.linalg.norm(cross, axis=1)
+    return np.ceil(cutoff / perpendicular_width - _REPLICA_TOL).astype(int)
+
+
+class NeighborListHandler:
+    """Computes the neighbor list from a single raw.Structure object."""
+
+    def __init__(self, raw_structure, steps=None):
+        self._structure = StructureHandler.from_data(raw_structure, steps=steps)
+
+    @classmethod
+    def from_data(cls, raw_structure, steps=None) -> "NeighborListHandler":
+        return cls(raw_structure, steps=steps)
+
+    def _lattice_vectors(self):
+        return np.asarray(self._structure.lattice_vectors())
+
+
+@quantity("neighbor_list")
+class NeighborList:
+    """The neighbor list contains all atom pairs within a cutoff radius.
+
+    Given a cutoff radius, this class determines every pair of atoms that is
+    closer than the cutoff, taking the periodic boundary conditions into account.
+    The relevant data (cell, atom types, positions) is taken from the structure.
+    """
+
+    def __init__(self, source, quantity_name: str = "neighbor_list", steps=None):
+        self._source = source
+        self._quantity_name = quantity_name
+        self._steps = steps
+
+    @classmethod
+    def from_data(cls, raw_structure) -> "NeighborList":
+        """Create a NeighborList dispatcher from raw structure data."""
+        return cls(source=DataSource(raw_structure))
+
+    def _handler_factory(self, raw_data):
+        return NeighborListHandler.from_data(raw_data, steps=self._steps)

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -8,8 +8,10 @@ import itertools
 import numpy as np
 from scipy.spatial import cKDTree
 
+from py4vasp import exception
 from py4vasp._calculation.dispatch import DataSource, merge_default, quantity
 from py4vasp._calculation.structure import StructureHandler
+from py4vasp._util import select
 
 # NeighborList owns no raw data of its own; it derives cell, positions, and atom
 # types from the structure. Dispatch therefore accesses the "structure" schema
@@ -52,6 +54,37 @@ def _replica_counts(lattice_vectors, cutoff):
     return np.ceil(cutoff / perpendicular_width - _REPLICA_TOL).astype(int)
 
 
+def _selection_label(selection):
+    return " ".join(str(part) for part in selection)
+
+
+def _part_mask(part, elements, source, neighbor):
+    """Boolean mask selecting the pairs that match one selection element."""
+    if isinstance(part, select.Group) and part.separator == select.pair_separator:
+        source_type, neighbor_type = part.group
+        _raise_if_unknown(source_type, elements)
+        _raise_if_unknown(neighbor_type, elements)
+        return (source == source_type) & (neighbor == neighbor_type)
+    if isinstance(part, str):
+        _raise_if_unknown(part, elements)
+        return source == part
+    message = (
+        f"The selection '{part}' is not supported. Please select pairs of atom "
+        "types with a tilde, e.g. 'Sr~Ti', or a single atom type, e.g. 'Sr'."
+    )
+    raise exception.IncorrectUsage(message)
+
+
+def _raise_if_unknown(atom_type, elements):
+    if not np.any(elements == atom_type):
+        available = ", ".join(dict.fromkeys(elements))
+        message = (
+            f"The atom type '{atom_type}' is not present in the structure. "
+            f"The available atom types are: {available}."
+        )
+        raise exception.IncorrectUsage(message)
+
+
 class NeighborListHandler:
     """Computes the neighbor list from a single raw.Structure object."""
 
@@ -63,8 +96,28 @@ class NeighborListHandler:
         return cls(raw_structure, steps=steps)
 
     def to_dict(self, selection=None, *, cutoff) -> dict:
-        """Compute the neighbor list and store it in a dictionary."""
-        return self._all_pairs(cutoff)
+        """Compute the neighbor list and store it in a dictionary.
+
+        Without a selection the flat dictionary of all pairs is returned. When a
+        selection is given, the result is keyed by the selection label and each
+        value is the flat dictionary restricted to that pair of atom types.
+        """
+        pairs = self._all_pairs(cutoff)
+        if selection is None:
+            return pairs
+        elements = np.array(self._structure._stoichiometry().elements())
+        tree = select.Tree.from_selection(selection)
+        return {
+            _selection_label(sel): self._filter_pairs(pairs, sel, elements)
+            for sel in tree.selections()
+        }
+
+    def _filter_pairs(self, pairs, selection, elements):
+        source = elements[pairs["indices"][:, 0]]
+        neighbor = elements[pairs["indices"][:, 1]]
+        masks = [_part_mask(part, elements, source, neighbor) for part in selection]
+        mask = np.logical_and.reduce(masks)
+        return {key: value[mask] for key, value in pairs.items()}
 
     def _lattice_vectors(self):
         return np.asarray(self._structure.lattice_vectors())

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -3,9 +3,12 @@
 """Neighbor list of all atom pairs within a cutoff radius, derived from a
 :class:`~py4vasp.calculation.structure`."""
 
-import numpy as np
+import itertools
 
-from py4vasp._calculation.dispatch import DataSource, quantity
+import numpy as np
+from scipy.spatial import cKDTree
+
+from py4vasp._calculation.dispatch import DataSource, merge_default, quantity
 from py4vasp._calculation.structure import StructureHandler
 
 # NeighborList owns no raw data of its own; it derives cell, positions, and atom
@@ -59,8 +62,48 @@ class NeighborListHandler:
     def from_data(cls, raw_structure, steps=None) -> "NeighborListHandler":
         return cls(raw_structure, steps=steps)
 
+    def to_dict(self, selection=None, *, cutoff) -> dict:
+        """Compute the neighbor list and store it in a dictionary."""
+        return self._all_pairs(cutoff)
+
     def _lattice_vectors(self):
         return np.asarray(self._structure.lattice_vectors())
+
+    def _all_pairs(self, cutoff) -> dict:
+        """All atom pairs within *cutoff*, respecting periodic boundaries.
+
+        The search wraps the atoms into the unit cell, replicates them into every
+        periodic image that could hold a neighbor (see :func:`_replica_counts`),
+        and uses a k-d tree to find the pairs within the cutoff in N log N time.
+        """
+        lattice_vectors = self._lattice_vectors()
+        home = (np.asarray(self._structure.positions()) % 1.0) @ lattice_vectors
+        offsets = self._cell_offsets(lattice_vectors, cutoff)
+        images = (home[:, np.newaxis, :] + offsets @ lattice_vectors).reshape(-1, 3)
+        number_offsets = len(offsets)
+        home_tree = cKDTree(home)
+        image_tree = cKDTree(images)
+        distance_matrix = home_tree.sparse_distance_matrix(
+            image_tree, cutoff, output_type="coo_matrix"
+        )
+        # distance == 0 is the atom paired with its own home image; drop it but
+        # keep the (nonzero) pairings of an atom with its own periodic replicas.
+        keep = distance_matrix.data > 0
+        source = distance_matrix.row[keep]
+        image = distance_matrix.col[keep]
+        neighbor = image // number_offsets
+        return {
+            "indices": np.stack([source, neighbor], axis=1),
+            "distances": distance_matrix.data[keep],
+            "distance_vectors": images[image] - home[source],
+            "cell_offsets": offsets[image % number_offsets],
+        }
+
+    @staticmethod
+    def _cell_offsets(lattice_vectors, cutoff):
+        counts = _replica_counts(lattice_vectors, cutoff)
+        ranges = [np.arange(-count, count + 1) for count in counts]
+        return np.array(list(itertools.product(*ranges)))
 
 
 @quantity("neighbor_list")
@@ -84,3 +127,37 @@ class NeighborList:
 
     def _handler_factory(self, raw_data):
         return NeighborListHandler.from_data(raw_data, steps=self._steps)
+
+    def read(self, selection=None, *, cutoff) -> dict:
+        """Compute the neighbor list and store it in a dictionary.
+
+        Parameters
+        ----------
+        selection : str
+            Select pairs of atom types with a tilde, e.g. 'Sr~Ti'. Combine
+            multiple selections with commas or whitespace. When no selection is
+            given, all pairs are returned.
+        cutoff : float
+            The neighbor cutoff radius in Å. Only pairs closer than this radius
+            are returned.
+
+        Returns
+        -------
+        dict
+            Contains the atom ``indices`` (i, j) of each pair, their
+            ``distances``, the cartesian ``distance_vectors`` from i to j, and
+            the integer ``cell_offsets`` locating the periodic image of j. When a
+            selection is given the result is keyed by the selection label.
+        """
+        return merge_default(
+            self._source,
+            _DATA_QUANTITY,
+            selection,
+            self._handler_factory,
+            NeighborListHandler.to_dict,
+            cutoff=cutoff,
+        )
+
+    def to_dict(self, selection=None, *, cutoff) -> dict:
+        """Convenient alias for :py:meth:`read`. Please read the documentation there."""
+        return self.read(selection, cutoff=cutoff)

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -35,10 +35,13 @@ _REPLICA_TOL = 1e-9
 
 # Default cutoff (Å) used when rendering the neighbor table for __str__/print,
 # where no radius can be supplied. Roughly a first-shell bonding distance.
-_DEFAULT_CUTOFF = 3.0
+_DEFAULT_CUTOFF = 3.5
 
 # Header of the VASP-style nearest-neighbor table produced by __str__/to_string.
 _NEIGHBOR_TABLE_HEADER = " ion  position               nearest neighbor table"
+
+# Neighbors wrap onto indented continuation lines after this many per line (VASP).
+_NEIGHBORS_PER_LINE = 8
 
 
 def _replica_counts(lattice_vectors, cutoff):
@@ -136,26 +139,29 @@ class NeighborListHandler:
 
         Each row lists an ion (1-based), its direct coordinates, and its
         neighbors as ``index distance`` pairs sorted by increasing distance.
+        Long neighbor lists wrap onto indented continuation lines.
         """
         pairs = self._all_pairs(cutoff)
         positions = np.asarray(self._structure.positions())
-        lines = [_NEIGHBOR_TABLE_HEADER]
-        lines += [
-            self._table_row(atom, position, pairs)
-            for atom, position in enumerate(positions)
-        ]
+        lines = [f"(neighbors within {cutoff} Å)", _NEIGHBOR_TABLE_HEADER]
+        for atom, position in enumerate(positions):
+            lines += self._table_rows(atom, position, pairs)
         return "\n".join(lines)
 
-    def _table_row(self, atom, position, pairs):
+    def _table_rows(self, atom, position, pairs):
         mask = pairs["indices"][:, 0] == atom
         neighbors = pairs["indices"][mask, 1]
         distances = pairs["distances"][mask]
         order = np.lexsort((neighbors, distances))
-        row = f"{atom + 1:4d}{position[0]:7.3f}{position[1]:7.3f}{position[2]:7.3f}-"
-        entries = "".join(
-            f"{neighbors[k] + 1:4d}{distances[k]:5.2f}" for k in order
-        )
-        return row + entries
+        entries = [f"{neighbors[k] + 1:4d}{distances[k]:5.2f}" for k in order]
+        prefix = f"{atom + 1:4d}{position[0]:7.3f}{position[1]:7.3f}{position[2]:7.3f}-"
+        indent = " " * len(prefix)
+        starts = range(0, max(len(entries), 1), _NEIGHBORS_PER_LINE)
+        return [
+            (prefix if start == 0 else indent)
+            + "".join(entries[start : start + _NEIGHBORS_PER_LINE])
+            for start in starts
+        ]
 
     def selections(self) -> list:
         """Return every pair of atom types that can be selected.
@@ -349,8 +355,9 @@ class NeighborList:
         Returns
         -------
         str
-            A VASP OUTCAR-style table with one row per ion. Each row contains the
-            1-based ion index, its direct coordinates, and its neighbors as
+            A VASP OUTCAR-style table with one row per ion (neighbor lists longer
+            than eight wrap onto indented continuation lines). Each row contains
+            the 1-based ion index, its direct coordinates, and its neighbors as
             ``index distance`` pairs sorted by increasing distance.
 
         Examples
@@ -359,6 +366,7 @@ class NeighborList:
         >>> calculation = demo.calculation(path)
 
         >>> print(calculation.neighbor_list.to_string(cutoff=3.0))
+        (neighbors within 3.0 Å)
          ion  position               nearest neighbor table
            1  ...
         """

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -33,6 +33,13 @@ _DATA_QUANTITY = "structure"
 # far smaller than any physically meaningful fraction of a replica.
 _REPLICA_TOL = 1e-9
 
+# Default cutoff (Å) used when rendering the neighbor table for __str__/print,
+# where no radius can be supplied. Roughly a first-shell bonding distance.
+_DEFAULT_CUTOFF = 3.0
+
+# Header of the VASP-style nearest-neighbor table produced by __str__/to_string.
+_NEIGHBOR_TABLE_HEADER = " ion  position               nearest neighbor table"
+
 
 def _replica_counts(lattice_vectors, cutoff):
     """Number of periodic replicas needed along each lattice direction.
@@ -122,9 +129,33 @@ class NeighborListHandler:
         }
 
     def __str__(self) -> str:
-        elements = self._structure._stoichiometry().elements()
-        atom_types = ", ".join(dict.fromkeys(elements))
-        return f"neighbor list of {len(elements)} atoms ({atom_types})"
+        return self.to_string()
+
+    def to_string(self, cutoff=_DEFAULT_CUTOFF) -> str:
+        """Render the nearest-neighbor table up to *cutoff* (VASP OUTCAR style).
+
+        Each row lists an ion (1-based), its direct coordinates, and its
+        neighbors as ``index distance`` pairs sorted by increasing distance.
+        """
+        pairs = self._all_pairs(cutoff)
+        positions = np.asarray(self._structure.positions())
+        lines = [_NEIGHBOR_TABLE_HEADER]
+        lines += [
+            self._table_row(atom, position, pairs)
+            for atom, position in enumerate(positions)
+        ]
+        return "\n".join(lines)
+
+    def _table_row(self, atom, position, pairs):
+        mask = pairs["indices"][:, 0] == atom
+        neighbors = pairs["indices"][mask, 1]
+        distances = pairs["distances"][mask]
+        order = np.lexsort((neighbors, distances))
+        row = f"{atom + 1:4d}{position[0]:7.3f}{position[1]:7.3f}{position[2]:7.3f}-"
+        entries = "".join(
+            f"{neighbors[k] + 1:4d}{distances[k]:5.2f}" for k in order
+        )
+        return row + entries
 
     def selections(self) -> list:
         """Return every pair of atom types that can be selected.
@@ -302,6 +333,42 @@ class NeighborList:
             None,
             self._handler_factory,
             NeighborListHandler.selections,
+        )
+
+    def to_string(self, cutoff=_DEFAULT_CUTOFF) -> str:
+        """Render the nearest-neighbor table up to *cutoff*.
+
+        This is the string produced by ``print`` (which uses the default cutoff);
+        use this method to obtain the table for a different radius.
+
+        Parameters
+        ----------
+        cutoff : float
+            The neighbor cutoff radius in Å.
+
+        Returns
+        -------
+        str
+            A VASP OUTCAR-style table with one row per ion. Each row contains the
+            1-based ion index, its direct coordinates, and its neighbors as
+            ``index distance`` pairs sorted by increasing distance.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+
+        >>> print(calculation.neighbor_list.to_string(cutoff=3.0))
+         ion  position               nearest neighbor table
+           1  ...
+        """
+        return merge_strings(
+            self._source,
+            _DATA_QUANTITY,
+            None,
+            self._handler_factory,
+            NeighborListHandler.to_string,
+            cutoff,
         )
 
     def __str__(self, selection=None) -> str:

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -301,6 +301,16 @@ def test_str_uses_default_cutoff(raw_data):
     assert str(neighbor_list) == neighbor_list.to_string(cutoff=3.5)
 
 
+def test_str_trajectory_degrades_gracefully(raw_data):
+    # Sr2TiO4 demo data is a trajectory; a multi-step selection cannot render a
+    # single table, but str()/print() must not raise (they run in display code).
+    structure = raw_data.structure("Sr2TiO4")
+    neighbor_list = NeighborList.from_data(structure)
+    assert "trajectory" in str(neighbor_list[0:2])
+    # selecting a single step still renders the table
+    assert str(neighbor_list[0]).startswith("(neighbors within")
+
+
 def _parse_table(text):
     """Parse a neighbor-table string into (lines, {ion0: [(neighbor1, dist), ...]})."""
     lines = text.splitlines()

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -281,3 +281,20 @@ def test_factory_methods_access_structure(raw_data):
 def test_calculation_exposes_neighbor_list():
     calculation = Calculation.from_path(".")
     assert isinstance(calculation.neighbor_list, NeighborList)
+
+
+def test_selections(raw_data):
+    structure = raw_data.structure("Sr2TiO4")
+    neighbor_list = NeighborList.from_data(structure)
+    assert neighbor_list.selections() == [
+        "Sr~Sr", "Sr~Ti", "Sr~O", "Ti~Ti", "Ti~O", "O~O"
+    ]
+
+
+def test_selections_are_valid(raw_data):
+    # every selection returned must be accepted by read
+    structure = raw_data.structure("Sr2TiO4")
+    neighbor_list = NeighborList.from_data(structure)
+    for selection in neighbor_list.selections():
+        result = neighbor_list.read(selection, cutoff=3.5)
+        assert set(result) == {selection}

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -1,11 +1,13 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import itertools
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 
 from py4vasp import exception, raw
+from py4vasp._calculation import Calculation
 from py4vasp._calculation.neighbor_list import NeighborList, _replica_counts
 from py4vasp._calculation.structure import StructureHandler
 
@@ -62,9 +64,9 @@ def _tilted_structure():
     return _raw_structure(lattice, positions, ["Si", "C"], [2, 2])
 
 
-def _brute_force_map(raw_structure, cutoff):
+def _brute_force_map(raw_structure, cutoff, steps=None):
     """Independent O(N^2) neighbor search over an over-generous set of images."""
-    handler = StructureHandler.from_data(raw_structure)
+    handler = StructureHandler.from_data(raw_structure, steps=steps)
     lattice = np.asarray(handler.lattice_vectors())
     home = (np.asarray(handler.positions()) % 1.0) @ lattice
     volume = np.abs(np.linalg.det(lattice))
@@ -218,3 +220,64 @@ def test_read_unknown_element_raises():
     structure = _tilted_structure()
     with pytest.raises(exception.IncorrectUsage):
         NeighborList.from_data(structure).read("Xx~C", cutoff=4.0)
+
+
+def test_read_unsupported_selection_raises():
+    # a range (":") is not a meaningful pair selection for a neighbor list
+    structure = _tilted_structure()
+    with pytest.raises(exception.IncorrectUsage):
+        NeighborList.from_data(structure).read("Si:C", cutoff=4.0)
+
+
+# --- aliases, steps, print, factory, exposure --------------------------------
+
+
+def test_to_dict_is_alias_of_read(Assert):
+    structure = _tilted_structure()
+    neighbor_list = NeighborList.from_data(structure)
+    from_read = neighbor_list.read(cutoff=4.0)
+    from_dict = neighbor_list.to_dict(cutoff=4.0)
+    assert from_read.keys() == from_dict.keys()
+    for key in from_read:
+        Assert.allclose(from_dict[key], from_read[key])
+
+
+def test_read_single_step(raw_data, Assert):
+    # Sr2TiO4 demo data is a trajectory; [step] selects a single geometry.
+    structure = raw_data.structure("Sr2TiO4")
+    result = NeighborList.from_data(structure)[0].read(cutoff=4.5)
+    expected = _brute_force_map(structure, 4.5, steps=0)
+    _compare_maps(_result_to_map(result), expected, Assert)
+
+
+def test_read_multiple_steps_not_implemented(raw_data):
+    structure = raw_data.structure("Sr2TiO4")
+    with pytest.raises(exception.NotImplemented):
+        NeighborList.from_data(structure)[0:2].read(cutoff=4.5)
+
+
+def test_print(raw_data, format_):
+    structure = raw_data.structure("Sr2TiO4")
+    neighbor_list = NeighborList.from_data(structure)
+    actual, _ = format_(neighbor_list)
+    assert actual == {"text/plain": "neighbor list of 7 atoms (Sr, Ti, O)"}
+
+
+def test_factory_methods_access_structure(raw_data):
+    # NeighborList owns no data of its own; from_path/from_file must access the
+    # structure in the schema rather than a nonexistent "neighbor_list" entry.
+    data = raw_data.structure("Sr2TiO4")
+    instances = (NeighborList.from_path(), NeighborList.from_file("vaspout.h5"))
+    calls = (lambda nl: nl.read(cutoff=4.0), lambda nl: str(nl))
+    for neighbor_list in instances:
+        for call in calls:
+            with patch("py4vasp.raw.access") as mock_access:
+                mock_access.return_value.__enter__.return_value = data
+                call(neighbor_list)
+                mock_access.assert_called_once()
+                assert mock_access.call_args.args[0] == "structure"
+
+
+def test_calculation_exposes_neighbor_list():
+    calculation = Calculation.from_path(".")
+    assert isinstance(calculation.neighbor_list, NeighborList)

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -48,7 +48,9 @@ def _raw_structure(lattice, positions, ion_types, number_ion_types):
         raw.Stoichiometry(
             number_ion_types=np.array(number_ion_types), ion_types=ion_types
         ),
-        raw.Cell(lattice_vectors=np.array(lattice, dtype=float), scale=raw.VaspData(1.0)),
+        raw.Cell(
+            lattice_vectors=np.array(lattice, dtype=float), scale=raw.VaspData(1.0)
+        ),
         positions=np.array(positions, dtype=float),
     )
 
@@ -113,19 +115,30 @@ def _compare_maps(actual, expected, Assert):
 def test_simple_cubic_neighbors(Assert):
     # a single atom in a cubic cell of edge 3 Å has exactly its six periodic
     # images within a cutoff between 3 (faces) and 3*sqrt(2)~4.24 (edges).
-    structure = _raw_structure([[3, 0, 0], [0, 3, 0], [0, 0, 3]], [[0, 0, 0]], ["H"], [1])
+    structure = _raw_structure(
+        [[3, 0, 0], [0, 3, 0], [0, 0, 3]], [[0, 0, 0]], ["H"], [1]
+    )
     result = NeighborList.from_data(structure).read(cutoff=3.3)
     assert len(result["distances"]) == 6
     assert np.all(result["indices"] == 0)
     Assert.allclose(result["distances"], np.full(6, 3.0))
     expected_offsets = {
-        (1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)
+        (1, 0, 0),
+        (-1, 0, 0),
+        (0, 1, 0),
+        (0, -1, 0),
+        (0, 0, 1),
+        (0, 0, -1),
     }
-    assert {tuple(int(x) for x in off) for off in result["cell_offsets"]} == expected_offsets
+    assert {
+        tuple(int(x) for x in off) for off in result["cell_offsets"]
+    } == expected_offsets
 
 
 def test_read_returns_expected_fields(Assert):
-    structure = _raw_structure([[3, 0, 0], [0, 3, 0], [0, 0, 3]], [[0, 0, 0]], ["H"], [1])
+    structure = _raw_structure(
+        [[3, 0, 0], [0, 3, 0], [0, 0, 3]], [[0, 0, 0]], ["H"], [1]
+    )
     result = NeighborList.from_data(structure).read(cutoff=3.3)
     assert set(result) == {"indices", "distances", "distance_vectors", "cell_offsets"}
     assert result["indices"].shape == (6, 2)
@@ -158,7 +171,7 @@ def test_neighbor_pairs_are_symmetric():
     structure = _tilted_structure()
     result = NeighborList.from_data(structure).read(cutoff=4.0)
     map_ = _result_to_map(result)
-    for (i, j, ox, oy, oz) in map_:
+    for i, j, ox, oy, oz in map_:
         assert (j, i, -ox, -oy, -oz) in map_
 
 
@@ -379,9 +392,15 @@ def test_selections(raw_data):
     structure = raw_data.structure("Sr2TiO4")
     neighbor_list = NeighborList.from_data(structure)
     assert neighbor_list.selections() == [
-        "Sr~Sr", "Sr~Ti", "Sr~O",
-        "Ti~Sr", "Ti~Ti", "Ti~O",
-        "O~Sr", "O~Ti", "O~O",
+        "Sr~Sr",
+        "Sr~Ti",
+        "Sr~O",
+        "Ti~Sr",
+        "Ti~Ti",
+        "Ti~O",
+        "O~Sr",
+        "O~Ti",
+        "O~O",
     ]
 
 

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -230,6 +230,28 @@ def test_read_unsupported_selection_raises():
         NeighborList.from_data(structure).read("Si:C", cutoff=4.0)
 
 
+def test_read_sorted_by_default():
+    structure = _tilted_structure()
+    distances = NeighborList.from_data(structure).read(cutoff=4.0)["distances"]
+    assert np.all(np.diff(distances) >= 0)
+
+
+def test_read_unsorted_has_same_pairs(Assert):
+    structure = _tilted_structure()
+    neighbor_list = NeighborList.from_data(structure)
+    unsorted = neighbor_list.read(cutoff=4.0, sorted=False)
+    ordered = neighbor_list.read(cutoff=4.0, sorted=True)
+    _compare_maps(_result_to_map(ordered), _result_to_map(unsorted), Assert)
+    Assert.allclose(ordered["distances"], np.sort(unsorted["distances"]))
+
+
+def test_read_sorted_within_selection():
+    structure = _tilted_structure()
+    result = NeighborList.from_data(structure).read("Si~C", cutoff=4.0)
+    distances = result["Si~C"]["distances"]
+    assert np.all(np.diff(distances) >= 0)
+
+
 # --- aliases, steps, print, factory, exposure --------------------------------
 
 

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -1,0 +1,34 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import numpy as np
+import pytest
+
+from py4vasp import raw
+from py4vasp._calculation.neighbor_list import NeighborList, _replica_counts
+
+
+def test_replica_counts_cubic():
+    # A cube of edge a has perpendicular width a along every direction, so the
+    # number of replicas is ceil(cutoff / a) in each direction.
+    lattice = 4.0 * np.eye(3)
+    np.testing.assert_array_equal(_replica_counts(lattice, 4.0), [1, 1, 1])
+    np.testing.assert_array_equal(_replica_counts(lattice, 5.0), [2, 2, 2])
+    np.testing.assert_array_equal(_replica_counts(lattice, 9.0), [3, 3, 3])
+
+
+def test_replica_counts_tilted_cell():
+    # a0 and a1 enclose a small angle (~5.7°). Shearing a1 keeps the volume at 1
+    # but shrinks the perpendicular width along direction 0 to 1/sqrt(1+k^2)=0.1
+    # while the other two directions keep width 1.
+    k = np.sqrt(99.0)
+    lattice = np.array([[1.0, 0.0, 0.0], [k, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    counts = _replica_counts(lattice, 0.95)
+    # ceil(0.95 / 0.1) = 10 replicas are needed along the tilted direction
+    assert counts[0] == 10
+    # the other two directions have width 1, so a single replica suffices
+    assert counts[1] == 1
+    assert counts[2] == 1
+    # a naive |a_i|-based count would use ceil(0.95 / |a0|=1) = 1 replica along
+    # direction 0 and miss neighbors; the perpendicular-width criterion must not.
+    naive = int(np.ceil(0.95 / np.linalg.norm(lattice[0])))
+    assert counts[0] > naive

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -5,7 +5,7 @@ import itertools
 import numpy as np
 import pytest
 
-from py4vasp import raw
+from py4vasp import exception, raw
 from py4vasp._calculation.neighbor_list import NeighborList, _replica_counts
 from py4vasp._calculation.structure import StructureHandler
 
@@ -157,3 +157,64 @@ def test_neighbor_pairs_are_symmetric():
     map_ = _result_to_map(result)
     for (i, j, ox, oy, oz) in map_:
         assert (j, i, -ox, -oy, -oz) in map_
+
+
+# --- selection ---------------------------------------------------------------
+
+
+def _elements(structure):
+    return StructureHandler.from_data(structure).to_dict()["elements"]
+
+
+def _filter_map(brute_map, elements, source_type, neighbor_type=None):
+    return {
+        key: value
+        for key, value in brute_map.items()
+        if elements[key[0]] == source_type
+        and (neighbor_type is None or elements[key[1]] == neighbor_type)
+    }
+
+
+def test_read_pair_selection(Assert):
+    structure = _tilted_structure()
+    elements = _elements(structure)
+    result = NeighborList.from_data(structure).read("Si~C", cutoff=4.0)
+    assert set(result) == {"Si~C"}
+    expected = _filter_map(_brute_force_map(structure, 4.0), elements, "Si", "C")
+    _compare_maps(_result_to_map(result["Si~C"]), expected, Assert)
+
+
+def test_read_pair_selection_reversed(Assert):
+    structure = _tilted_structure()
+    elements = _elements(structure)
+    result = NeighborList.from_data(structure).read("C~Si", cutoff=4.0)
+    expected = _filter_map(_brute_force_map(structure, 4.0), elements, "C", "Si")
+    _compare_maps(_result_to_map(result["C~Si"]), expected, Assert)
+
+
+def test_read_bare_element_selection(Assert):
+    structure = _tilted_structure()
+    elements = _elements(structure)
+    result = NeighborList.from_data(structure).read("Si", cutoff=4.0)
+    expected = _filter_map(_brute_force_map(structure, 4.0), elements, "Si")
+    _compare_maps(_result_to_map(result["Si"]), expected, Assert)
+
+
+def test_read_multiple_selections(Assert):
+    structure = _tilted_structure()
+    elements = _elements(structure)
+    result = NeighborList.from_data(structure).read("Si~C, C~C", cutoff=4.0)
+    assert set(result) == {"Si~C", "C~C"}
+    brute = _brute_force_map(structure, 4.0)
+    _compare_maps(
+        _result_to_map(result["Si~C"]), _filter_map(brute, elements, "Si", "C"), Assert
+    )
+    _compare_maps(
+        _result_to_map(result["C~C"]), _filter_map(brute, elements, "C", "C"), Assert
+    )
+
+
+def test_read_unknown_element_raises():
+    structure = _tilted_structure()
+    with pytest.raises(exception.IncorrectUsage):
+        NeighborList.from_data(structure).read("Xx~C", cutoff=4.0)

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -12,6 +12,10 @@ from py4vasp._calculation import Calculation
 from py4vasp._calculation.neighbor_list import NeighborList, _replica_counts
 from py4vasp._calculation.structure import StructureHandler
 
+# NeighborList runs its pair search with scipy's cKDTree, which is not part of the
+# py4vasp-core install. Skip the whole module when scipy is unavailable.
+pytest.importorskip("scipy")
+
 
 def test_replica_counts_cubic():
     # A cube of edge a has perpendicular width a along every direction, so the

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -287,7 +287,9 @@ def test_selections(raw_data):
     structure = raw_data.structure("Sr2TiO4")
     neighbor_list = NeighborList.from_data(structure)
     assert neighbor_list.selections() == [
-        "Sr~Sr", "Sr~Ti", "Sr~O", "Ti~Ti", "Ti~O", "O~O"
+        "Sr~Sr", "Sr~Ti", "Sr~O",
+        "Ti~Sr", "Ti~Ti", "Ti~O",
+        "O~Sr", "O~Ti", "O~O",
     ]
 
 
@@ -298,3 +300,15 @@ def test_selections_are_valid(raw_data):
     for selection in neighbor_list.selections():
         result = neighbor_list.read(selection, cutoff=3.5)
         assert set(result) == {selection}
+
+
+def test_selections_partition_all_pairs(raw_data):
+    # iterating over selections must cover every pair of the full list exactly once
+    structure = raw_data.structure("Sr2TiO4")
+    neighbor_list = NeighborList.from_data(structure)
+    total = len(neighbor_list.read(cutoff=3.5)["distances"])
+    per_selection = sum(
+        len(neighbor_list.read(selection, cutoff=3.5)[selection]["distances"])
+        for selection in neighbor_list.selections()
+    )
+    assert per_selection == total

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -1,6 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import itertools
+from collections import Counter
 from unittest.mock import patch
 
 import numpy as np
@@ -256,11 +257,45 @@ def test_read_multiple_steps_not_implemented(raw_data):
         NeighborList.from_data(structure)[0:2].read(cutoff=4.5)
 
 
+_HEADER = " ion  position               nearest neighbor table"
+
+
 def test_print(raw_data, format_):
-    structure = raw_data.structure("Sr2TiO4")
+    # a single atom in a cubic cell of edge 2.5 Å has its six periodic images as
+    # nearest neighbors (all at 2.50 Å) within the default 3.0 Å print cutoff.
+    structure = _raw_structure(
+        [[2.5, 0, 0], [0, 2.5, 0], [0, 0, 2.5]], [[0, 0, 0]], ["H"], [1]
+    )
     neighbor_list = NeighborList.from_data(structure)
+    row = "   1  0.000  0.000  0.000-" + "   1 2.50" * 6
     actual, _ = format_(neighbor_list)
-    assert actual == {"text/plain": "neighbor list of 7 atoms (Sr, Ti, O)"}
+    assert actual == {"text/plain": f"{_HEADER}\n{row}"}
+
+
+def test_str_uses_default_cutoff(raw_data):
+    structure = raw_data.structure("SrTiO3")
+    neighbor_list = NeighborList.from_data(structure)
+    assert str(neighbor_list) == neighbor_list.to_string(cutoff=3.0)
+
+
+def test_to_string_lists_all_neighbors_sorted(raw_data):
+    structure = raw_data.structure("SrTiO3")
+    neighbor_list = NeighborList.from_data(structure)
+    reference = neighbor_list.read(cutoff=3.0)
+    counts = Counter(int(atom) for atom in reference["indices"][:, 0])
+    lines = neighbor_list.to_string(cutoff=3.0).splitlines()
+    assert lines[0] == _HEADER
+    seen = {}
+    for line in lines[1:]:
+        ion = int(line[:4])
+        tokens = line[26:].split()  # neighbor block starts after the fixed columns
+        neighbor_indices = [int(token) for token in tokens[0::2]]
+        neighbor_distances = [float(token) for token in tokens[1::2]]
+        assert neighbor_distances == sorted(neighbor_distances)
+        assert all(1 <= index <= 5 for index in neighbor_indices)  # 5 atoms, 1-based
+        if neighbor_indices:
+            seen[ion - 1] = len(neighbor_indices)
+    assert seen == dict(counts)
 
 
 def test_factory_methods_access_structure(raw_data):

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -1,10 +1,13 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import itertools
+
 import numpy as np
 import pytest
 
 from py4vasp import raw
 from py4vasp._calculation.neighbor_list import NeighborList, _replica_counts
+from py4vasp._calculation.structure import StructureHandler
 
 
 def test_replica_counts_cubic():
@@ -32,3 +35,125 @@ def test_replica_counts_tilted_cell():
     # direction 0 and miss neighbors; the perpendicular-width criterion must not.
     naive = int(np.ceil(0.95 / np.linalg.norm(lattice[0])))
     assert counts[0] > naive
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _raw_structure(lattice, positions, ion_types, number_ion_types):
+    return raw.Structure(
+        raw.Stoichiometry(
+            number_ion_types=np.array(number_ion_types), ion_types=ion_types
+        ),
+        raw.Cell(lattice_vectors=np.array(lattice, dtype=float), scale=raw.VaspData(1.0)),
+        positions=np.array(positions, dtype=float),
+    )
+
+
+def _tilted_structure():
+    """A strongly sheared cell (a0, a1 enclose a small angle) with four atoms."""
+    lattice = [[3.0, 0.0, 0.0], [2.9, 0.8, 0.0], [0.1, 0.2, 3.0]]
+    positions = [
+        [0.0, 0.0, 0.0],
+        [0.5, 0.5, 0.5],
+        [0.25, 0.1, 0.6],
+        [0.7, 0.8, 0.2],
+    ]
+    return _raw_structure(lattice, positions, ["Si", "C"], [2, 2])
+
+
+def _brute_force_map(raw_structure, cutoff):
+    """Independent O(N^2) neighbor search over an over-generous set of images."""
+    handler = StructureHandler.from_data(raw_structure)
+    lattice = np.asarray(handler.lattice_vectors())
+    home = (np.asarray(handler.positions()) % 1.0) @ lattice
+    volume = np.abs(np.linalg.det(lattice))
+    cross = np.cross(lattice[[1, 2, 0]], lattice[[2, 0, 1]])
+    reps = np.ceil(cutoff / (volume / np.linalg.norm(cross, axis=1))).astype(int) + 1
+    offsets = itertools.product(*[range(-r, r + 1) for r in reps])
+    result = {}
+    for offset in offsets:
+        shift = np.array(offset, dtype=float) @ lattice
+        for i in range(len(home)):
+            for j in range(len(home)):
+                vector = home[j] + shift - home[i]
+                distance = np.linalg.norm(vector)
+                if 0 < distance <= cutoff:
+                    result[(i, j, *offset)] = (distance, vector)
+    return result
+
+
+def _result_to_map(result):
+    """Reshape a flat neighbor-list dict into {(i, j, offset): (distance, vector)}."""
+    indices = np.asarray(result["indices"])
+    offsets = np.asarray(result["cell_offsets"])
+    distances = np.asarray(result["distances"])
+    vectors = np.asarray(result["distance_vectors"])
+    map_ = {}
+    for row in range(len(distances)):
+        i, j = indices[row]
+        key = (int(i), int(j), *(int(x) for x in offsets[row]))
+        map_[key] = (distances[row], vectors[row])
+    return map_
+
+
+def _compare_maps(actual, expected, Assert):
+    assert set(actual) == set(expected)
+    for key, (distance, vector) in expected.items():
+        Assert.allclose(actual[key][0], distance)
+        Assert.allclose(actual[key][1], vector)
+
+
+# --- default (all pairs) -----------------------------------------------------
+
+
+def test_simple_cubic_neighbors(Assert):
+    # a single atom in a cubic cell of edge 3 Å has exactly its six periodic
+    # images within a cutoff between 3 (faces) and 3*sqrt(2)~4.24 (edges).
+    structure = _raw_structure([[3, 0, 0], [0, 3, 0], [0, 0, 3]], [[0, 0, 0]], ["H"], [1])
+    result = NeighborList.from_data(structure).read(cutoff=3.3)
+    assert len(result["distances"]) == 6
+    assert np.all(result["indices"] == 0)
+    Assert.allclose(result["distances"], np.full(6, 3.0))
+    expected_offsets = {
+        (1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)
+    }
+    assert {tuple(int(x) for x in off) for off in result["cell_offsets"]} == expected_offsets
+
+
+def test_read_returns_expected_fields(Assert):
+    structure = _raw_structure([[3, 0, 0], [0, 3, 0], [0, 0, 3]], [[0, 0, 0]], ["H"], [1])
+    result = NeighborList.from_data(structure).read(cutoff=3.3)
+    assert set(result) == {"indices", "distances", "distance_vectors", "cell_offsets"}
+    assert result["indices"].shape == (6, 2)
+    assert result["distance_vectors"].shape == (6, 3)
+    assert result["cell_offsets"].shape == (6, 3)
+    assert np.issubdtype(result["indices"].dtype, np.integer)
+    assert np.issubdtype(result["cell_offsets"].dtype, np.integer)
+    assert np.issubdtype(result["distances"].dtype, np.floating)
+
+
+@pytest.mark.parametrize(
+    "name, cutoff",
+    [("SrTiO3", 4.3), ("ZnS", 4.1), ("BN", 3.7), ("Sr2TiO4", 4.5)],
+)
+def test_read_matches_brute_force(name, cutoff, raw_data, Assert):
+    structure = raw_data.structure(name)
+    result = NeighborList.from_data(structure).read(cutoff=cutoff)
+    _compare_maps(_result_to_map(result), _brute_force_map(structure, cutoff), Assert)
+
+
+def test_read_matches_brute_force_tilted_cell(Assert):
+    # robustness for a strongly sheared cell (small enclosed angle)
+    structure = _tilted_structure()
+    result = NeighborList.from_data(structure).read(cutoff=4.0)
+    _compare_maps(_result_to_map(result), _brute_force_map(structure, 4.0), Assert)
+
+
+def test_neighbor_pairs_are_symmetric():
+    # every (i, j, offset) has its mirror (j, i, -offset)
+    structure = _tilted_structure()
+    result = NeighborList.from_data(structure).read(cutoff=4.0)
+    map_ = _result_to_map(result)
+    for (i, j, ox, oy, oz) in map_:
+        assert (j, i, -ox, -oy, -oz) in map_

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -262,20 +262,38 @@ _HEADER = " ion  position               nearest neighbor table"
 
 def test_print(raw_data, format_):
     # a single atom in a cubic cell of edge 2.5 Å has its six periodic images as
-    # nearest neighbors (all at 2.50 Å) within the default 3.0 Å print cutoff.
+    # nearest neighbors (all at 2.50 Å) within the default 3.5 Å print cutoff.
     structure = _raw_structure(
         [[2.5, 0, 0], [0, 2.5, 0], [0, 0, 2.5]], [[0, 0, 0]], ["H"], [1]
     )
     neighbor_list = NeighborList.from_data(structure)
     row = "   1  0.000  0.000  0.000-" + "   1 2.50" * 6
+    expected = f"(neighbors within 3.5 Å)\n{_HEADER}\n{row}"
     actual, _ = format_(neighbor_list)
-    assert actual == {"text/plain": f"{_HEADER}\n{row}"}
+    assert actual == {"text/plain": expected}
 
 
 def test_str_uses_default_cutoff(raw_data):
     structure = raw_data.structure("SrTiO3")
     neighbor_list = NeighborList.from_data(structure)
-    assert str(neighbor_list) == neighbor_list.to_string(cutoff=3.0)
+    assert str(neighbor_list) == neighbor_list.to_string(cutoff=3.5)
+
+
+def _parse_table(text):
+    """Parse a neighbor-table string into (lines, {ion0: [(neighbor1, dist), ...]})."""
+    lines = text.splitlines()
+    per_ion = {}
+    current = None
+    for line in lines[2:]:  # skip the cutoff line and the column header
+        tokens = line[26:].split()  # neighbor block starts after the fixed columns
+        contacts = list(
+            zip((int(t) for t in tokens[0::2]), (float(t) for t in tokens[1::2]))
+        )
+        if line[:26].strip():  # the first line of an ion carries index + position
+            current = int(line[:4]) - 1
+            per_ion[current] = []
+        per_ion[current].extend(contacts)
+    return lines, per_ion
 
 
 def test_to_string_lists_all_neighbors_sorted(raw_data):
@@ -283,19 +301,26 @@ def test_to_string_lists_all_neighbors_sorted(raw_data):
     neighbor_list = NeighborList.from_data(structure)
     reference = neighbor_list.read(cutoff=3.0)
     counts = Counter(int(atom) for atom in reference["indices"][:, 0])
-    lines = neighbor_list.to_string(cutoff=3.0).splitlines()
-    assert lines[0] == _HEADER
-    seen = {}
-    for line in lines[1:]:
-        ion = int(line[:4])
-        tokens = line[26:].split()  # neighbor block starts after the fixed columns
-        neighbor_indices = [int(token) for token in tokens[0::2]]
-        neighbor_distances = [float(token) for token in tokens[1::2]]
-        assert neighbor_distances == sorted(neighbor_distances)
-        assert all(1 <= index <= 5 for index in neighbor_indices)  # 5 atoms, 1-based
-        if neighbor_indices:
-            seen[ion - 1] = len(neighbor_indices)
-    assert seen == dict(counts)
+    lines, per_ion = _parse_table(neighbor_list.to_string(cutoff=3.0))
+    assert lines[0] == "(neighbors within 3.0 Å)"
+    assert lines[1] == _HEADER
+    for contacts in per_ion.values():
+        distances = [distance for _, distance in contacts]
+        indices = [index for index, _ in contacts]
+        assert distances == sorted(distances)
+        assert all(1 <= index <= 5 for index in indices)  # 5 atoms, 1-based
+    assert {atom: len(contacts) for atom, contacts in per_ion.items()} == dict(counts)
+
+
+def test_to_string_wraps_at_eight_neighbors(raw_data):
+    # in SrTiO3 at 3 Å the octahedral O sites have 14 neighbors, forcing a wrap
+    structure = raw_data.structure("SrTiO3")
+    neighbor_list = NeighborList.from_data(structure)
+    lines = neighbor_list.to_string(cutoff=3.0).splitlines()[2:]
+    for line in lines:
+        assert len(line[26:].split()) // 2 <= 8  # at most 8 neighbors per line
+    # a wrapped ion emits a continuation line indented under the neighbor column
+    assert any(line.startswith(" " * 26) and line.strip() for line in lines)
 
 
 def test_factory_methods_access_structure(raw_data):

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -15,6 +15,7 @@ from py4vasp._calculation import (  # noqa: F401 — imports submodules as _calc
     force,
     kpoint,
     local_moment,
+    neighbor_list,
     optics,
     projector,
     structure,
@@ -46,6 +47,7 @@ def _all_calculation_examples():
         + find_examples(_calculation.force)
         + find_examples(_calculation.kpoint)
         + find_examples(_calculation.local_moment)
+        + find_examples(_calculation.neighbor_list)
         + find_examples(_calculation.optics)
         + find_examples(_calculation.projector)
         + find_examples(_calculation.structure)
@@ -60,6 +62,7 @@ def _all_calculation_examples():
 # mapped to the package it needs; they run in test_calculation_full which skips via
 # importorskip when that package is missing. Everything else runs in test_calculation.
 _FULL_INSTALL_EXAMPLES = {
+    "py4vasp._calculation.neighbor_list.NeighborList.read": "scipy",
     "py4vasp._calculation.optics.Optics.color": "scipy",
     "py4vasp._calculation.symmetry.Symmetry.space_group": "spglib",
     "py4vasp._calculation.symmetry.Symmetry.point_group_schoenflies": "spglib",

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -63,6 +63,7 @@ def _all_calculation_examples():
 # importorskip when that package is missing. Everything else runs in test_calculation.
 _FULL_INSTALL_EXAMPLES = {
     "py4vasp._calculation.neighbor_list.NeighborList.read": "scipy",
+    "py4vasp._calculation.neighbor_list.NeighborList.to_string": "scipy",
     "py4vasp._calculation.optics.Optics.color": "scipy",
     "py4vasp._calculation.symmetry.Symmetry.space_group": "spglib",
     "py4vasp._calculation.symmetry.Symmetry.point_group_schoenflies": "spglib",


### PR DESCRIPTION
Adds a new `NeighborList` quantity that computes all atom pairs within a cutoff
radius under periodic boundary conditions, derived from the existing `Structure`
data (no new schema).

- Robust for very tilted cells: replica counts from perpendicular cell widths.
- N log N search via scipy `cKDTree` over explicit periodic images; numpy for the
  distance/vector math. Validated against an independent brute-force N² oracle
  across several structures and a strongly sheared cell.
- `read(selection=None, *, cutoff, sorted=True)` returns per-pair `indices`,
  `distances`, `distance_vectors`, and `cell_offsets`; `cutoff` is required,
  results sorted by increasing distance by default.
- `"X~Y"` atom-type pair selections (directional), combinable; `selections()`
  lists all ordered type pairs.
- `print`/`to_string(cutoff=3.5)` renders a VASP OUTCAR-style nearest-neighbor
  table, wrapping at 8 neighbors per line with a `(neighbors within R Å)` header.
