### PR TITLE
Feat: Add Structure.symmetrize and a py4vasp symmetrize CLI command

### DIFF
--- a/src/py4vasp/_calculation/_stoichiometry.py
+++ b/src/py4vasp/_calculation/_stoichiometry.py
@@ -423,9 +423,14 @@ class Stoichiometry:
 
 def raw_stoichiometry_from_ase(structure):
     """Convert the given ase Atoms object to a raw.Stoichiometry."""
+    return raw_stoichiometry_from_elements(list(structure.symbols))
+
+
+def raw_stoichiometry_from_elements(elements):
+    """Run-length encode a per-atom element sequence into a raw.Stoichiometry."""
     number_ion_types = []
     ion_types = []
-    for element in structure.symbols:
+    for element in elements:
         if ion_types and ion_types[-1] == element:
             number_ion_types[-1] += 1
         else:

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -374,9 +374,13 @@ Atoms # atomic
             lattice, positions, numbers = spglib.standardize_cell(
                 cell, to_primitive=True, no_idealize=False, symprec=symprec
             )
-            positions, elements = _group_by_species(positions, numbers, element_of_number)
+            positions, elements = _group_by_species(
+                positions, numbers, element_of_number
+            )
         else:
-            lattice, positions = _symmetrize_in_cell(lattice, positions, numbers, symprec)
+            lattice, positions = _symmetrize_in_cell(
+                lattice, positions, numbers, symprec
+            )
         return _raw_structure(lattice, positions, elements)
 
     def to_database(self, steps=-1) -> StructureModel:
@@ -1629,9 +1633,13 @@ def _cell_from_ase(structure):
 
 def _species_numbers(elements):
     """Map each atom's element to a consecutive integer species number for spglib."""
-    number_of_element = {element: number for number, element in enumerate(dict.fromkeys(elements))}
+    number_of_element = {
+        element: number for number, element in enumerate(dict.fromkeys(elements))
+    }
     numbers = [number_of_element[element] for element in elements]
-    element_of_number = {number: element for element, number in number_of_element.items()}
+    element_of_number = {
+        number: element for element, number in number_of_element.items()
+    }
     return numbers, element_of_number
 
 

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -353,6 +353,32 @@ Atoms # atomic
         _, orbits = np.unique(labels, return_inverse=True)
         return orbits
 
+    def symmetrize(self, to_primitive=False, symprec=_SYMPREC):
+        """Snap the atoms onto their high-symmetry positions for a single frame.
+
+        The symmetry is derived from the bare geometry with spglib, so this works
+        even for structures that do not carry VASP's symmetry information (e.g. one
+        read from a POSCAR file). With *to_primitive* the cell is reduced to its
+        idealized primitive form; otherwise the input cell and the number of atoms
+        are kept and the atoms are snapped onto their exact symmetric positions.
+        """
+        positions = self.positions()
+        if positions.ndim == 3:
+            message = "Symmetrizing multiple steps is not implemented."
+            raise exception.NotImplemented(message)
+        lattice = self.lattice_vectors()
+        elements = self._stoichiometry().elements()
+        numbers, element_of_number = _species_numbers(elements)
+        cell = (lattice, positions, numbers)
+        if to_primitive:
+            lattice, positions, numbers = spglib.standardize_cell(
+                cell, to_primitive=True, no_idealize=False, symprec=symprec
+            )
+            positions, elements = _group_by_species(positions, numbers, element_of_number)
+        else:
+            lattice, positions = _symmetrize_in_cell(lattice, positions, numbers, symprec)
+        return _raw_structure(lattice, positions, elements)
+
     def to_database(self, steps=-1) -> StructureModel:
         """Return database-ready data for a single structure geometry.
 
@@ -1414,6 +1440,54 @@ class Structure(view.Mixin):
             StructureHandler.standardized_cell,
         )
 
+    def symmetrize(self, to_primitive=False, symprec=_SYMPREC):
+        """Symmetrize the structure and return it as a new :class:`Structure`.
+
+        spglib derives the symmetry from the bare geometry, so this works for any
+        single structure, including one read from a POSCAR file that carries no
+        symmetry information. Reading the returned structure yields the same result
+        you would obtain from a VASP calculation on the symmetrized structure.
+
+        Parameters
+        ----------
+        to_primitive : bool
+            If False (default) the input cell and the number of atoms are kept and
+            only the atoms are snapped onto their exact high-symmetry positions. If
+            True the cell is reduced to its idealized primitive form, which may
+            change the number of atoms.
+        symprec : float
+            Distance tolerance (in Å) spglib uses to detect the symmetry. Increase
+            it to symmetrize structures that deviate more strongly from the ideal
+            positions.
+
+        Returns
+        -------
+        Structure
+            A new structure with the atoms on their high-symmetry positions.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path, "perovskite")
+
+        Symmetrizing the cubic perovskite and reducing it to the primitive cell
+        leaves the five atoms of the SrTiO3 formula unit.
+
+        >>> symmetrized = calculation.structure.symmetrize(to_primitive=True)
+        >>> symmetrized.read()["elements"]
+        ['Sr', 'Ti', 'O', 'O', 'O']
+        """
+        raw_structure = merge_default(
+            self._source,
+            self._quantity_name,
+            None,
+            self._handler_factory,
+            StructureHandler.symmetrize,
+            to_primitive,
+            symprec,
+        )
+        return Structure.from_data(raw_structure)
+
     def prototype(self):
         """Determine the AFLOW prototype label of the crystal.
 
@@ -1551,6 +1625,63 @@ def _same_geometry(first, second):
 def _cell_from_ase(structure):
     lattice_vectors = np.array([structure.get_cell()])
     return raw.Cell(lattice_vectors, scale=raw.VaspData(1.0))
+
+
+def _species_numbers(elements):
+    """Map each atom's element to a consecutive integer species number for spglib."""
+    number_of_element = {element: number for number, element in enumerate(dict.fromkeys(elements))}
+    numbers = [number_of_element[element] for element in elements]
+    element_of_number = {number: element for element, number in number_of_element.items()}
+    return numbers, element_of_number
+
+
+def _group_by_species(positions, numbers, element_of_number):
+    """Group atoms of the same species contiguously, keeping the input species order."""
+    order = np.argsort(numbers, kind="stable")
+    positions = np.array(positions)[order]
+    elements = [element_of_number[int(numbers[index])] for index in order]
+    return positions, elements
+
+
+def _symmetrize_in_cell(lattice, positions, numbers, symprec):
+    """Snap the atoms onto their high-symmetry positions keeping the cell.
+
+    spglib only idealizes the positions in its standardized setting. Following
+    ``ase.spacegroup.symmetrize``, the idealized standard positions are rotated
+    back into the input orientation and mapped onto the original atoms via the
+    primitive-cell correspondence. This preserves the input number of atoms and
+    their ordering while idealizing the cell to be exactly consistent with the
+    detected symmetry.
+    """
+    cell = (lattice, positions, numbers)
+    dataset = spglib.get_symmetry_dataset(cell, symprec=symprec)
+    primitive_lattice = spglib.find_primitive(cell, symprec=symprec)[0]
+    rotation = dataset.std_rotation_matrix
+    ideal_cartesian = dataset.std_positions @ (dataset.std_lattice @ rotation)
+    cartesian = positions @ lattice
+    atom_to_primitive = list(dataset.mapping_to_primitive)
+    ideal_to_primitive = list(dataset.std_mapping_to_primitive)
+    reference = ideal_cartesian[ideal_to_primitive.index(0)]
+    aligned = ideal_cartesian + (cartesian[atom_to_primitive.index(0)] - reference)
+    primitive = primitive_lattice @ rotation
+    inverse_primitive = np.linalg.inv(primitive)
+    symmetrized = np.zeros_like(cartesian)
+    for atom, primitive_index in enumerate(atom_to_primitive):
+        ideal = aligned[ideal_to_primitive.index(primitive_index)]
+        shift = np.rint((ideal - cartesian[atom]) @ inverse_primitive)
+        symmetrized[atom] = ideal - shift @ primitive
+    new_lattice = dataset.transformation_matrix.T @ dataset.std_lattice @ rotation
+    new_positions = np.remainder(symmetrized @ np.linalg.inv(new_lattice), 1)
+    return new_lattice, new_positions
+
+
+def _raw_structure(lattice_vectors, positions, elements):
+    """Assemble a single-frame raw.Structure from lattice, positions, and elements."""
+    return raw.Structure(
+        stoichiometry=_stoichiometry.raw_stoichiometry_from_elements(elements),
+        cell=raw.Cell(np.array(lattice_vectors), scale=raw.VaspData(1.0)),
+        positions=np.array(positions),
+    )
 
 
 def _stoichiometry_prefix(elements):

--- a/src/py4vasp/cli.py
+++ b/src/py4vasp/cli.py
@@ -6,6 +6,10 @@ import click
 
 import py4vasp
 from py4vasp import exception
+from py4vasp._calculation.structure import Structure
+from py4vasp._calculation.symmetry import _SYMPREC
+
+_HDF5_SUFFIXES = (".h5", ".hdf5")
 
 
 @click.group()
@@ -54,3 +58,41 @@ def _convert_to_lammps(path, selection):
     else:
         result = calculation.structure.to_lammps(selection=selection)
     return result
+
+
+@cli.command()
+@click.argument(
+    "file", type=click.Path(exists=True, readable=True, path_type=pathlib.Path)
+)
+@click.option(
+    "-p",
+    "--primitive",
+    is_flag=True,
+    help="Reduce the structure to its primitive cell instead of keeping the input cell.",
+)
+@click.option(
+    "--symprec",
+    type=float,
+    default=_SYMPREC,
+    show_default=True,
+    help="Symmetry tolerance in Å passed to spglib.",
+)
+def symmetrize(file, primitive, symprec):
+    """Symmetrize the structure in FILE and write it in POSCAR format.
+
+    FILE may be a POSCAR, CONTCAR, or HDF5 file containing a structure. By default
+    the symmetrized structure is written in POSCAR format to stdout.
+    """
+    try:
+        structure = _read_structure(file)
+        result = structure.symmetrize(to_primitive=primitive, symprec=symprec)
+        poscar = result.to_POSCAR()
+    except exception.Py4VaspError as error:
+        raise click.ClickException(*error.args) from error
+    print(poscar)
+
+
+def _read_structure(file):
+    if file.suffix in _HDF5_SUFFIXES:
+        return py4vasp.Calculation.from_file(file).structure
+    return Structure.from_POSCAR(file.read_text())

--- a/src/py4vasp/cli.py
+++ b/src/py4vasp/cli.py
@@ -77,22 +77,50 @@ def _convert_to_lammps(path, selection):
     show_default=True,
     help="Symmetry tolerance in Å passed to spglib.",
 )
-def symmetrize(file, primitive, symprec):
+@click.option(
+    "-i",
+    "--in-place",
+    "in_place",
+    is_flag=True,
+    help="Overwrite FILE with the symmetrized structure.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=pathlib.Path),
+    help="Write the symmetrized structure to this file instead of stdout.",
+)
+def symmetrize(file, primitive, symprec, in_place, output):
     """Symmetrize the structure in FILE and write it in POSCAR format.
 
     FILE may be a POSCAR, CONTCAR, or HDF5 file containing a structure. By default
-    the symmetrized structure is written in POSCAR format to stdout.
+    the symmetrized structure is written in POSCAR format to stdout; use
+    -o/--output or -i/--in-place to write it to a file instead.
     """
+    if in_place and output:
+        message = "The options -i/--in-place and -o/--output are mutually exclusive."
+        raise click.UsageError(message)
+    destination = file if in_place else output
     try:
+        _raise_if_hdf5_output(destination)
         structure = _read_structure(file)
         result = structure.symmetrize(to_primitive=primitive, symprec=symprec)
         poscar = result.to_POSCAR()
     except exception.Py4VaspError as error:
         raise click.ClickException(*error.args) from error
-    print(poscar)
+    if destination is None:
+        print(poscar)
+    else:
+        destination.write_text(poscar)
 
 
 def _read_structure(file):
     if file.suffix in _HDF5_SUFFIXES:
         return py4vasp.Calculation.from_file(file).structure
     return Structure.from_POSCAR(file.read_text())
+
+
+def _raise_if_hdf5_output(destination):
+    if destination is not None and destination.suffix in _HDF5_SUFFIXES:
+        message = "Writing the symmetrized structure to an HDF5 file is not implemented."
+        raise exception.NotImplemented(message)

--- a/src/py4vasp/cli.py
+++ b/src/py4vasp/cli.py
@@ -122,5 +122,7 @@ def _read_structure(file):
 
 def _raise_if_hdf5_output(destination):
     if destination is not None and destination.suffix in _HDF5_SUFFIXES:
-        message = "Writing the symmetrized structure to an HDF5 file is not implemented."
+        message = (
+            "Writing the symmetrized structure to an HDF5 file is not implemented."
+        )
         raise exception.NotImplemented(message)

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -911,7 +911,9 @@ def test_symmetrize_to_primitive_reduces_atoms(Assert):
 def test_symmetrize_to_primitive_keeps_species_order(Assert):
     spglib = pytest.importorskip("spglib")
     poscar = _perovskite_poscar(_IDEAL_PEROVSKITE + _PEROVSKITE_DISTORTION)
-    actual = Structure.from_POSCAR(poscar).symmetrize(to_primitive=True, symprec=0.1).read()
+    actual = (
+        Structure.from_POSCAR(poscar).symmetrize(to_primitive=True, symprec=0.1).read()
+    )
     # the primitive and conventional cells coincide for cubic perovskite
     assert actual["elements"] == ["Sr", "Ti", "O", "O", "O"]
     cell = (actual["lattice_vectors"], actual["positions"], [0, 1, 2, 2, 2])

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -879,3 +879,40 @@ def test_symmetrize_multiple_steps_not_implemented(Sr2TiO4):
     pytest.importorskip("spglib")
     with pytest.raises(exception.NotImplemented):
         Sr2TiO4[:].symmetrize()
+
+
+_BCC_POSCAR = """\
+Fe
+3.0
+1.0 0.0 0.0
+0.0 1.0 0.0
+0.0 0.0 1.0
+Fe
+2
+Direct
+0.002 0.000 -0.001
+0.500 0.501 0.499"""
+
+
+def test_symmetrize_to_primitive_reduces_atoms(Assert):
+    spglib = pytest.importorskip("spglib")
+    primitive = Structure.from_POSCAR(_BCC_POSCAR).symmetrize(
+        to_primitive=True, symprec=0.1
+    )
+    assert isinstance(primitive, Structure)
+    actual = primitive.read()
+    # the body-centered conventional cell reduces to a single-atom primitive cell
+    assert actual["elements"] == ["Fe"]
+    Assert.allclose(primitive.volume(), 13.5)
+    cell = (actual["lattice_vectors"], actual["positions"], [0])
+    assert spglib.get_symmetry_dataset(cell, symprec=1e-5).number == 229
+
+
+def test_symmetrize_to_primitive_keeps_species_order(Assert):
+    spglib = pytest.importorskip("spglib")
+    poscar = _perovskite_poscar(_IDEAL_PEROVSKITE + _PEROVSKITE_DISTORTION)
+    actual = Structure.from_POSCAR(poscar).symmetrize(to_primitive=True, symprec=0.1).read()
+    # the primitive and conventional cells coincide for cubic perovskite
+    assert actual["elements"] == ["Sr", "Ti", "O", "O", "O"]
+    cell = (actual["lattice_vectors"], actual["positions"], [0, 1, 2, 2, 2])
+    assert spglib.get_symmetry_dataset(cell, symprec=1e-5).number == 221

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -784,3 +784,98 @@ def test_to_database_prototype_absent_without_symmetry(Sr2TiO4):
     # structures without symmetry (or without spglib) leave the field empty
     handler = StructureHandler.from_data(Sr2TiO4.ref.raw_data)
     assert handler.to_database().prototype is None
+
+
+# ---------------------------------------------------------------------------
+# Symmetrize (derived from the bare geometry, no VASP symmetry data required)
+# ---------------------------------------------------------------------------
+
+_IDEAL_PEROVSKITE = np.array(
+    [
+        [0.0, 0.0, 0.0],  # Sr
+        [0.5, 0.5, 0.5],  # Ti
+        [0.5, 0.5, 0.0],  # O
+        [0.5, 0.0, 0.5],  # O
+        [0.0, 0.5, 0.5],  # O
+    ]
+)
+# small generic displacements (< symprec=0.1) that break the cubic symmetry
+_PEROVSKITE_DISTORTION = np.array(
+    [
+        [0.004, -0.003, 0.002],
+        [-0.002, 0.004, -0.003],
+        [0.003, 0.002, -0.004],
+        [-0.004, -0.002, 0.003],
+        [0.002, 0.003, -0.002],
+    ]
+)
+# a snapped special position matches the ideal one to well below this tolerance
+_SNAP_TOLERANCE = 1e8  # Assert.allclose scales this by 1e-14 -> atol/rtol = 1e-6
+
+
+def _perovskite_poscar(positions):
+    lines = [
+        "SrTiO3",
+        "4.0",
+        "1.0 0.0 0.0",
+        "0.0 1.0 0.0",
+        "0.0 0.0 1.0",
+        "Sr Ti O",
+        "1 1 3",
+        "Direct",
+    ]
+    lines += [" ".join(f"{x:.10f}" for x in position) for position in positions]
+    return "\n".join(lines)
+
+
+def _positions_relative_to_first_atom(positions):
+    """The symmetrized structure is anchored to the first atom, so compare offsets."""
+    return np.remainder(np.array(positions) - positions[0], 1)
+
+
+def test_symmetrize_snaps_atoms_keeping_the_cell(Assert):
+    pytest.importorskip("spglib")
+    poscar = _perovskite_poscar(_IDEAL_PEROVSKITE + _PEROVSKITE_DISTORTION)
+    symmetrized = Structure.from_POSCAR(poscar).symmetrize(symprec=0.1)
+    assert isinstance(symmetrized, Structure)
+    actual = symmetrized.read()
+    # the cell and the number and order of atoms are preserved
+    Assert.allclose(actual["lattice_vectors"], 4.0 * np.eye(3))
+    assert actual["elements"] == ["Sr", "Ti", "O", "O", "O"]
+    # the atoms are snapped onto the ideal cubic perovskite geometry
+    relative = _positions_relative_to_first_atom(actual["positions"])
+    Assert.allclose(relative, _IDEAL_PEROVSKITE, tolerance=_SNAP_TOLERANCE)
+
+
+def test_symmetrize_result_is_symmetric():
+    spglib = pytest.importorskip("spglib")
+    poscar = _perovskite_poscar(_IDEAL_PEROVSKITE + _PEROVSKITE_DISTORTION)
+    symmetrized = Structure.from_POSCAR(poscar).symmetrize(symprec=0.1).read()
+    cell = (symmetrized["lattice_vectors"], symmetrized["positions"], [0, 1, 2, 2, 2])
+    # the snapped geometry is exactly cubic (Pm-3m) at a much tighter tolerance
+    assert spglib.get_symmetry_dataset(cell, symprec=1e-5).number == 221
+
+
+def test_symmetrize_of_symmetric_structure_is_unchanged(Assert):
+    pytest.importorskip("spglib")
+    structure = Structure.from_POSCAR(_perovskite_poscar(_IDEAL_PEROVSKITE))
+    actual = structure.symmetrize().read()
+    relative = _positions_relative_to_first_atom(actual["positions"])
+    Assert.allclose(relative, _IDEAL_PEROVSKITE, tolerance=_SNAP_TOLERANCE)
+    assert actual["elements"] == ["Sr", "Ti", "O", "O", "O"]
+
+
+def test_symmetrize_respects_symprec():
+    spglib = pytest.importorskip("spglib")
+    poscar = _perovskite_poscar(_IDEAL_PEROVSKITE + _PEROVSKITE_DISTORTION)
+    structure = Structure.from_POSCAR(poscar)
+    # a tolerance smaller than the distortion hides the symmetry, so nothing snaps
+    actual = structure.symmetrize(symprec=1e-6).read()
+    cell = (actual["lattice_vectors"], actual["positions"], [0, 1, 2, 2, 2])
+    assert spglib.get_symmetry_dataset(cell, symprec=1e-5).number == 1
+
+
+def test_symmetrize_multiple_steps_not_implemented(Sr2TiO4):
+    pytest.importorskip("spglib")
+    with pytest.raises(exception.NotImplemented):
+        Sr2TiO4[:].symmetrize()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,12 +7,19 @@ import pytest
 from click.testing import CliRunner
 
 from py4vasp import exception
+from py4vasp._calculation.symmetry import _SYMPREC
 from py4vasp.cli import cli
 
 
 @pytest.fixture
 def mock_calculation():
     with patch("py4vasp.Calculation", autospec=True) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_structure():
+    with patch("py4vasp.cli.Structure", autospec=True) as mock:
         yield mock
 
 
@@ -97,3 +104,75 @@ def test_error_in_py4vasp(mock_calculation):
     result = runner.invoke(cli, ["convert", "structure", "lammps"])
     assert result.exit_code != 0
     assert error_message in result.output
+
+
+# ---------------------------------------------------------------------------
+# symmetrize command
+# ---------------------------------------------------------------------------
+
+
+def _write(path, text="contents"):
+    path.write_text(text)
+    return path
+
+
+@pytest.mark.parametrize("filename", ("POSCAR", "CONTCAR", "structure.vasp"))
+def test_symmetrize_poscar_to_stdout(mock_structure, tmp_path, filename):
+    poscar = _write(tmp_path / filename)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(poscar)])
+    assert result.exit_code == 0
+    mock_structure.from_POSCAR.assert_called_once_with("contents")
+    structure = mock_structure.from_POSCAR.return_value
+    structure.symmetrize.assert_called_once_with(to_primitive=False, symprec=_SYMPREC)
+    symmetrized = structure.symmetrize.return_value
+    symmetrized.to_POSCAR.assert_called_once_with()
+    assert result.output == f"{symmetrized.to_POSCAR.return_value}\n"
+
+
+@pytest.mark.parametrize("suffix", (".h5", ".hdf5"))
+def test_symmetrize_hdf5_reads_via_calculation(mock_calculation, tmp_path, suffix):
+    hdf5 = _write(tmp_path / f"vaspout{suffix}")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(hdf5)])
+    assert result.exit_code == 0
+    mock_calculation.from_file.assert_called_once_with(hdf5)
+    structure = mock_calculation.from_file.return_value.structure
+    structure.symmetrize.assert_called_once_with(to_primitive=False, symprec=_SYMPREC)
+    symmetrized = structure.symmetrize.return_value
+    assert result.output == f"{symmetrized.to_POSCAR.return_value}\n"
+
+
+@pytest.mark.parametrize("flag", ("-p", "--primitive"))
+def test_symmetrize_primitive_flag(mock_structure, tmp_path, flag):
+    poscar = _write(tmp_path / "POSCAR")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(poscar), flag])
+    assert result.exit_code == 0
+    structure = mock_structure.from_POSCAR.return_value
+    structure.symmetrize.assert_called_once_with(to_primitive=True, symprec=_SYMPREC)
+
+
+def test_symmetrize_symprec_option(mock_structure, tmp_path):
+    poscar = _write(tmp_path / "POSCAR")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(poscar), "--symprec", "0.1"])
+    assert result.exit_code == 0
+    structure = mock_structure.from_POSCAR.return_value
+    structure.symmetrize.assert_called_once_with(to_primitive=False, symprec=0.1)
+
+
+def test_symmetrize_error_in_py4vasp(mock_structure, tmp_path):
+    poscar = _write(tmp_path / "POSCAR")
+    error_message = "Cannot symmetrize."
+    mock_structure.from_POSCAR.side_effect = exception.Py4VaspError(error_message)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(poscar)])
+    assert result.exit_code != 0
+    assert error_message in result.output
+
+
+def test_symmetrize_missing_file():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", "does_not_exist"])
+    assert result.exit_code != 0

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -176,3 +176,60 @@ def test_symmetrize_missing_file():
     runner = CliRunner()
     result = runner.invoke(cli, ["symmetrize", "does_not_exist"])
     assert result.exit_code != 0
+
+
+def _set_symmetrized_poscar(mock_structure, text):
+    structure = mock_structure.from_POSCAR.return_value
+    structure.symmetrize.return_value.to_POSCAR.return_value = text
+
+
+@pytest.mark.parametrize("flag", ("-o", "--output"))
+def test_symmetrize_output_file(mock_structure, tmp_path, flag):
+    poscar = _write(tmp_path / "POSCAR")
+    output = tmp_path / "symmetrized.vasp"
+    _set_symmetrized_poscar(mock_structure, "SYMMETRIZED")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(poscar), flag, str(output)])
+    assert result.exit_code == 0
+    assert output.read_text() == "SYMMETRIZED"
+    assert result.output == ""  # nothing written to stdout
+
+
+@pytest.mark.parametrize("flag", ("-i", "--in-place"))
+def test_symmetrize_in_place(mock_structure, tmp_path, flag):
+    poscar = _write(tmp_path / "POSCAR")
+    _set_symmetrized_poscar(mock_structure, "SYMMETRIZED")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(poscar), flag])
+    assert result.exit_code == 0
+    mock_structure.from_POSCAR.assert_called_once_with("contents")
+    assert poscar.read_text() == "SYMMETRIZED"
+    assert result.output == ""
+
+
+def test_symmetrize_in_place_and_output_are_exclusive(mock_structure, tmp_path):
+    poscar = _write(tmp_path / "POSCAR")
+    output = tmp_path / "out.vasp"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(poscar), "-i", "-o", str(output)])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+@pytest.mark.parametrize("suffix", (".h5", ".hdf5"))
+def test_symmetrize_output_to_hdf5_not_implemented(mock_structure, tmp_path, suffix):
+    poscar = _write(tmp_path / "POSCAR")
+    output = tmp_path / f"out{suffix}"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(poscar), "-o", str(output)])
+    assert result.exit_code != 0
+    assert "not implemented" in result.output.lower()
+    assert not output.exists()
+
+
+def test_symmetrize_in_place_hdf5_not_implemented(mock_calculation, tmp_path):
+    hdf5 = _write(tmp_path / "vaspout.h5")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["symmetrize", str(hdf5), "-i"])
+    assert result.exit_code != 0
+    assert "not implemented" in result.output.lower()

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -79,6 +79,7 @@ _FULL_INSTALL_EXAMPLES = {
     "py4vasp._calculation.structure.Structure.wyckoff_positions": "spglib",
     "py4vasp._calculation.structure.Structure.standardized_cell": "spglib",
     "py4vasp._calculation.structure.Structure.prototype": "spglib",
+    "py4vasp._calculation.structure.Structure.symmetrize": "spglib",
 }
 
 


### PR DESCRIPTION
Integrates the symmetrize_poscar functionality from #242 into py4vasp.

* Structure.symmetrize(to_primitive=False, symprec=1e-5) — returns a new Structure with the atoms snapped onto their high-symmetry positions. The symmetry is derived from the bare geometry via spglib, so it works even for structures without VASP symmetry data (e.g. read from a POSCAR). Single frame only.
  * Default (to_primitive=False): keeps the input cell, atom count, and ordering, mapping spglib's idealized standard positions back onto the original atoms (the approach used by ase.spacegroup.symmetrize).
  * to_primitive=True: reduces to the idealized primitive cell.
* py4vasp symmetrize <file> — reads a POSCAR/CONTCAR text file or an HDF5 file (detected by the .h5/.hdf5 extension), symmetrizes it, and writes POSCAR to stdout. Options: -p/--primitive, --symprec, -o/--output, -i/--in-place (-i/-o mutually exclusive). Writing an HDF5 file raises a not-implemented error for now.

**Notes**
* Addresses part of [#242](https://github.com/vasp-dev/py4vasp/issues/242) (the symmetrize_poscar utility).
* Requires spglib; symmetry-dependent tests and doctests skip when it is absent.
