### PR TITLE
Feat: bader charge analysis

### DIFF
--- a/src/py4vasp/_calculation/bader.py
+++ b/src/py4vasp/_calculation/bader.py
@@ -36,6 +36,16 @@ def _bader_charge(self, selection=None, *, bader_analysis=None, snap_to_atoms=Tr
 class BaderMixin:
     """Add a Bader charge analysis to a quantity defined on a real-space grid."""
 
+    def _bader_selection(self, selection):
+        # Honor a source chosen via item access (e.g. density["all_electron"]) the
+        # same way read and plot do, combining it with the method selection.
+        source = getattr(self, "_selection_name", None)
+        if source is None:
+            return selection
+        if selection is None:
+            return source
+        return f"{source}({selection})"
+
     def bader_analysis(self, selection=None, *, snap_to_atoms=True):
         """Partition the selected density into atomic Bader basins.
 
@@ -65,7 +75,7 @@ class BaderMixin:
         return merge_default(
             self._source,
             self._quantity_name,
-            selection,
+            self._bader_selection(selection),
             self._handler_factory,
             _bader_analysis,
             snap_to_atoms=snap_to_atoms,
@@ -94,6 +104,19 @@ class BaderMixin:
             ``{atom: charge}`` for a single selection, or
             ``{selection: {atom: charge}}`` for several.
 
+        Notes
+        -----
+        The returned charge is the integral of the *selected* density within the
+        basins. ``bader_charge("all_electron")`` therefore integrates the
+        all-electron valence density in all-electron basins. To reproduce the
+        Henkelman workflow instead -- basins from the all-electron density but the
+        integral of the pseudo (valence) density -- combine both explicitly::
+
+            calc.density.bader_charge(bader_analysis=calc.density.bader_analysis("all_electron"))
+
+        The two differ by how the valence charge is distributed near the nuclei
+        (typically a few hundredths of an electron), not by the basins.
+
         Examples
         --------
         >>> from py4vasp import demo
@@ -104,7 +127,7 @@ class BaderMixin:
         return merge_default(
             self._source,
             self._quantity_name,
-            selection,
+            self._bader_selection(selection),
             self._handler_factory,
             _bader_charge,
             bader_analysis=bader_analysis,

--- a/src/py4vasp/_calculation/bader.py
+++ b/src/py4vasp/_calculation/bader.py
@@ -3,10 +3,14 @@
 """Expose the Bader charge analysis on quantities defined on a real-space grid.
 
 The heavy lifting lives in :mod:`py4vasp._util.bader`; this module only wires it
-into the dispatch architecture. A quantity opts in by adding :class:`BaderMixin`
-to its public class and a ``_bader_grid`` method to its handler. The two
-module-level functions act as the dispatched "handler methods" (their first
-parameter is named ``self`` so the dispatcher forwards the selection correctly).
+into the dispatch architecture. Bader basins are defined by the topology of the
+*charge density*, so only the charge density can construct them: it opts in with
+:class:`BaderAnalysisMixin`. Every other grid quantity opts in with the lighter
+:class:`BaderMixin`, which only integrates a quantity within basins that were
+supplied from the density. A quantity contributes a ``_bader_grid`` method to its
+handler. The two module-level functions act as the dispatched "handler methods"
+(their first parameter is named ``self`` so the dispatcher forwards the selection
+correctly).
 """
 from py4vasp._calculation.dispatch import merge_default
 from py4vasp._util import bader as _bader
@@ -22,19 +26,12 @@ def _bader_analysis(self, selection=None, *, snap_to_atoms=True):
     )
 
 
-def _bader_charge(self, selection=None, *, bader_analysis=None, snap_to_atoms=True):
-    return _bader.charges_from_selection(
-        self._structure(),
-        self._bader_grid,
-        selection,
-        snap_to_atoms,
-        bader_analysis,
-        reference_for_selection=getattr(self, "_bader_reference", None),
-    )
+def _bader_charge(self, selection=None, *, bader_analysis=None):
+    return _bader.charges_from_selection(self._bader_grid, selection, bader_analysis)
 
 
 class BaderMixin:
-    """Add a Bader charge analysis to a quantity defined on a real-space grid."""
+    """Integrate a grid quantity within Bader basins supplied by the density."""
 
     def _bader_selection(self, selection):
         # Honor a source chosen via item access (e.g. density["all_electron"]) the
@@ -46,6 +43,57 @@ class BaderMixin:
             return source
         return f"{source}({selection})"
 
+    def bader_charge(self, selection=None, *, bader_analysis=None):
+        """Integrate the selected quantity within Bader basins.
+
+        Bader basins are defined by the topology of the charge density, so they
+        cannot be constructed from this quantity itself (a potential, for instance,
+        is minimal rather than maximal at the nuclei). You therefore always supply
+        the basins through ``bader_analysis``, obtained from
+        :meth:`Density.bader_analysis`.
+
+        Parameters
+        ----------
+        selection : str
+            Select which grid(s) of this quantity to integrate. Defaults to the
+            quantity's default grid.
+        bader_analysis : BaderAnalysis
+            The basins to integrate in, obtained from a :meth:`Density.bader_analysis`
+            call, e.g.
+            ``potential.bader_charge(bader_analysis=density.bader_analysis())``.
+
+        Returns
+        -------
+        dict
+            ``{atom: charge}`` for a single selection, or
+            ``{selection: {atom: charge}}`` for several.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> basins = calculation.density.bader_analysis()
+        >>> calculation.potential.bader_charge(bader_analysis=basins)
+        {...}
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            self._bader_selection(selection),
+            self._handler_factory,
+            _bader_charge,
+            bader_analysis=bader_analysis,
+        )
+
+
+class BaderAnalysisMixin(BaderMixin):
+    """Add the full Bader charge analysis to the charge density.
+
+    Only the charge density can *define* Bader basins, so it alone exposes
+    :meth:`bader_analysis` in addition to the :meth:`bader_charge` integration
+    inherited from :class:`BaderMixin`.
+    """
+
     def bader_analysis(self, selection=None, *, snap_to_atoms=True):
         """Partition the selected density into atomic Bader basins.
 
@@ -53,7 +101,7 @@ class BaderMixin:
         ----------
         selection : str
             Select a single density component to partition. Defaults to the
-            quantity's default density.
+            default charge density.
         snap_to_atoms : bool
             Snap every density maximum to its nearest atom (default). Disable to
             label basins by the raw maxima instead.
@@ -61,8 +109,9 @@ class BaderMixin:
         Returns
         -------
         BaderAnalysis
-            An analysis object whose basins can be visualized with ``plot`` or
-            reused to integrate another density via ``bader_charge``.
+            An analysis object whose basins can be visualized with ``plot``, whose
+            Bader charges are available via ``charges``, or which can be passed to
+            any quantity's ``bader_charge`` to integrate it in these basins.
 
         Examples
         --------
@@ -78,58 +127,5 @@ class BaderMixin:
             self._bader_selection(selection),
             self._handler_factory,
             _bader_analysis,
-            snap_to_atoms=snap_to_atoms,
-        )
-
-    def bader_charge(self, selection=None, *, bader_analysis=None, snap_to_atoms=True):
-        """Integrate the selected density within Bader basins.
-
-        Parameters
-        ----------
-        selection : str
-            Select the density to integrate. You may define the basins from a
-            different density of the same quantity with the ``basins=`` syntax,
-            e.g. ``"m(basins=scalar)"`` integrates the magnetization within basins
-            built from the scalar charge.
-        bader_analysis : BaderAnalysis
-            Reuse basins from a previous :meth:`bader_analysis` call, possibly of a
-            different quantity, e.g.
-            ``potential.bader_charge(bader_analysis=density.bader_analysis())``.
-        snap_to_atoms : bool
-            Snap every density maximum to its nearest atom (default).
-
-        Returns
-        -------
-        dict
-            ``{atom: charge}`` for a single selection, or
-            ``{selection: {atom: charge}}`` for several.
-
-        Notes
-        -----
-        The returned charge is the integral of the *selected* density within the
-        basins. ``bader_charge("all_electron")`` therefore integrates the
-        all-electron valence density in all-electron basins. To reproduce the
-        Henkelman workflow instead -- basins from the all-electron density but the
-        integral of the pseudo (valence) density -- combine both explicitly::
-
-            calc.density.bader_charge(bader_analysis=calc.density.bader_analysis("all_electron"))
-
-        The two differ by how the valence charge is distributed near the nuclei
-        (typically a few hundredths of an electron), not by the basins.
-
-        Examples
-        --------
-        >>> from py4vasp import demo
-        >>> calculation = demo.calculation(path)
-        >>> calculation.density.bader_charge()
-        {...}
-        """
-        return merge_default(
-            self._source,
-            self._quantity_name,
-            self._bader_selection(selection),
-            self._handler_factory,
-            _bader_charge,
-            bader_analysis=bader_analysis,
             snap_to_atoms=snap_to_atoms,
         )

--- a/src/py4vasp/_calculation/bader.py
+++ b/src/py4vasp/_calculation/bader.py
@@ -1,0 +1,103 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+"""Expose the Bader charge analysis on quantities defined on a real-space grid.
+
+The heavy lifting lives in :mod:`py4vasp._util.bader`; this module only wires it
+into the dispatch architecture. A quantity opts in by adding :class:`BaderMixin`
+to its public class and a ``_bader_grid`` method to its handler. The two
+module-level functions act as the dispatched "handler methods" (their first
+parameter is named ``self`` so the dispatcher forwards the selection correctly).
+"""
+from py4vasp._calculation.dispatch import merge_default
+from py4vasp._util import bader as _bader
+
+
+def _bader_analysis(self, selection=None, *, snap_to_atoms=True):
+    return _bader.analysis_from_selection(
+        self._structure(), self._bader_grid, selection, snap_to_atoms
+    )
+
+
+def _bader_charge(self, selection=None, *, bader_analysis=None, snap_to_atoms=True):
+    return _bader.charges_from_selection(
+        self._structure(), self._bader_grid, selection, snap_to_atoms, bader_analysis
+    )
+
+
+class BaderMixin:
+    """Add a Bader charge analysis to a quantity defined on a real-space grid."""
+
+    def bader_analysis(self, selection=None, *, snap_to_atoms=True):
+        """Partition the selected density into atomic Bader basins.
+
+        Parameters
+        ----------
+        selection : str
+            Select a single density component to partition. Defaults to the
+            quantity's default density.
+        snap_to_atoms : bool
+            Snap every density maximum to its nearest atom (default). Disable to
+            label basins by the raw maxima instead.
+
+        Returns
+        -------
+        BaderAnalysis
+            An analysis object whose basins can be visualized with ``plot`` or
+            reused to integrate another density via ``bader_charge``.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> analysis = calculation.density.bader_analysis()
+        >>> analysis.charges()
+        {...}
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            selection,
+            self._handler_factory,
+            _bader_analysis,
+            snap_to_atoms=snap_to_atoms,
+        )
+
+    def bader_charge(self, selection=None, *, bader_analysis=None, snap_to_atoms=True):
+        """Integrate the selected density within Bader basins.
+
+        Parameters
+        ----------
+        selection : str
+            Select the density to integrate. You may define the basins from a
+            different density of the same quantity with the ``basins=`` syntax,
+            e.g. ``"m(basins=scalar)"`` integrates the magnetization within basins
+            built from the scalar charge.
+        bader_analysis : BaderAnalysis
+            Reuse basins from a previous :meth:`bader_analysis` call, possibly of a
+            different quantity, e.g.
+            ``potential.bader_charge(bader_analysis=density.bader_analysis())``.
+        snap_to_atoms : bool
+            Snap every density maximum to its nearest atom (default).
+
+        Returns
+        -------
+        dict
+            ``{atom: charge}`` for a single selection, or
+            ``{selection: {atom: charge}}`` for several.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> calculation.density.bader_charge()
+        {...}
+        """
+        return merge_default(
+            self._source,
+            self._quantity_name,
+            selection,
+            self._handler_factory,
+            _bader_charge,
+            bader_analysis=bader_analysis,
+            snap_to_atoms=snap_to_atoms,
+        )

--- a/src/py4vasp/_calculation/bader.py
+++ b/src/py4vasp/_calculation/bader.py
@@ -12,6 +12,7 @@ handler. The two module-level functions act as the dispatched "handler methods"
 (their first parameter is named ``self`` so the dispatcher forwards the selection
 correctly).
 """
+
 from py4vasp._calculation.dispatch import merge_default
 from py4vasp._util import bader as _bader
 

--- a/src/py4vasp/_calculation/bader.py
+++ b/src/py4vasp/_calculation/bader.py
@@ -1,23 +1,66 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
-"""Expose the Bader charge analysis on quantities defined on a real-space grid.
+"""Wire the Bader charge analysis into the grid quantities via composition.
 
-The heavy lifting lives in :mod:`py4vasp._util.bader`; this module only wires it
-into the dispatch architecture. Bader basins are defined by the topology of the
-*charge density*, so only the charge density can construct them: it opts in with
-:class:`BaderAnalysisMixin`. Every other grid quantity opts in with the lighter
-:class:`BaderMixin`, which only integrates a quantity within basins that were
-supplied from the density. A quantity contributes a ``_bader_grid`` method to its
-handler. The two module-level functions act as the dispatched "handler methods"
-(their first parameter is named ``self`` so the dispatcher forwards the selection
-correctly).
+The heavy lifting lives in :mod:`py4vasp._util.bader`; this module only bridges it
+to the dispatch architecture. Each grid quantity composes the analysis by defining
+its own ``bader_charge`` (and the charge density additionally ``bader_analysis``)
+as a thin method that forwards to :func:`charge` / :func:`analysis` here -- there
+is no shared base class. Bader basins are defined by the topology of the charge
+density, so only the charge density can construct them; every other quantity
+integrates within basins that were supplied from the density. A quantity
+contributes a ``_bader_grid`` method (and optionally ``_bader_reference``) to its
+handler; the private dispatch functions below receive that handler as ``self``.
 """
 
 from py4vasp._calculation.dispatch import merge_default
 from py4vasp._util import bader as _bader
 
 
-def _bader_analysis(self, selection=None, *, snap_to_atoms=True):
+def analysis(quantity, selection=None, *, snap_to_atoms=True):
+    """Build a :class:`~py4vasp._util.bader.BaderAnalysis` from a grid quantity.
+
+    Forwarding target for the charge density's ``bader_analysis`` method.
+    """
+    return merge_default(
+        quantity._source,
+        quantity._quantity_name,
+        _combine_source(quantity, selection),
+        quantity._handler_factory,
+        _dispatch_analysis,
+        snap_to_atoms=snap_to_atoms,
+    )
+
+
+def charge(quantity, selection=None, *, bader_analysis=None):
+    """Integrate a grid quantity within the basins of ``bader_analysis``.
+
+    Forwarding target for every quantity's ``bader_charge`` method.
+    """
+    return merge_default(
+        quantity._source,
+        quantity._quantity_name,
+        _combine_source(quantity, selection),
+        quantity._handler_factory,
+        _dispatch_charge,
+        bader_analysis=bader_analysis,
+    )
+
+
+def _combine_source(quantity, selection):
+    # Honor a source chosen via item access (e.g. density["all_electron"]) the same
+    # way read and plot do, combining it with the method selection.
+    source = getattr(quantity, "_selection_name", None)
+    if source is None:
+        return selection
+    if selection is None:
+        return source
+    return f"{source}({selection})"
+
+
+def _dispatch_analysis(self, selection=None, *, snap_to_atoms=True):
+    # self is the quantity handler; its first parameter name lets the dispatcher
+    # forward the remaining selection here.
     return _bader.analysis_from_selection(
         self._structure(),
         self._bader_grid,
@@ -27,106 +70,5 @@ def _bader_analysis(self, selection=None, *, snap_to_atoms=True):
     )
 
 
-def _bader_charge(self, selection=None, *, bader_analysis=None):
+def _dispatch_charge(self, selection=None, *, bader_analysis=None):
     return _bader.charges_from_selection(self._bader_grid, selection, bader_analysis)
-
-
-class BaderMixin:
-    """Integrate a grid quantity within Bader basins supplied by the density."""
-
-    def _bader_selection(self, selection):
-        # Honor a source chosen via item access (e.g. density["all_electron"]) the
-        # same way read and plot do, combining it with the method selection.
-        source = getattr(self, "_selection_name", None)
-        if source is None:
-            return selection
-        if selection is None:
-            return source
-        return f"{source}({selection})"
-
-    def bader_charge(self, selection=None, *, bader_analysis=None):
-        """Integrate the selected quantity within Bader basins.
-
-        Bader basins are defined by the topology of the charge density, so they
-        cannot be constructed from this quantity itself (a potential, for instance,
-        is minimal rather than maximal at the nuclei). You therefore always supply
-        the basins through ``bader_analysis``, obtained from
-        :meth:`Density.bader_analysis`.
-
-        Parameters
-        ----------
-        selection : str
-            Select which grid(s) of this quantity to integrate. Defaults to the
-            quantity's default grid.
-        bader_analysis : BaderAnalysis
-            The basins to integrate in, obtained from a :meth:`Density.bader_analysis`
-            call, e.g.
-            ``potential.bader_charge(bader_analysis=density.bader_analysis())``.
-
-        Returns
-        -------
-        dict
-            ``{atom: charge}`` for a single selection, or
-            ``{selection: {atom: charge}}`` for several.
-
-        Examples
-        --------
-        >>> from py4vasp import demo
-        >>> calculation = demo.calculation(path)
-        >>> basins = calculation.density.bader_analysis()
-        >>> calculation.potential.bader_charge(bader_analysis=basins)
-        {...}
-        """
-        return merge_default(
-            self._source,
-            self._quantity_name,
-            self._bader_selection(selection),
-            self._handler_factory,
-            _bader_charge,
-            bader_analysis=bader_analysis,
-        )
-
-
-class BaderAnalysisMixin(BaderMixin):
-    """Add the full Bader charge analysis to the charge density.
-
-    Only the charge density can *define* Bader basins, so it alone exposes
-    :meth:`bader_analysis` in addition to the :meth:`bader_charge` integration
-    inherited from :class:`BaderMixin`.
-    """
-
-    def bader_analysis(self, selection=None, *, snap_to_atoms=True):
-        """Partition the selected density into atomic Bader basins.
-
-        Parameters
-        ----------
-        selection : str
-            Select a single density component to partition. Defaults to the
-            default charge density.
-        snap_to_atoms : bool
-            Snap every density maximum to its nearest atom (default). Disable to
-            label basins by the raw maxima instead.
-
-        Returns
-        -------
-        BaderAnalysis
-            An analysis object whose basins can be visualized with ``plot``, whose
-            Bader charges are available via ``charges``, or which can be passed to
-            any quantity's ``bader_charge`` to integrate it in these basins.
-
-        Examples
-        --------
-        >>> from py4vasp import demo
-        >>> calculation = demo.calculation(path)
-        >>> analysis = calculation.density.bader_analysis()
-        >>> analysis.charges()
-        {...}
-        """
-        return merge_default(
-            self._source,
-            self._quantity_name,
-            self._bader_selection(selection),
-            self._handler_factory,
-            _bader_analysis,
-            snap_to_atoms=snap_to_atoms,
-        )

--- a/src/py4vasp/_calculation/bader.py
+++ b/src/py4vasp/_calculation/bader.py
@@ -14,13 +14,22 @@ from py4vasp._util import bader as _bader
 
 def _bader_analysis(self, selection=None, *, snap_to_atoms=True):
     return _bader.analysis_from_selection(
-        self._structure(), self._bader_grid, selection, snap_to_atoms
+        self._structure(),
+        self._bader_grid,
+        selection,
+        snap_to_atoms,
+        reference_for_selection=getattr(self, "_bader_reference", None),
     )
 
 
 def _bader_charge(self, selection=None, *, bader_analysis=None, snap_to_atoms=True):
     return _bader.charges_from_selection(
-        self._structure(), self._bader_grid, selection, snap_to_atoms, bader_analysis
+        self._structure(),
+        self._bader_grid,
+        selection,
+        snap_to_atoms,
+        bader_analysis,
+        reference_for_selection=getattr(self, "_bader_reference", None),
     )
 
 

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -16,7 +16,7 @@ from py4vasp._calculation.dispatch import (
     merge_strings,
     quantity,
 )
-from py4vasp._calculation.bader import BaderMixin
+from py4vasp._calculation.bader import BaderAnalysisMixin
 from py4vasp._calculation.structure import StructureHandler
 from py4vasp._raw import data as raw
 from py4vasp._third_party import graph, view
@@ -290,7 +290,7 @@ class DensityHandler:
 
 
 @quantity("density")
-class Density(view.Mixin, BaderMixin):
+class Density(view.Mixin, BaderAnalysisMixin):
     """This class accesses various densities (charge, magnetization, ...) of VASP.
 
     The charge density is one key quantity optimized by VASP. With this class you

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -99,7 +99,16 @@ class DensityHandler:
         return {"component": components}
 
     def to_numpy(self):
-        return np.moveaxis(self._raw_density.charge, 0, -1).T
+        return np.moveaxis(self._charge(), 0, -1).T
+
+    def _charge(self):
+        "Return the charge grid, adding the core density to the scalar component."
+        charge = self._raw_density.charge
+        if self._raw_density.core.is_none():
+            return charge
+        charge = np.array(charge)
+        charge[0] = charge[0] + np.asarray(self._raw_density.core)[0]
+        return charge
 
     def to_view(
         self,
@@ -109,7 +118,7 @@ class DensityHandler:
     ) -> view.View:
         _raise_error_if_no_data(self._raw_density.charge)
         map_ = self._create_map()
-        selector = index.Selector({0: map_}, self._raw_density.charge)
+        selector = index.Selector({0: map_}, self._charge())
         component = component or _INTERNAL
         tree = select.Tree.from_selection(component)
         selections = list(self._filter_noncollinear_magnetization_from_selections(tree))
@@ -139,7 +148,7 @@ class DensityHandler:
         supercell: Optional[Union[int, np.ndarray]] = None,
     ) -> graph.Graph:
         map_ = self._create_map()
-        selector = index.Selector({0: map_}, self._raw_density.charge)
+        selector = index.Selector({0: map_}, self._charge())
         component = component or _INTERNAL
         tree = select.Tree.from_selection(component)
         selections = list(self._filter_noncollinear_magnetization_from_selections(tree))
@@ -162,7 +171,7 @@ class DensityHandler:
         supercell: Optional[Union[int, np.ndarray]] = None,
     ) -> graph.Graph:
         if self.is_collinear():
-            data = self._raw_density.charge[1].T
+            data = self._charge()[1].T
         else:
             data = self.to_numpy()[1:]
         visualizer = Visualizer(self._structure())
@@ -193,7 +202,7 @@ class DensityHandler:
 
     def _bader_grid(self, selection):
         map_ = self._create_map()
-        selector = index.Selector({0: map_}, self._raw_density.charge)
+        selector = index.Selector({0: map_}, self._charge())
         tree = select.Tree.from_selection(selection or _INTERNAL)
         selections = self._filter_noncollinear_magnetization_from_selections(tree)
         return {

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -99,16 +99,7 @@ class DensityHandler:
         return {"component": components}
 
     def to_numpy(self):
-        return np.moveaxis(self._charge(), 0, -1).T
-
-    def _charge(self):
-        "Return the charge grid, adding the core density to the scalar component."
-        charge = self._raw_density.charge
-        if self._raw_density.core.is_none():
-            return charge
-        charge = np.array(charge)
-        charge[0] = charge[0] + np.asarray(self._raw_density.core)[0]
-        return charge
+        return np.moveaxis(self._raw_density.charge, 0, -1).T
 
     def to_view(
         self,
@@ -118,7 +109,7 @@ class DensityHandler:
     ) -> view.View:
         _raise_error_if_no_data(self._raw_density.charge)
         map_ = self._create_map()
-        selector = index.Selector({0: map_}, self._charge())
+        selector = index.Selector({0: map_}, self._raw_density.charge)
         component = component or _INTERNAL
         tree = select.Tree.from_selection(component)
         selections = list(self._filter_noncollinear_magnetization_from_selections(tree))
@@ -148,7 +139,7 @@ class DensityHandler:
         supercell: Optional[Union[int, np.ndarray]] = None,
     ) -> graph.Graph:
         map_ = self._create_map()
-        selector = index.Selector({0: map_}, self._charge())
+        selector = index.Selector({0: map_}, self._raw_density.charge)
         component = component or _INTERNAL
         tree = select.Tree.from_selection(component)
         selections = list(self._filter_noncollinear_magnetization_from_selections(tree))
@@ -171,7 +162,7 @@ class DensityHandler:
         supercell: Optional[Union[int, np.ndarray]] = None,
     ) -> graph.Graph:
         if self.is_collinear():
-            data = self._charge()[1].T
+            data = self._raw_density.charge[1].T
         else:
             data = self.to_numpy()[1:]
         visualizer = Visualizer(self._structure())
@@ -202,12 +193,20 @@ class DensityHandler:
 
     def _bader_grid(self, selection):
         map_ = self._create_map()
-        selector = index.Selector({0: map_}, self._charge())
+        selector = index.Selector({0: map_}, self._raw_density.charge)
         tree = select.Tree.from_selection(selection or _INTERNAL)
         selections = self._filter_noncollinear_magnetization_from_selections(tree)
         return {
             self._label(selector.label(sel)): selector[sel].T for sel in selections
         }
+
+    def _bader_reference(self, selection):
+        "Peaked scalar density (valence + core) used only to define the basins."
+        if self._raw_density.core.is_none():
+            return None
+        charge = np.asarray(self._raw_density.charge)
+        core = np.asarray(self._raw_density.core)[0]
+        return (charge[0] + core).T
 
     def _read_density(self):
         density = self.to_numpy()

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -8,8 +8,7 @@ import numpy as np
 
 from py4vasp import _config, exception
 from py4vasp import raw as raw_module
-from py4vasp._calculation import _stoichiometry
-from py4vasp._calculation.bader import BaderAnalysisMixin
+from py4vasp._calculation import _stoichiometry, bader
 from py4vasp._calculation.dispatch import (
     DataSource,
     is_available_raw,
@@ -288,7 +287,7 @@ class DensityHandler:
 
 
 @quantity("density")
-class Density(view.Mixin, BaderAnalysisMixin):
+class Density(view.Mixin):
     """This class accesses various densities (charge, magnetization, ...) of VASP.
 
     The charge density is one key quantity optimized by VASP. With this class you
@@ -725,6 +724,67 @@ class Density(view.Mixin, BaderAnalysisMixin):
             self._handler_factory,
             DensityHandler.is_noncollinear,
         )
+
+    def bader_analysis(self, selection=None, *, snap_to_atoms=True):
+        """Partition the selected density into atomic Bader basins.
+
+        Bader basins follow the topology of the charge density, which is why only
+        the density exposes this method. The resulting analysis can be reused to
+        integrate any other grid quantity via its ``bader_charge`` method.
+
+        Parameters
+        ----------
+        selection : str
+            Select a single density component to partition. Defaults to the
+            default charge density.
+        snap_to_atoms : bool
+            Snap every density maximum to its nearest atom (default). Disable to
+            label basins by the raw maxima instead.
+
+        Returns
+        -------
+        BaderAnalysis
+            An analysis object whose basins can be visualized with ``plot`` and
+            whose Bader charges are available via ``charges``.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> analysis = calculation.density.bader_analysis()
+        >>> analysis.charges()
+        {...}
+        """
+        return bader.analysis(self, selection, snap_to_atoms=snap_to_atoms)
+
+    def bader_charge(self, selection=None, *, bader_analysis=None):
+        """Integrate the selected density within Bader basins.
+
+        Parameters
+        ----------
+        selection : str
+            Select which density component to integrate. Defaults to the default
+            charge density.
+        bader_analysis : BaderAnalysis
+            The basins to integrate in, obtained from :meth:`bader_analysis`. This
+            argument is required because the basins are defined by the density
+            topology rather than reconstructed on the fly.
+
+        Returns
+        -------
+        dict
+            ``{atom: charge}`` for a single selection, or
+            ``{selection: {atom: charge}}`` for several.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> basins = calculation.density.bader_analysis()
+        >>> calculation.density.bader_charge(bader_analysis=basins)
+        {...}
+        """
+        return bader.charge(self, selection, bader_analysis=bader_analysis)
 
 
 def _raise_error_if_color_is_specified(color):

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -16,6 +16,7 @@ from py4vasp._calculation.dispatch import (
     merge_strings,
     quantity,
 )
+from py4vasp._calculation.bader import BaderMixin
 from py4vasp._calculation.structure import StructureHandler
 from py4vasp._raw import data as raw
 from py4vasp._third_party import graph, view
@@ -190,6 +191,15 @@ class DensityHandler:
     def _structure(self):
         return StructureHandler.from_data(self._raw_density.structure)
 
+    def _bader_grid(self, selection):
+        map_ = self._create_map()
+        selector = index.Selector({0: map_}, self._raw_density.charge)
+        tree = select.Tree.from_selection(selection or _INTERNAL)
+        selections = self._filter_noncollinear_magnetization_from_selections(tree)
+        return {
+            self._label(selector.label(sel)): selector[sel].T for sel in selections
+        }
+
     def _read_density(self):
         density = self.to_numpy()
         if self._selection:
@@ -272,7 +282,7 @@ class DensityHandler:
 
 
 @quantity("density")
-class Density(view.Mixin):
+class Density(view.Mixin, BaderMixin):
     """This class accesses various densities (charge, magnetization, ...) of VASP.
 
     The charge density is one key quantity optimized by VASP. With this class you

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -9,6 +9,7 @@ import numpy as np
 from py4vasp import _config, exception
 from py4vasp import raw as raw_module
 from py4vasp._calculation import _stoichiometry
+from py4vasp._calculation.bader import BaderAnalysisMixin
 from py4vasp._calculation.dispatch import (
     DataSource,
     is_available_raw,
@@ -16,7 +17,6 @@ from py4vasp._calculation.dispatch import (
     merge_strings,
     quantity,
 )
-from py4vasp._calculation.bader import BaderAnalysisMixin
 from py4vasp._calculation.structure import StructureHandler
 from py4vasp._raw import data as raw
 from py4vasp._third_party import graph, view
@@ -196,9 +196,7 @@ class DensityHandler:
         selector = index.Selector({0: map_}, self._raw_density.charge)
         tree = select.Tree.from_selection(selection or _INTERNAL)
         selections = self._filter_noncollinear_magnetization_from_selections(tree)
-        return {
-            self._label(selector.label(sel)): selector[sel].T for sel in selections
-        }
+        return {self._label(selector.label(sel)): selector[sel].T for sel in selections}
 
     def _bader_reference(self, selection):
         "Peaked scalar density (valence + core) used only to define the basins."

--- a/src/py4vasp/_calculation/exciton_density.py
+++ b/src/py4vasp/_calculation/exciton_density.py
@@ -5,8 +5,8 @@ from typing import Optional, Union
 import numpy as np
 
 from py4vasp import _config, exception, raw
+from py4vasp._calculation import bader
 from py4vasp._calculation._stoichiometry import StoichiometryHandler
-from py4vasp._calculation.bader import BaderMixin
 from py4vasp._calculation.dispatch import (
     DataSource,
     merge_default,
@@ -95,7 +95,7 @@ class ExcitonDensityHandler:
 
 
 @quantity("density", group="exciton")
-class ExcitonDensity(view.Mixin, BaderMixin):
+class ExcitonDensity(view.Mixin):
     """This class accesses exciton charge densities of VASP.
 
     The exciton charge densities can be calculated via the BSE/TDHF algorithm in
@@ -249,6 +249,36 @@ class ExcitonDensity(view.Mixin, BaderMixin):
             center=center,
             **user_options,
         )
+
+    def bader_charge(self, selection=None, *, bader_analysis=None):
+        """Integrate the selected exciton density within Bader basins.
+
+        Bader basins follow the topology of the charge density, so supply them
+        through ``bader_analysis`` obtained from :meth:`Density.bader_analysis`.
+
+        Parameters
+        ----------
+        selection : str
+            Select which exciton density to integrate, i.e., "1" or "1+2".
+        bader_analysis : BaderAnalysis
+            The basins to integrate in, obtained from a
+            :meth:`Density.bader_analysis` call.
+
+        Returns
+        -------
+        dict
+            ``{atom: charge}`` for a single selection, or
+            ``{selection: {atom: charge}}`` for several.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> basins = calculation.density.bader_analysis()
+        >>> calculation.exciton.density.bader_charge(bader_analysis=basins)
+        {...}
+        """
+        return bader.charge(self, selection, bader_analysis=bader_analysis)
 
 
 def _raise_error_if_no_data(data):

--- a/src/py4vasp/_calculation/exciton_density.py
+++ b/src/py4vasp/_calculation/exciton_density.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from py4vasp import _config, exception, raw
 from py4vasp._calculation._stoichiometry import StoichiometryHandler
+from py4vasp._calculation.bader import BaderMixin
 from py4vasp._calculation.dispatch import (
     DataSource,
     merge_default,
@@ -78,6 +79,12 @@ class ExcitonDensityHandler:
     def _structure(self) -> StructureHandler:
         return StructureHandler.from_data(self._raw_exciton_density.structure)
 
+    def _bader_grid(self, selection):
+        map_ = self._create_map()
+        selector = index.Selector({0: map_}, self._raw_exciton_density.exciton_charge)
+        tree = select.Tree.from_selection(selection or _DEFAULT_SELECTION)
+        return {selector.label(sel): selector[sel].T for sel in tree.selections()}
+
     def _create_map(self) -> dict:
         num_excitons = self._raw_exciton_density.exciton_charge.shape[0]
         return {str(choice + 1): choice for choice in range(num_excitons)}
@@ -88,7 +95,7 @@ class ExcitonDensityHandler:
 
 
 @quantity("density", group="exciton")
-class ExcitonDensity(view.Mixin):
+class ExcitonDensity(view.Mixin, BaderMixin):
     """This class accesses exciton charge densities of VASP.
 
     The exciton charge densities can be calculated via the BSE/TDHF algorithm in

--- a/src/py4vasp/_calculation/nics.py
+++ b/src/py4vasp/_calculation/nics.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from py4vasp import _config, exception
 from py4vasp._calculation import _stoichiometry
+from py4vasp._calculation.bader import BaderMixin
 from py4vasp._calculation.dispatch import (
     DataSource,
     _dispatch,
@@ -111,6 +112,10 @@ nucleus-independent chemical shift:
     def _structure(self):
         return StructureHandler.from_data(self._raw_nics.structure)
 
+    def _bader_grid(self, selection):
+        self._raise_error_if_used_in_points_mode()
+        return self._read_selected_data(selection or _DEFAULT_SELECTION)
+
     @property
     def _data_is_on_grid(self):
         return check.is_none(self._raw_nics.positions)
@@ -212,8 +217,13 @@ nucleus-independent chemical shift:
 
 
 @quantity("nics")
-class Nics(view.Mixin):
+class Nics(view.Mixin, BaderMixin):
     """This class accesses information on the nucleus-independent chemical shift (NICS).
+
+    Because the NICS is a shielding field rather than a density, its Bader basins
+    are not physically meaningful on their own. Use ``bader_charge`` with an
+    external ``bader_analysis`` built from the charge density to integrate the NICS
+    within charge-density basins.
 
     Examples
     --------

--- a/src/py4vasp/_calculation/nics.py
+++ b/src/py4vasp/_calculation/nics.py
@@ -6,8 +6,7 @@ from typing import Optional, Union
 import numpy as np
 
 from py4vasp import _config, exception
-from py4vasp._calculation import _stoichiometry
-from py4vasp._calculation.bader import BaderMixin
+from py4vasp._calculation import _stoichiometry, bader
 from py4vasp._calculation.dispatch import (
     DataSource,
     _dispatch,
@@ -217,7 +216,7 @@ nucleus-independent chemical shift:
 
 
 @quantity("nics")
-class Nics(view.Mixin, BaderMixin):
+class Nics(view.Mixin):
     """This class accesses information on the nucleus-independent chemical shift (NICS).
 
     Because the NICS is a shielding field rather than a density, its Bader basins
@@ -474,6 +473,39 @@ class Nics(view.Mixin, BaderMixin):
             normal=normal,
             supercell=supercell,
         )
+
+    def bader_charge(self, selection=None, *, bader_analysis=None):
+        """Integrate the selected chemical shift within Bader basins.
+
+        The NICS is a shielding field rather than a density, so its own Bader
+        basins are not physically meaningful. Supply the basins through
+        ``bader_analysis`` obtained from :meth:`Density.bader_analysis` to
+        integrate the NICS within charge-density basins.
+
+        Parameters
+        ----------
+        selection : str
+            Select which tensor element to integrate, e.g. "isotropic" or "xx".
+            Defaults to the isotropic shift.
+        bader_analysis : BaderAnalysis
+            The basins to integrate in, obtained from a
+            :meth:`Density.bader_analysis` call.
+
+        Returns
+        -------
+        dict
+            ``{atom: charge}`` for a single selection, or
+            ``{selection: {atom: charge}}`` for several.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> basins = calculation.density.bader_analysis()
+        >>> calculation.nics.bader_charge(bader_analysis=basins)
+        {...}
+        """
+        return bader.charge(self, selection, bader_analysis=bader_analysis)
 
     def _to_database(self) -> dict:
         """Return {quantity[_selection]: handler_result} for database storage."""

--- a/src/py4vasp/_calculation/partial_density.py
+++ b/src/py4vasp/_calculation/partial_density.py
@@ -8,8 +8,7 @@ from typing import Optional, Union
 import numpy as np
 
 from py4vasp import _config, exception
-from py4vasp._calculation import _stoichiometry
-from py4vasp._calculation.bader import BaderMixin
+from py4vasp._calculation import _stoichiometry, bader
 from py4vasp._calculation.dispatch import (
     DataSource,
     merge_default,
@@ -337,7 +336,7 @@ class PartialDensityHandler:
 
 
 @quantity("partial_density")
-class PartialDensity(view.Mixin, BaderMixin):
+class PartialDensity(view.Mixin):
     """Partial charges describe the fraction of the charge density in a certain energy,
     band, or k-point range.
 
@@ -637,6 +636,37 @@ class PartialDensity(view.Mixin, BaderMixin):
             supercell=supercell,
             stm_settings=stm_settings,
         )
+
+    def bader_charge(self, selection=None, *, bader_analysis=None):
+        """Integrate the selected partial density within Bader basins.
+
+        Bader basins follow the topology of the charge density, so supply them
+        through ``bader_analysis`` obtained from :meth:`Density.bader_analysis`.
+
+        Parameters
+        ----------
+        selection : str
+            Select which partial density to integrate. Defaults to the total
+            partial charge density.
+        bader_analysis : BaderAnalysis
+            The basins to integrate in, obtained from a
+            :meth:`Density.bader_analysis` call.
+
+        Returns
+        -------
+        dict
+            ``{atom: charge}`` for a single selection, or
+            ``{selection: {atom: charge}}`` for several.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> basins = calculation.density.bader_analysis()
+        >>> calculation.partial_density.bader_charge(bader_analysis=basins)
+        {...}
+        """
+        return bader.charge(self, selection, bader_analysis=bader_analysis)
 
     def _stoichiometry(self):
         return merge_default(

--- a/src/py4vasp/_calculation/partial_density.py
+++ b/src/py4vasp/_calculation/partial_density.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from py4vasp import _config, exception
 from py4vasp._calculation import _stoichiometry
+from py4vasp._calculation.bader import BaderMixin
 from py4vasp._calculation.dispatch import (
     DataSource,
     merge_default,
@@ -176,6 +177,10 @@ class PartialDensityHandler:
     def _structure(self):
         return StructureHandler.from_data(self._raw_partial_density.structure)
 
+    def _bader_grid(self, selection):
+        selection = selection or "total"
+        return {selection: self.to_numpy(selection)}
+
     def _spin_polarized(self):
         return self._raw_partial_density.partial_charge.shape[2] == 2
 
@@ -332,7 +337,7 @@ class PartialDensityHandler:
 
 
 @quantity("partial_density")
-class PartialDensity(view.Mixin):
+class PartialDensity(view.Mixin, BaderMixin):
     """Partial charges describe the fraction of the charge density in a certain energy,
     band, or k-point range.
 

--- a/src/py4vasp/_calculation/potential.py
+++ b/src/py4vasp/_calculation/potential.py
@@ -7,8 +7,7 @@ from typing import Optional, Union
 import numpy as np
 
 from py4vasp import _config, exception
-from py4vasp._calculation import _stoichiometry
-from py4vasp._calculation.bader import BaderMixin
+from py4vasp._calculation import _stoichiometry, bader
 from py4vasp._calculation.dispatch import (
     DataSource,
     _dispatch,
@@ -241,7 +240,7 @@ class PotentialHandler:
 
 
 @quantity("potential")
-class Potential(view.Mixin, BaderMixin):
+class Potential(view.Mixin):
     """The local potential describes the interactions between electrons and ions.
 
     In DFT calculations, the local potential consists of various contributions, each
@@ -516,6 +515,37 @@ class Potential(view.Mixin, BaderMixin):
             normal=normal,
             supercell=supercell,
         )
+
+    def bader_charge(self, selection=None, *, bader_analysis=None):
+        """Integrate the selected potential within Bader basins.
+
+        The local potential is minimal rather than maximal at the nuclei, so it
+        cannot define its own basins. You therefore supply the basins through
+        ``bader_analysis``, obtained from :meth:`Density.bader_analysis`.
+
+        Parameters
+        ----------
+        selection : str
+            Select which potential to integrate. Defaults to the total potential.
+        bader_analysis : BaderAnalysis
+            The basins to integrate in, obtained from a
+            :meth:`Density.bader_analysis` call.
+
+        Returns
+        -------
+        dict
+            ``{atom: charge}`` for a single selection, or
+            ``{selection: {atom: charge}}`` for several.
+
+        Examples
+        --------
+        >>> from py4vasp import demo
+        >>> calculation = demo.calculation(path)
+        >>> basins = calculation.density.bader_analysis()
+        >>> calculation.potential.bader_charge(bader_analysis=basins)
+        {...}
+        """
+        return bader.charge(self, selection, bader_analysis=bader_analysis)
 
     def _to_database(self) -> dict:
         """Return {quantity[_selection]: handler_result} for database storage."""

--- a/src/py4vasp/_calculation/potential.py
+++ b/src/py4vasp/_calculation/potential.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from py4vasp import _config, exception
 from py4vasp._calculation import _stoichiometry
+from py4vasp._calculation.bader import BaderMixin
 from py4vasp._calculation.dispatch import (
     DataSource,
     _dispatch,
@@ -164,6 +165,9 @@ class PotentialHandler:
     def _structure(self):
         return StructureHandler.from_data(self._raw_potential.structure)
 
+    def _bader_grid(self, selection):
+        return dict(self._get_potentials(selection or "total"))
+
     def _get_potentials(self, selection, is_magnetic=False):
         tree = select.Tree.from_selection(selection)
         for selection in tree.selections():
@@ -237,7 +241,7 @@ class PotentialHandler:
 
 
 @quantity("potential")
-class Potential(view.Mixin):
+class Potential(view.Mixin, BaderMixin):
     """The local potential describes the interactions between electrons and ions.
 
     In DFT calculations, the local potential consists of various contributions, each

--- a/src/py4vasp/_demo/density.py
+++ b/src/py4vasp/_demo/density.py
@@ -13,3 +13,14 @@ def Fe3O4(selection):
     structure = _demo.structure.Fe3O4()
     grid = (_demo.number_components(selection), *_demo.GRID_DIMENSIONS)
     return raw.Density(structure=structure, charge=_demo.wrap_random_data(grid))
+
+
+def all_electron():
+    structure = _demo.structure.Fe3O4()
+    grid = (_demo.COLLINEAR, *_demo.GRID_DIMENSIONS)
+    core_grid = (1, *_demo.GRID_DIMENSIONS)
+    return raw.Density(
+        structure=structure,
+        charge=_demo.wrap_random_data(grid),
+        core=_demo.wrap_random_data(core_grid),
+    )

--- a/src/py4vasp/_raw/data.py
+++ b/src/py4vasp/_raw/data.py
@@ -199,6 +199,8 @@ class Density:
     "The atomic structure to represent the densities."
     charge: VaspData
     "The data of electronic charge and magnetization density."
+    core: VaspData = NONE()
+    "Optional core density added to the scalar charge, e.g. for the all-electron density."
 
 
 @dataclasses.dataclass

--- a/src/py4vasp/_raw/definition.py
+++ b/src/py4vasp/_raw/definition.py
@@ -148,6 +148,13 @@ schema.add(
     structure=Link("structure", DEFAULT_SOURCE),
     charge="kinetic_energy_density/values",
 )
+schema.add(
+    raw.Density,
+    name="all_electron",
+    structure=Link("structure", DEFAULT_SOURCE),
+    charge="results/charge/all_electron",
+    core="results/charge/core",
+)
 #
 group = "results/linear_response"
 energies = "energies_dielectric_function"

--- a/src/py4vasp/_third_party/view/__init__.py
+++ b/src/py4vasp/_third_party/view/__init__.py
@@ -3,6 +3,7 @@
 from .mixin import Mixin
 from .view import (
     CrystalSymmetry,
+    GridDomain,
     GridQuantity,
     IonArrow,
     Isosurface,

--- a/src/py4vasp/_third_party/view/view.py
+++ b/src/py4vasp/_third_party/view/view.py
@@ -111,6 +111,31 @@ class GridQuantity:
 
 
 @dataclass
+class GridDomain:
+    """Dataclass to store a partition of a grid into labeled integer domains.
+
+    In contrast to a :class:`~py4vasp.view.GridQuantity`, which stores a continuous
+    field visualized as isosurfaces, a ``GridDomain`` stores an integer label for
+    every grid point assigning it to one of several domains (for example the Bader
+    basins of a charge density). The ``labels`` provide a name for each domain.
+
+    Examples
+    --------
+    >>> from py4vasp.view import GridDomain
+    >>> quantity = [[[[0, 1], [1, 2]], [[1, 1], [2, 2]]]]
+    >>> GridDomain(quantity=quantity, label='basins', labels=['Sr_1', 'Ti_1'])
+    GridDomain(quantity=[[[[...]]]], label='basins', labels=['Sr_1', 'Ti_1'])
+    """
+
+    quantity: npt.ArrayLike
+    """The integer domain index for every grid point. Expected shape is (number of steps, grid size x, grid size y, grid size z)."""
+    label: str
+    """Name of the domain partition."""
+    labels: Sequence[str] = None
+    """Sequence of labels naming each domain. The domain with index ``i`` in ``quantity`` is named by ``labels[i]``."""
+
+
+@dataclass
 class IonArrow:
     """Dataclass to store a vectorial quantity defined at the ion positions and the settings for the arrows to be plotted for this quantity.
 
@@ -349,6 +374,8 @@ class View:
     """Ion positions for all structures in the trajectory, in Direct coordinates. Expected shape is (number of steps, number of ions, 3)."""
     grid_scalars: Optional[Sequence[GridQuantity]] = None
     """This sequence stores quantities that are generated on a grid. Expected shape is (number of quantities,)."""
+    grid_domains: Optional[Sequence[GridDomain]] = None
+    """This sequence stores partitions of a grid into labeled integer domains. Expected shape is (number of quantities,)."""
     ion_arrows: Optional[Sequence[IonArrow]] = None
     """This sequence stores arrows at the atom-centers. Expected shape is (number of quantities,)."""
     phonon: Optional[PhononDispersion] = None

--- a/src/py4vasp/_third_party/view/view.py
+++ b/src/py4vasp/_third_party/view/view.py
@@ -451,6 +451,7 @@ class View:
         >>> calculation.structure.to_view().to_ngl()
         NGLWidget(...)
         """
+        self._raise_error_if_grid_domains_not_implemented()
         self._verify("ngl")
         trajectory = [self._create_atoms(i) for i in self._iterate_trajectory_frames()]
         ngl_trajectory = nglview.ASETrajectory(trajectory)
@@ -483,6 +484,7 @@ class View:
         structure, isosurfaces and arrows at atom centers. The attributes of View are
         added to a dictionary with which to initialize a VASP Viewer widget.
         """
+        self._raise_error_if_grid_domains_not_implemented()
         self._verify()
         structure: dict = {
             "atoms_trajectory": self._convert_to_list(self.positions),
@@ -592,6 +594,12 @@ class View:
                 [int(index), str(label)] for index, label in phonon.path_labels
             ]
         return config
+
+    def _raise_error_if_grid_domains_not_implemented(self):
+        if self.grid_domains:
+            raise exception.NotImplemented(
+                "Visualizing grid domains is not implemented yet."
+            )
 
     def _verify(self, mode=None):
         self._raise_error_if_present_on_multiple_steps(self.grid_scalars, mode)
@@ -779,7 +787,7 @@ class View:
 def _merge_view_fields(left_view, right_view):
     merged = {}
     for field in fields(View):
-        if field.name in ("grid_scalars", "ion_arrows"):
+        if field.name in ("grid_scalars", "grid_domains", "ion_arrows"):
             merged[field.name] = _merge_special_sequence(
                 getattr(left_view, field.name),
                 getattr(right_view, field.name),

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -5,6 +5,8 @@ import itertools
 
 import numpy as np
 
+from py4vasp import exception
+
 # the 26 neighbor offsets on a 3d grid (all combinations of -1, 0, 1 except origin)
 _OFFSETS = np.array(
     [offset for offset in itertools.product((-1, 0, 1), repeat=3) if any(offset)]
@@ -42,10 +44,28 @@ def basins(charge, lattice_vectors, positions=None):
         point to a basin.
     """
     charge = np.asarray(charge)
-    pointers = _ascent_pointers(charge, np.asarray(lattice_vectors))
+    lattice_vectors = np.asarray(lattice_vectors)
+    _raise_error_if_charge_not_3d(charge)
+    pointers = _ascent_pointers(charge, lattice_vectors)
     maxima = _resolve_to_maxima(pointers)
-    labels = _label_consecutively(maxima)
+    if positions is None:
+        return _label_consecutively(maxima).reshape(charge.shape)
+    positions = np.asarray(positions)
+    _raise_error_if_positions_invalid(positions)
+    labels = _label_by_nearest_atom(maxima, charge.shape, lattice_vectors, positions)
     return labels.reshape(charge.shape)
+
+
+def _label_by_nearest_atom(maxima, shape, lattice_vectors, positions):
+    "Assign the basin of each maximum to the nearest atom (minimum image)."
+    unique_maxima, inverse = np.unique(maxima, return_inverse=True)
+    grid_indices = np.stack(np.unravel_index(unique_maxima, shape), axis=1)
+    fractional = grid_indices / np.array(shape)
+    distance = fractional[:, np.newaxis, :] - positions[np.newaxis, :, :]
+    distance = (distance + 0.5) % 1.0 - 0.5
+    cartesian = distance @ lattice_vectors
+    nearest_atom = np.argmin(np.sum(cartesian**2, axis=-1), axis=1)
+    return nearest_atom[inverse]
 
 
 def _resolve_to_maxima(pointers):
@@ -85,3 +105,19 @@ def _ascent_pointers(charge, lattice_vectors):
         best_slope = np.where(improved, slope, best_slope)
         pointers = np.where(improved, neighbor, pointers)
     return pointers.ravel()
+
+
+def _raise_error_if_charge_not_3d(charge):
+    if charge.ndim != 3:
+        raise exception.IncorrectUsage(
+            "The charge density must be sampled on a 3d grid, but an array with "
+            f"{charge.ndim} dimensions was provided."
+        )
+
+
+def _raise_error_if_positions_invalid(positions):
+    if positions.ndim != 2 or positions.shape[1] != 3:
+        raise exception.IncorrectUsage(
+            "The positions must have shape (number_atoms, 3), but an array with "
+            f"shape {positions.shape} was provided."
+        )

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -40,11 +40,20 @@ class BaderAnalysis(view.Mixin):
         maximum is snapped to its nearest atom and the basins are labeled by atom
         index. If False, the basins are labeled by an arbitrary index enumerating
         the distinct maxima.
+    reference : np.ndarray or None
+        Optional density used *only* to construct the basins. If given, the basins
+        follow this (typically better-peaked) density while ``charges`` and
+        ``to_view`` still act on ``density``. This is used for the all-electron
+        density, where the core is accurate enough to place the basins but too
+        coarsely sampled to integrate.
     """
 
-    def __init__(self, structure, density, snap_to_atoms=True):
+    def __init__(self, structure, density, snap_to_atoms=True, reference=None):
         self._density = np.asarray(density)
         _raise_error_if_density_not_3d(self._density)
+        basin_density = self._density if reference is None else np.asarray(reference)
+        _raise_error_if_density_not_3d(basin_density)
+        _raise_error_if_shape_differs(basin_density, self._density)
         # Materialize everything derived from the structure now, while the raw data
         # is still available. The analysis is typically returned to the user after
         # the file context has closed, so it must not read lazily loaded data later.
@@ -52,14 +61,14 @@ class BaderAnalysis(view.Mixin):
         positions = np.asarray(structure.positions())
         self._names = list(structure.to_dict()["names"])
         self._view = structure.to_view()
-        maxima = _resolve_to_maxima(_ascent_pointers(self._density, lattice_vectors))
+        maxima = _resolve_to_maxima(_ascent_pointers(basin_density, lattice_vectors))
         if snap_to_atoms:
             labels = _label_by_nearest_atom(
-                maxima, self._density.shape, lattice_vectors, positions
+                maxima, basin_density.shape, lattice_vectors, positions
             )
         else:
             labels = _label_consecutively(maxima)
-        self._basins = labels.reshape(self._density.shape)
+        self._basins = labels.reshape(basin_density.shape)
 
     def __str__(self):
         charges = self.charges()
@@ -149,28 +158,45 @@ class BaderAnalysis(view.Mixin):
         return viewer
 
 
-def analysis_from_selection(structure, grid_for_selection, selection, snap_to_atoms=True):
+def analysis_from_selection(
+    structure,
+    grid_for_selection,
+    selection,
+    snap_to_atoms=True,
+    reference_for_selection=None,
+):
     """Build a :class:`BaderAnalysis` from a single selected density.
 
     ``grid_for_selection`` is a callable mapping a selection string to a dictionary
     of labeled grid arrays. Injecting it keeps this helper free of any coupling to
-    a specific quantity (composition instead of inheritance).
+    a specific quantity (composition instead of inheritance). ``reference_for_selection``
+    optionally provides a different density (e.g. with the core) to construct the
+    basins from.
     """
     grids = grid_for_selection(selection)
     _raise_error_if_not_single_density(grids)
     (density,) = grids.values()
-    return BaderAnalysis(structure, density, snap_to_atoms=snap_to_atoms)
+    reference = _reference(reference_for_selection, selection)
+    return BaderAnalysis(
+        structure, density, snap_to_atoms=snap_to_atoms, reference=reference
+    )
 
 
 def charges_from_selection(
-    structure, grid_for_selection, selection, snap_to_atoms=True, analysis=None
+    structure,
+    grid_for_selection,
+    selection,
+    snap_to_atoms=True,
+    analysis=None,
+    reference_for_selection=None,
 ):
     """Integrate the selected density within Bader basins.
 
     The basins are taken from ``analysis`` if given, otherwise from an inner
     ``basins=Y`` selection (partitioning the density selected by ``Y``), otherwise
-    from the integrated density itself. Returns ``{atom: charge}`` for a single
-    selection or ``{selection: {atom: charge}}`` for several.
+    from the integrated density itself (or its ``reference_for_selection`` when one
+    is provided). Returns ``{atom: charge}`` for a single selection or
+    ``{selection: {atom: charge}}`` for several.
     """
     results = {}
     for parsed in select.Tree.from_selection(selection).selections():
@@ -180,12 +206,18 @@ def charges_from_selection(
         for label, density in grid_for_selection(integrand_selection).items():
             basis = _basis_analysis(
                 structure, grid_for_selection, basin_source, analysis, density,
-                snap_to_atoms,
+                snap_to_atoms, reference_for_selection, integrand_selection,
             )
             results[label] = basis.charges(density)
     if len(results) == 1:
         return next(iter(results.values()))
     return results
+
+
+def _reference(reference_for_selection, selection):
+    if reference_for_selection is None:
+        return None
+    return reference_for_selection(selection)
 
 
 def _basin_source(parsed):
@@ -205,14 +237,24 @@ def _is_basins_assignment(part):
 
 
 def _basis_analysis(
-    structure, grid_for_selection, basin_source, analysis, density, snap_to_atoms
+    structure,
+    grid_for_selection,
+    basin_source,
+    analysis,
+    density,
+    snap_to_atoms,
+    reference_for_selection,
+    integrand_selection,
 ):
     if analysis is not None:
         return analysis
     if basin_source is not None:
         (basin_density,) = grid_for_selection(basin_source).values()
         return BaderAnalysis(structure, basin_density, snap_to_atoms=snap_to_atoms)
-    return BaderAnalysis(structure, density, snap_to_atoms=snap_to_atoms)
+    reference = _reference(reference_for_selection, integrand_selection)
+    return BaderAnalysis(
+        structure, density, snap_to_atoms=snap_to_atoms, reference=reference
+    )
 
 
 def _label_by_nearest_atom(maxima, shape, lattice_vectors, positions):

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -6,6 +6,7 @@ import itertools
 import numpy as np
 
 from py4vasp import exception
+from py4vasp._third_party import view
 
 # the 26 neighbor offsets on a 3d grid (all combinations of -1, 0, 1 except origin)
 _OFFSETS = np.array(
@@ -13,7 +14,7 @@ _OFFSETS = np.array(
 )
 
 
-class Bader:
+class Bader(view.Mixin):
     """Bader charge analysis of a density defined on a grid.
 
     This class partitions a charge density into atomic basins following the
@@ -25,7 +26,7 @@ class Bader:
     ----------
     structure
         A structure handler providing the geometry of the system via
-        ``lattice_vectors``, ``positions``, and ``to_view``.
+        ``lattice_vectors``, ``positions``, ``to_dict``, and ``to_view``.
     """
 
     def __init__(self, structure):
@@ -58,6 +59,41 @@ class Bader:
         """
         positions = self._structure.positions() if snap_to_atoms else None
         return _partition(charge, self._structure.lattice_vectors(), positions)
+
+    def to_view(self, charge, threshold=0.0, supercell=None):
+        """Visualize the Bader basins as labeled domains within the structure.
+
+        Parameters
+        ----------
+        charge : np.ndarray
+            The charge density sampled on a 3d grid with shape ``(nx, ny, nz)``.
+        threshold : float
+            Grid points where the density is below this absolute value are
+            assigned to the background domain ``0`` and hidden. The default of
+            ``0`` keeps every point.
+        supercell : int | np.ndarray | None
+            If present the structure is replicated the specified number of times
+            along each direction.
+
+        Returns
+        -------
+        View
+            A visualization where every grid point carries the index of the atom
+            its basin was snapped to (``1`` to number of atoms), or ``0`` if it is
+            below the threshold. The domains are labeled by the atom names.
+        """
+        charge = np.asarray(charge)
+        domains = self.basins(charge, snap_to_atoms=True) + 1
+        domains[charge < threshold] = 0
+        viewer = self._structure.to_view(supercell)
+        viewer.grid_domains = [
+            view.GridDomain(
+                quantity=domains[np.newaxis],
+                label="basins",
+                labels=self._structure.to_dict()["names"],
+            )
+        ]
+        return viewer
 
 
 def _partition(charge, lattice_vectors, positions=None):

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -69,6 +69,9 @@ class BaderAnalysis(view.Mixin):
         ]
         return "Bader charges:\n" + "\n".join(lines)
 
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self))
+
     def basins(self):
         """Return the basin partition of the density.
 
@@ -115,9 +118,11 @@ class BaderAnalysis(view.Mixin):
         Parameters
         ----------
         threshold : float
-            Grid points where the density is below this absolute value are
-            assigned to the background domain ``0`` and hidden. The default of
-            ``0`` keeps every point.
+            Grid points where the density is below ``threshold`` times the maximum
+            density are assigned to the background domain ``0`` and hidden. Because
+            the cutoff is relative to the maximum, it is independent of the grid
+            sampling and of the total number of electrons. The default of ``0``
+            keeps every point.
         supercell : int | np.ndarray | None
             If present the structure is replicated the specified number of times
             along each direction.
@@ -130,7 +135,7 @@ class BaderAnalysis(view.Mixin):
             below the threshold. The domains are labeled by the atom names.
         """
         domains = self._basins + 1
-        domains[self._density < threshold] = 0
+        domains[self._density < threshold * self._density.max()] = 0
         viewer = copy.copy(self._view)
         if supercell is not None:
             viewer.supercell = supercell

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -13,36 +13,54 @@ _OFFSETS = np.array(
 )
 
 
-def basins(charge, lattice_vectors, positions=None):
-    """Partition a charge-density grid into Bader basins.
+class Bader:
+    """Bader charge analysis of a density defined on a grid.
 
-    Every grid point is assigned to a basin by following the steepest ascent of
-    the density until a local maximum is reached; all points reaching the same
-    maximum form one basin.
+    This class partitions a charge density into atomic basins following the
+    grid-based steepest-ascent algorithm. It is constructed from a structure so
+    that the lattice vectors, atomic positions, and atom labels are all available
+    to the analysis.
 
     Parameters
     ----------
-    charge : np.ndarray
-        The charge density sampled on a 3d grid with shape ``(nx, ny, nz)``, in
-        the orientation returned by :py:meth:`Density.to_numpy`.
-    lattice_vectors : np.ndarray
-        The ``3x3`` lattice vectors (rows) spanning the unit cell. They define the
-        Cartesian distances between neighboring grid points, so that the ascent
-        respects the anisotropy of a non-orthogonal cell.
-    positions : np.ndarray or None
-        Optional fractional coordinates of the atoms with shape ``(n_atoms, 3)``.
-        VASP pseudo densities need not be peaked at the nuclei, so the raw maxima
-        may sit in bonds or interstitial regions. If positions are provided, every
-        maximum is snapped to its nearest atom and the resulting basins are
-        labeled by atom index. If omitted, the basins are labeled by an arbitrary
-        index enumerating the distinct maxima.
-
-    Returns
-    -------
-    np.ndarray
-        An integer array of the same shape as ``charge`` assigning every grid
-        point to a basin.
+    structure
+        A structure handler providing the geometry of the system via
+        ``lattice_vectors``, ``positions``, and ``to_view``.
     """
+
+    def __init__(self, structure):
+        self._structure = structure
+
+    def basins(self, charge, snap_to_atoms=True):
+        """Partition a charge-density grid into Bader basins.
+
+        Every grid point is assigned to a basin by following the steepest ascent
+        of the density until a local maximum is reached; all points reaching the
+        same maximum form one basin.
+
+        Parameters
+        ----------
+        charge : np.ndarray
+            The charge density sampled on a 3d grid with shape ``(nx, ny, nz)``,
+            in the orientation returned by :py:meth:`Density.to_numpy`.
+        snap_to_atoms : bool
+            VASP pseudo densities need not be peaked at the nuclei, so the raw
+            maxima may sit in bonds or interstitial regions. If True (default),
+            every maximum is snapped to its nearest atom and the resulting basins
+            are labeled by atom index. If False, the basins are labeled by an
+            arbitrary index enumerating the distinct maxima.
+
+        Returns
+        -------
+        np.ndarray
+            An integer array of the same shape as ``charge`` assigning every grid
+            point to a basin.
+        """
+        positions = self._structure.positions() if snap_to_atoms else None
+        return _partition(charge, self._structure.lattice_vectors(), positions)
+
+
+def _partition(charge, lattice_vectors, positions=None):
     charge = np.asarray(charge)
     lattice_vectors = np.asarray(lattice_vectors)
     _raise_error_if_charge_not_3d(charge)
@@ -51,7 +69,6 @@ def basins(charge, lattice_vectors, positions=None):
     if positions is None:
         return _label_consecutively(maxima).reshape(charge.shape)
     positions = np.asarray(positions)
-    _raise_error_if_positions_invalid(positions)
     labels = _label_by_nearest_atom(maxima, charge.shape, lattice_vectors, positions)
     return labels.reshape(charge.shape)
 
@@ -112,12 +129,4 @@ def _raise_error_if_charge_not_3d(charge):
         raise exception.IncorrectUsage(
             "The charge density must be sampled on a 3d grid, but an array with "
             f"{charge.ndim} dimensions was provided."
-        )
-
-
-def _raise_error_if_positions_invalid(positions):
-    if positions.ndim != 2 or positions.shape[1] != 3:
-        raise exception.IncorrectUsage(
-            "The positions must have shape (number_atoms, 3), but an array with "
-            f"shape {positions.shape} was provided."
         )

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -14,59 +14,64 @@ _OFFSETS = np.array(
 )
 
 
-class Bader(view.Mixin):
+class BaderAnalysis(view.Mixin):
     """Bader charge analysis of a density defined on a grid.
 
-    This class partitions a charge density into atomic basins following the
-    grid-based steepest-ascent algorithm. It is constructed from a structure so
-    that the lattice vectors, atomic positions, and atom labels are all available
-    to the analysis.
+    This class partitions a density into atomic basins following the grid-based
+    steepest-ascent algorithm. The density is provided at construction time, so
+    the (comparatively expensive) partition is computed once and reused by all
+    methods. The structure supplies the lattice vectors, atomic positions, and
+    atom labels the analysis needs.
 
     Parameters
     ----------
     structure
         A structure handler providing the geometry of the system via
-        ``lattice_vectors``, ``positions``, ``to_dict``, and ``to_view``.
+        ``lattice_vectors``, ``positions``, ``volume``, ``to_dict``, and
+        ``to_view``.
+    density : np.ndarray
+        The density sampled on a 3d grid with shape ``(nx, ny, nz)``, in the
+        orientation returned by :py:meth:`Density.to_numpy`.
+    snap_to_atoms : bool
+        VASP pseudo densities need not be peaked at the nuclei, so the raw maxima
+        may sit in bonds or interstitial regions. If True (default), every
+        maximum is snapped to its nearest atom and the basins are labeled by atom
+        index. If False, the basins are labeled by an arbitrary index enumerating
+        the distinct maxima.
     """
 
-    def __init__(self, structure):
+    def __init__(self, structure, density, snap_to_atoms=True):
         self._structure = structure
+        self._density = np.asarray(density)
+        _raise_error_if_density_not_3d(self._density)
+        self._snap_to_atoms = snap_to_atoms
+        lattice_vectors = structure.lattice_vectors()
+        maxima = _resolve_to_maxima(_ascent_pointers(self._density, lattice_vectors))
+        if snap_to_atoms:
+            labels = _label_by_nearest_atom(
+                maxima, self._density.shape, lattice_vectors, structure.positions()
+            )
+        else:
+            labels = _label_consecutively(maxima)
+        self._basins = labels.reshape(self._density.shape)
 
-    def basins(self, charge, snap_to_atoms=True):
-        """Partition a charge-density grid into Bader basins.
-
-        Every grid point is assigned to a basin by following the steepest ascent
-        of the density until a local maximum is reached; all points reaching the
-        same maximum form one basin.
-
-        Parameters
-        ----------
-        charge : np.ndarray
-            The charge density sampled on a 3d grid with shape ``(nx, ny, nz)``,
-            in the orientation returned by :py:meth:`Density.to_numpy`.
-        snap_to_atoms : bool
-            VASP pseudo densities need not be peaked at the nuclei, so the raw
-            maxima may sit in bonds or interstitial regions. If True (default),
-            every maximum is snapped to its nearest atom and the resulting basins
-            are labeled by atom index. If False, the basins are labeled by an
-            arbitrary index enumerating the distinct maxima.
+    def basins(self):
+        """Return the basin partition of the density.
 
         Returns
         -------
         np.ndarray
-            An integer array of the same shape as ``charge`` assigning every grid
-            point to a basin.
+            An integer array of the same shape as the density assigning every grid
+            point to a basin. With ``snap_to_atoms`` the label is the index of the
+            nearest atom, otherwise an arbitrary index enumerating the maxima.
         """
-        positions = self._structure.positions() if snap_to_atoms else None
-        return _partition(charge, self._structure.lattice_vectors(), positions)
+        return self._basins
 
-    def to_view(self, charge, threshold=0.0, supercell=None):
+    def to_view(self, threshold=0.0, supercell=None):
         """Visualize the Bader basins as labeled domains within the structure.
 
         Parameters
         ----------
-        charge : np.ndarray
-            The charge density sampled on a 3d grid with shape ``(nx, ny, nz)``.
         threshold : float
             Grid points where the density is below this absolute value are
             assigned to the background domain ``0`` and hidden. The default of
@@ -82,9 +87,8 @@ class Bader(view.Mixin):
             its basin was snapped to (``1`` to number of atoms), or ``0`` if it is
             below the threshold. The domains are labeled by the atom names.
         """
-        charge = np.asarray(charge)
-        domains = self.basins(charge, snap_to_atoms=True) + 1
-        domains[charge < threshold] = 0
+        domains = self._basins + 1
+        domains[self._density < threshold] = 0
         viewer = self._structure.to_view(supercell)
         viewer.grid_domains = [
             view.GridDomain(
@@ -94,19 +98,6 @@ class Bader(view.Mixin):
             )
         ]
         return viewer
-
-
-def _partition(charge, lattice_vectors, positions=None):
-    charge = np.asarray(charge)
-    lattice_vectors = np.asarray(lattice_vectors)
-    _raise_error_if_charge_not_3d(charge)
-    pointers = _ascent_pointers(charge, lattice_vectors)
-    maxima = _resolve_to_maxima(pointers)
-    if positions is None:
-        return _label_consecutively(maxima).reshape(charge.shape)
-    positions = np.asarray(positions)
-    labels = _label_by_nearest_atom(maxima, charge.shape, lattice_vectors, positions)
-    return labels.reshape(charge.shape)
 
 
 def _label_by_nearest_atom(maxima, shape, lattice_vectors, positions):
@@ -160,9 +151,9 @@ def _ascent_pointers(charge, lattice_vectors):
     return pointers.ravel()
 
 
-def _raise_error_if_charge_not_3d(charge):
-    if charge.ndim != 3:
+def _raise_error_if_density_not_3d(density):
+    if density.ndim != 3:
         raise exception.IncorrectUsage(
-            "The charge density must be sampled on a 3d grid, but an array with "
-            f"{charge.ndim} dimensions was provided."
+            "The density must be sampled on a 3d grid, but an array with "
+            f"{density.ndim} dimensions was provided."
         )

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -61,6 +61,14 @@ class BaderAnalysis(view.Mixin):
             labels = _label_consecutively(maxima)
         self._basins = labels.reshape(self._density.shape)
 
+    def __str__(self):
+        charges = self.charges()
+        width = max(len(name) for name in charges)
+        lines = [
+            f"    {name:<{width}}   {charge:.4f}" for name, charge in charges.items()
+        ]
+        return "Bader charges:\n" + "\n".join(lines)
+
     def basins(self):
         """Return the basin partition of the density.
 

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -1,0 +1,35 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+"""Grid-based Bader partitioning of a charge density into atomic basins."""
+import itertools
+
+import numpy as np
+
+# the 26 neighbor offsets on a 3d grid (all combinations of -1, 0, 1 except origin)
+_OFFSETS = np.array(
+    [offset for offset in itertools.product((-1, 0, 1), repeat=3) if any(offset)]
+)
+
+
+def _ascent_pointers(charge, lattice_vectors):
+    """For every grid point, return the flat index of its steepest-ascent neighbor.
+
+    The gradient towards each of the 26 neighbors is the density difference divided
+    by the Cartesian distance to that neighbor, so that the anisotropy of a
+    non-orthogonal cell is accounted for. A grid point that is a local maximum
+    points to itself.
+    """
+    shape = charge.shape
+    spacing = lattice_vectors / np.reshape(shape, (3, 1))
+    flat_indices = np.arange(charge.size).reshape(shape)
+    best_slope = np.zeros(shape)
+    pointers = flat_indices.copy()
+    for offset in _OFFSETS:
+        distance = np.linalg.norm(offset @ spacing)
+        shift = tuple(-offset)
+        slope = (np.roll(charge, shift, axis=(0, 1, 2)) - charge) / distance
+        neighbor = np.roll(flat_indices, shift, axis=(0, 1, 2))
+        improved = slope > best_slope
+        best_slope = np.where(improved, slope, best_slope)
+        pointers = np.where(improved, neighbor, pointers)
+    return pointers.ravel()

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -67,6 +67,33 @@ class BaderAnalysis(view.Mixin):
         """
         return self._basins
 
+    def charges(self, density=None):
+        """Integrate a density within each basin.
+
+        Parameters
+        ----------
+        density : np.ndarray or None
+            The density to integrate on the same grid as the analysis. If None
+            (default), the density used to construct the basins is integrated,
+            which yields the Bader charges. Passing a different density integrates
+            that quantity within the existing basins, which is useful to combine
+            basins defined by one density with values taken from another.
+
+        Returns
+        -------
+        dict
+            Maps every atom label to the value integrated within its basin.
+        """
+        density = self._density if density is None else np.asarray(density)
+        _raise_error_if_density_not_3d(density)
+        _raise_error_if_shape_differs(density, self._density)
+        names = self._structure.to_dict()["names"]
+        volume_element = self._structure.volume() / density.size
+        totals = np.bincount(
+            self._basins.ravel(), weights=density.ravel(), minlength=len(names)
+        )
+        return dict(zip(names, totals * volume_element))
+
     def to_view(self, threshold=0.0, supercell=None):
         """Visualize the Bader basins as labeled domains within the structure.
 
@@ -156,4 +183,12 @@ def _raise_error_if_density_not_3d(density):
         raise exception.IncorrectUsage(
             "The density must be sampled on a 3d grid, but an array with "
             f"{density.ndim} dimensions was provided."
+        )
+
+
+def _raise_error_if_shape_differs(density, reference):
+    if density.shape != reference.shape:
+        raise exception.IncorrectUsage(
+            f"The density has shape {density.shape} which does not match the grid "
+            f"{reference.shape} used to construct the basins."
         )

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -1,6 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 """Grid-based Bader partitioning of a charge density into atomic basins."""
+import copy
 import itertools
 
 import numpy as np
@@ -42,15 +43,19 @@ class BaderAnalysis(view.Mixin):
     """
 
     def __init__(self, structure, density, snap_to_atoms=True):
-        self._structure = structure
         self._density = np.asarray(density)
         _raise_error_if_density_not_3d(self._density)
-        self._snap_to_atoms = snap_to_atoms
-        lattice_vectors = structure.lattice_vectors()
+        # Materialize everything derived from the structure now, while the raw data
+        # is still available. The analysis is typically returned to the user after
+        # the file context has closed, so it must not read lazily loaded data later.
+        lattice_vectors = np.asarray(structure.lattice_vectors())
+        positions = np.asarray(structure.positions())
+        self._names = list(structure.to_dict()["names"])
+        self._view = structure.to_view()
         maxima = _resolve_to_maxima(_ascent_pointers(self._density, lattice_vectors))
         if snap_to_atoms:
             labels = _label_by_nearest_atom(
-                maxima, self._density.shape, lattice_vectors, structure.positions()
+                maxima, self._density.shape, lattice_vectors, positions
             )
         else:
             labels = _label_consecutively(maxima)
@@ -83,17 +88,18 @@ class BaderAnalysis(view.Mixin):
         Returns
         -------
         dict
-            Maps every atom label to the value integrated within its basin.
+            Maps every atom label to the value integrated within its basin. The
+            density follows the VASP convention where ``sum(density) / density.size``
+            equals the total number of electrons, so summing over all basins
+            reproduces that total.
         """
         density = self._density if density is None else np.asarray(density)
         _raise_error_if_density_not_3d(density)
         _raise_error_if_shape_differs(density, self._density)
-        names = self._structure.to_dict()["names"]
-        volume_element = self._structure.volume() / density.size
         totals = np.bincount(
-            self._basins.ravel(), weights=density.ravel(), minlength=len(names)
+            self._basins.ravel(), weights=density.ravel(), minlength=len(self._names)
         )
-        return dict(zip(names, totals * volume_element))
+        return dict(zip(self._names, totals / density.size))
 
     def to_view(self, threshold=0.0, supercell=None):
         """Visualize the Bader basins as labeled domains within the structure.
@@ -117,12 +123,14 @@ class BaderAnalysis(view.Mixin):
         """
         domains = self._basins + 1
         domains[self._density < threshold] = 0
-        viewer = self._structure.to_view(supercell)
+        viewer = copy.copy(self._view)
+        if supercell is not None:
+            viewer.supercell = supercell
         viewer.grid_domains = [
             view.GridDomain(
                 quantity=domains[np.newaxis],
                 label="basins",
-                labels=self._structure.to_dict()["names"],
+                labels=self._names,
             )
         ]
         return viewer

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -182,33 +182,20 @@ def analysis_from_selection(
     )
 
 
-def charges_from_selection(
-    structure,
-    grid_for_selection,
-    selection,
-    snap_to_atoms=True,
-    analysis=None,
-    reference_for_selection=None,
-):
-    """Integrate the selected density within Bader basins.
+def charges_from_selection(grid_for_selection, selection, analysis):
+    """Integrate the selected grid(s) within the basins of ``analysis``.
 
-    The basins are taken from ``analysis`` if given, otherwise from an inner
-    ``basins=Y`` selection (partitioning the density selected by ``Y``), otherwise
-    from the integrated density itself (or its ``reference_for_selection`` when one
-    is provided). Returns ``{atom: charge}`` for a single selection or
+    ``analysis`` is a :class:`BaderAnalysis` supplying the basins (only the charge
+    density can define them, so it is always provided by the caller rather than
+    reconstructed here). Returns ``{atom: charge}`` for a single selection or
     ``{selection: {atom: charge}}`` for several.
     """
+    _raise_error_if_no_analysis(analysis)
     results = {}
     for parsed in select.Tree.from_selection(selection).selections():
-        basin_source = _basin_source(parsed)
-        _raise_error_if_basins_and_analysis(basin_source, analysis)
-        integrand_selection = _remaining_selection(parsed)
+        integrand_selection = _selection_string(parsed)
         for label, density in grid_for_selection(integrand_selection).items():
-            basis = _basis_analysis(
-                structure, grid_for_selection, basin_source, analysis, density,
-                snap_to_atoms, reference_for_selection, integrand_selection,
-            )
-            results[label] = basis.charges(density)
+            results[label] = analysis.charges(density)
     if len(results) == 1:
         return next(iter(results.values()))
     return results
@@ -220,41 +207,8 @@ def _reference(reference_for_selection, selection):
     return reference_for_selection(selection)
 
 
-def _basin_source(parsed):
-    for part in parsed:
-        if isinstance(part, select.Assignment) and part.left_operand == "basins":
-            return part.right_operand
-    return None
-
-
-def _remaining_selection(parsed):
-    parts = [part for part in parsed if not _is_basins_assignment(part)]
-    return select.selections_to_string([parts]) if parts else None
-
-
-def _is_basins_assignment(part):
-    return isinstance(part, select.Assignment) and part.left_operand == "basins"
-
-
-def _basis_analysis(
-    structure,
-    grid_for_selection,
-    basin_source,
-    analysis,
-    density,
-    snap_to_atoms,
-    reference_for_selection,
-    integrand_selection,
-):
-    if analysis is not None:
-        return analysis
-    if basin_source is not None:
-        (basin_density,) = grid_for_selection(basin_source).values()
-        return BaderAnalysis(structure, basin_density, snap_to_atoms=snap_to_atoms)
-    reference = _reference(reference_for_selection, integrand_selection)
-    return BaderAnalysis(
-        structure, density, snap_to_atoms=snap_to_atoms, reference=reference
-    )
+def _selection_string(parsed):
+    return select.selections_to_string([list(parsed)]) if parsed else None
 
 
 def _label_by_nearest_atom(maxima, shape, lattice_vectors, positions):
@@ -324,11 +278,12 @@ def _raise_error_if_shape_differs(density, reference):
         )
 
 
-def _raise_error_if_basins_and_analysis(basin_source, analysis):
-    if basin_source is not None and analysis is not None:
+def _raise_error_if_no_analysis(analysis):
+    if analysis is None:
         raise exception.IncorrectUsage(
-            "Specify the basin-defining density either via a 'basins=' selection "
-            "or via the bader_analysis argument, but not both."
+            "bader_charge requires the basins to be supplied via the bader_analysis "
+            "argument. Bader basins are defined by the charge density, so obtain them "
+            "from calc.density.bader_analysis() and pass the result here."
         )
 
 

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -1,6 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 """Grid-based Bader partitioning of a charge density into atomic basins."""
+
 import copy
 import itertools
 

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -11,6 +11,58 @@ _OFFSETS = np.array(
 )
 
 
+def basins(charge, lattice_vectors, positions=None):
+    """Partition a charge-density grid into Bader basins.
+
+    Every grid point is assigned to a basin by following the steepest ascent of
+    the density until a local maximum is reached; all points reaching the same
+    maximum form one basin.
+
+    Parameters
+    ----------
+    charge : np.ndarray
+        The charge density sampled on a 3d grid with shape ``(nx, ny, nz)``, in
+        the orientation returned by :py:meth:`Density.to_numpy`.
+    lattice_vectors : np.ndarray
+        The ``3x3`` lattice vectors (rows) spanning the unit cell. They define the
+        Cartesian distances between neighboring grid points, so that the ascent
+        respects the anisotropy of a non-orthogonal cell.
+    positions : np.ndarray or None
+        Optional fractional coordinates of the atoms with shape ``(n_atoms, 3)``.
+        VASP pseudo densities need not be peaked at the nuclei, so the raw maxima
+        may sit in bonds or interstitial regions. If positions are provided, every
+        maximum is snapped to its nearest atom and the resulting basins are
+        labeled by atom index. If omitted, the basins are labeled by an arbitrary
+        index enumerating the distinct maxima.
+
+    Returns
+    -------
+    np.ndarray
+        An integer array of the same shape as ``charge`` assigning every grid
+        point to a basin.
+    """
+    charge = np.asarray(charge)
+    pointers = _ascent_pointers(charge, np.asarray(lattice_vectors))
+    maxima = _resolve_to_maxima(pointers)
+    labels = _label_consecutively(maxima)
+    return labels.reshape(charge.shape)
+
+
+def _resolve_to_maxima(pointers):
+    "Follow the pointer field until each grid point reaches its maximum."
+    while True:
+        next_pointers = pointers[pointers]
+        if np.array_equal(next_pointers, pointers):
+            return pointers
+        pointers = next_pointers
+
+
+def _label_consecutively(maxima):
+    "Map the flat maximum indices to consecutive basin labels starting at 0."
+    _, labels = np.unique(maxima, return_inverse=True)
+    return labels.reshape(maxima.shape)
+
+
 def _ascent_pointers(charge, lattice_vectors):
     """For every grid point, return the flat index of its steepest-ascent neighbor.
 

--- a/src/py4vasp/_util/bader.py
+++ b/src/py4vasp/_util/bader.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from py4vasp import exception
 from py4vasp._third_party import view
+from py4vasp._util import select
 
 # the 26 neighbor offsets on a 3d grid (all combinations of -1, 0, 1 except origin)
 _OFFSETS = np.array(
@@ -127,6 +128,72 @@ class BaderAnalysis(view.Mixin):
         return viewer
 
 
+def analysis_from_selection(structure, grid_for_selection, selection, snap_to_atoms=True):
+    """Build a :class:`BaderAnalysis` from a single selected density.
+
+    ``grid_for_selection`` is a callable mapping a selection string to a dictionary
+    of labeled grid arrays. Injecting it keeps this helper free of any coupling to
+    a specific quantity (composition instead of inheritance).
+    """
+    grids = grid_for_selection(selection)
+    _raise_error_if_not_single_density(grids)
+    (density,) = grids.values()
+    return BaderAnalysis(structure, density, snap_to_atoms=snap_to_atoms)
+
+
+def charges_from_selection(
+    structure, grid_for_selection, selection, snap_to_atoms=True, analysis=None
+):
+    """Integrate the selected density within Bader basins.
+
+    The basins are taken from ``analysis`` if given, otherwise from an inner
+    ``basins=Y`` selection (partitioning the density selected by ``Y``), otherwise
+    from the integrated density itself. Returns ``{atom: charge}`` for a single
+    selection or ``{selection: {atom: charge}}`` for several.
+    """
+    results = {}
+    for parsed in select.Tree.from_selection(selection).selections():
+        basin_source = _basin_source(parsed)
+        _raise_error_if_basins_and_analysis(basin_source, analysis)
+        integrand_selection = _remaining_selection(parsed)
+        for label, density in grid_for_selection(integrand_selection).items():
+            basis = _basis_analysis(
+                structure, grid_for_selection, basin_source, analysis, density,
+                snap_to_atoms,
+            )
+            results[label] = basis.charges(density)
+    if len(results) == 1:
+        return next(iter(results.values()))
+    return results
+
+
+def _basin_source(parsed):
+    for part in parsed:
+        if isinstance(part, select.Assignment) and part.left_operand == "basins":
+            return part.right_operand
+    return None
+
+
+def _remaining_selection(parsed):
+    parts = [part for part in parsed if not _is_basins_assignment(part)]
+    return select.selections_to_string([parts]) if parts else None
+
+
+def _is_basins_assignment(part):
+    return isinstance(part, select.Assignment) and part.left_operand == "basins"
+
+
+def _basis_analysis(
+    structure, grid_for_selection, basin_source, analysis, density, snap_to_atoms
+):
+    if analysis is not None:
+        return analysis
+    if basin_source is not None:
+        (basin_density,) = grid_for_selection(basin_source).values()
+        return BaderAnalysis(structure, basin_density, snap_to_atoms=snap_to_atoms)
+    return BaderAnalysis(structure, density, snap_to_atoms=snap_to_atoms)
+
+
 def _label_by_nearest_atom(maxima, shape, lattice_vectors, positions):
     "Assign the basin of each maximum to the nearest atom (minimum image)."
     unique_maxima, inverse = np.unique(maxima, return_inverse=True)
@@ -191,4 +258,20 @@ def _raise_error_if_shape_differs(density, reference):
         raise exception.IncorrectUsage(
             f"The density has shape {density.shape} which does not match the grid "
             f"{reference.shape} used to construct the basins."
+        )
+
+
+def _raise_error_if_basins_and_analysis(basin_source, analysis):
+    if basin_source is not None and analysis is not None:
+        raise exception.IncorrectUsage(
+            "Specify the basin-defining density either via a 'basins=' selection "
+            "or via the bader_analysis argument, but not both."
+        )
+
+
+def _raise_error_if_not_single_density(grids):
+    if len(grids) != 1:
+        raise exception.IncorrectUsage(
+            "The Bader analysis requires exactly one density to define the basins, "
+            f"but the selection produced {len(grids)}."
         )

--- a/src/py4vasp/view.py
+++ b/src/py4vasp/view.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 from py4vasp._third_party.view import (
     CrystalSymmetry,
+    GridDomain,
     GridQuantity,
     IonArrow,
     Isosurface,
@@ -11,6 +12,7 @@ from py4vasp._third_party.view import (
 
 __all__ = [
     "CrystalSymmetry",
+    "GridDomain",
     "GridQuantity",
     "IonArrow",
     "Isosurface",

--- a/tests/calculation/test_default_calculation.py
+++ b/tests/calculation/test_default_calculation.py
@@ -163,7 +163,7 @@ def test_selections_with_method_filters_by_implementation(tmp_path):
 
     assert "band" not in full_view
     assert "dos" not in full_view
-    assert full_view["density"] == ["default", "tau"]
+    assert full_view["density"] == ["default", "tau", "all_electron"]
     assert "default" in full_view["structure"]
 
 

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -545,6 +545,27 @@ def test_bader_charge_multiple_selections(raw_data):
     assert all(isinstance(value, dict) for value in result.values())
 
 
+def test_all_electron_adds_core_to_scalar(raw_data, Assert):
+    raw_density = raw_data.density("all_electron")
+    density = Density.from_data(raw_density)
+
+    actual = density.read()
+
+    charge = np.array(raw_density.charge)
+    core = np.array(raw_density.core)
+    Assert.allclose(actual["charge"], (charge[0] + core[0]).T)
+    Assert.allclose(actual["magnetization"], charge[1].T)
+
+
+def test_all_electron_bader_charge_includes_core(raw_data, Assert):
+    density = Density.from_data(raw_data.density("all_electron"))
+
+    charges = density.bader_charge()
+
+    scalar = density.to_numpy()[0]
+    Assert.allclose(sum(charges.values()), scalar.sum() / scalar.size)
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.density("Fe3O4 collinear")
     parameters = {"to_contour": {"a": 0.3}}

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -8,8 +8,9 @@ import pytest
 
 from py4vasp import _config, exception, raw
 from py4vasp._calculation.density import Density
-from py4vasp._calculation.structure import Structure
+from py4vasp._calculation.structure import Structure, StructureHandler
 from py4vasp._third_party.view import Isosurface
+from py4vasp._util.bader import BaderAnalysis
 
 
 @pytest.fixture(params=[None, "kinetic_energy"])
@@ -501,6 +502,48 @@ def test_magnetization_without_component(selection, raw_data):
 def test_print(reference_density, format_):
     actual, _ = format_(reference_density)
     assert actual == {"text/plain": reference_density.ref.string}
+
+
+def test_bader_analysis_returns_analysis(raw_data):
+    raw_density = raw_data.density("Sr2TiO4")
+    density = Density.from_data(raw_density)
+    analysis = density.bader_analysis()
+    assert isinstance(analysis, BaderAnalysis)
+    view = analysis.plot()
+    assert len(view.grid_domains) == 1
+
+
+def test_bader_charge_conserves_total(raw_data, Assert):
+    raw_density = raw_data.density("Sr2TiO4")
+    density = Density.from_data(raw_density)
+    structure = StructureHandler.from_data(raw_density.structure)
+
+    charges = density.bader_charge()
+
+    assert list(charges) == structure.to_dict()["names"]
+    scalar = density.to_numpy()[0]
+    total = scalar.sum() * structure.volume() / scalar.size
+    Assert.allclose(sum(charges.values()), total)
+
+
+def test_bader_charge_combined_equals_explicit(raw_data, Assert):
+    density = Density.from_data(raw_data.density("Fe3O4 collinear"))
+
+    combined = density.bader_charge("m(basins=scalar)")
+    explicit = density.bader_charge("m", bader_analysis=density.bader_analysis("scalar"))
+
+    assert combined.keys() == explicit.keys()
+    for key in combined:
+        Assert.allclose(combined[key], explicit[key])
+
+
+def test_bader_charge_multiple_selections(raw_data):
+    density = Density.from_data(raw_data.density("Fe3O4 collinear"))
+
+    result = density.bader_charge("scalar, m")
+
+    assert len(result) == 2
+    assert all(isinstance(value, dict) for value in result.values())
 
 
 def test_factory_methods(raw_data, check_factory_methods):

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -519,28 +519,37 @@ def test_bader_charge_conserves_total(raw_data, Assert):
     density = Density.from_data(raw_density)
     structure = StructureHandler.from_data(raw_density.structure)
 
-    charges = density.bader_charge()
+    charges = density.bader_charge(bader_analysis=density.bader_analysis())
 
     assert list(charges) == structure.to_dict()["names"]
     scalar = density.to_numpy()[0]
     Assert.allclose(sum(charges.values()), scalar.sum() / scalar.size)
 
 
-def test_bader_charge_combined_equals_explicit(raw_data, Assert):
+def test_bader_charge_requires_analysis(raw_data):
+    density = Density.from_data(raw_data.density("Sr2TiO4"))
+    with pytest.raises(exception.IncorrectUsage):
+        density.bader_charge()
+
+
+def test_bader_charge_integrates_component_in_given_basins(raw_data, Assert):
     density = Density.from_data(raw_data.density("Fe3O4 collinear"))
+    analysis = density.bader_analysis("scalar")
 
-    combined = density.bader_charge("m(basins=scalar)")
-    explicit = density.bader_charge("m", bader_analysis=density.bader_analysis("scalar"))
+    # integrating the magnetization in scalar-defined basins goes through the
+    # analysis object directly
+    charges = density.bader_charge("m", bader_analysis=analysis)
+    manual = analysis.charges(density.to_numpy()[1])
 
-    assert combined.keys() == explicit.keys()
-    for key in combined:
-        Assert.allclose(combined[key], explicit[key])
+    assert charges.keys() == manual.keys()
+    for key in charges:
+        Assert.allclose(charges[key], manual[key])
 
 
 def test_bader_charge_multiple_selections(raw_data):
     density = Density.from_data(raw_data.density("Fe3O4 collinear"))
 
-    result = density.bader_charge("scalar, m")
+    result = density.bader_charge("scalar, m", bader_analysis=density.bader_analysis())
 
     assert len(result) == 2
     assert all(isinstance(value, dict) for value in result.values())
@@ -557,14 +566,17 @@ def test_bader_honors_getitem_source(raw_data, Assert):
     source = DictSource({"density": pseudo, ("density", "all_electron"): all_electron})
     density = Density(source)
 
-    from_getitem = density["all_electron"].bader_charge()
-    from_selection = density.bader_charge("all_electron")
+    # a fixed set of basins so only the integrand source varies between the calls
+    basins = density.bader_analysis()
+
+    from_getitem = density["all_electron"].bader_charge(bader_analysis=basins)
+    from_selection = density.bader_charge("all_electron", bader_analysis=basins)
 
     assert from_getitem.keys() == from_selection.keys()
     for key in from_getitem:
         Assert.allclose(from_getitem[key], from_selection[key])
     # and the get-item form must not silently fall back to the pseudo source
-    pseudo_charges = density.bader_charge()
+    pseudo_charges = density.bader_charge(bader_analysis=basins)
     assert from_getitem != pseudo_charges
 
 
@@ -589,7 +601,7 @@ def test_all_electron_core_only_defines_basins(raw_data, Assert):
     core = np.array(raw_density.core)
 
     # the charges integrate the valence density (no core), summing to its electrons
-    charges = density.bader_charge()
+    charges = density.bader_charge(bader_analysis=density.bader_analysis())
     valence_scalar = charge[0].T
     Assert.allclose(sum(charges.values()), valence_scalar.sum() / valence_scalar.size)
 
@@ -602,7 +614,9 @@ def test_all_electron_core_only_defines_basins(raw_data, Assert):
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.density("Fe3O4 collinear")
     parameters = {"to_contour": {"a": 0.3}}
-    check_factory_methods(Density, data, parameters)
+    # bader_charge needs an externally supplied bader_analysis; its data access is
+    # covered by the dedicated bader tests
+    check_factory_methods(Density, data, parameters, skip_methods=["bader_charge"])
 
 
 def test_is_available_to_quiver(raw_data):

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -549,25 +549,35 @@ def test_all_electron_is_selectable(nonpolarized_density):
     assert "all_electron" in nonpolarized_density.selections()["density"]
 
 
-def test_all_electron_adds_core_to_scalar(raw_data, Assert):
+def test_all_electron_read_excludes_core(raw_data, Assert):
+    # the core density is too coarsely sampled to be quantitative, so read and
+    # to_numpy report only the valence density (the core is not added)
     raw_density = raw_data.density("all_electron")
     density = Density.from_data(raw_density)
 
     actual = density.read()
 
     charge = np.array(raw_density.charge)
-    core = np.array(raw_density.core)
-    Assert.allclose(actual["charge"], (charge[0] + core[0]).T)
+    Assert.allclose(actual["charge"], charge[0].T)
     Assert.allclose(actual["magnetization"], charge[1].T)
 
 
-def test_all_electron_bader_charge_includes_core(raw_data, Assert):
-    density = Density.from_data(raw_data.density("all_electron"))
+def test_all_electron_core_only_defines_basins(raw_data, Assert):
+    raw_density = raw_data.density("all_electron")
+    density = Density.from_data(raw_density)
+    structure = StructureHandler.from_data(raw_density.structure)
+    charge = np.array(raw_density.charge)
+    core = np.array(raw_density.core)
 
+    # the charges integrate the valence density (no core), summing to its electrons
     charges = density.bader_charge()
+    valence_scalar = charge[0].T
+    Assert.allclose(sum(charges.values()), valence_scalar.sum() / valence_scalar.size)
 
-    scalar = density.to_numpy()[0]
-    Assert.allclose(sum(charges.values()), scalar.sum() / scalar.size)
+    # but the basins follow the core-augmented (peaked) density
+    peaked = (charge[0] + core[0]).T
+    expected_basins = BaderAnalysis(structure, peaked).basins()
+    Assert.allclose(density.bader_analysis().basins(), expected_basins)
 
 
 def test_factory_methods(raw_data, check_factory_methods):

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -575,6 +575,27 @@ def test_bader_honors_getitem_source(raw_data, Assert):
     assert from_getitem.keys() == from_selection.keys()
     for key in from_getitem:
         Assert.allclose(from_getitem[key], from_selection[key])
+
+
+def test_bader_combines_getitem_source_with_selection(raw_data, Assert):
+    # a component selection on a get-item source must combine the two, so that
+    # density["all_electron"].bader_charge("m") integrates the all_electron
+    # magnetization rather than falling back to the default source or component
+    pseudo = raw_data.density("Fe3O4 collinear")
+    all_electron = raw_data.density("all_electron")
+    source = DictSource({"density": pseudo, ("density", "all_electron"): all_electron})
+    density = Density(source)
+    basins = density.bader_analysis()
+
+    from_getitem = density["all_electron"].bader_charge("m", bader_analysis=basins)
+    from_selection = density.bader_charge("all_electron(m)", bader_analysis=basins)
+
+    assert from_getitem.keys() == from_selection.keys()
+    for key in from_getitem:
+        Assert.allclose(from_getitem[key], from_selection[key])
+    # and it must differ from integrating the scalar of the same source
+    scalar = density["all_electron"].bader_charge(bader_analysis=basins)
+    assert from_getitem != scalar
     # and the get-item form must not silently fall back to the pseudo source
     pseudo_charges = density.bader_charge(bader_analysis=basins)
     assert from_getitem != pseudo_charges

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -8,6 +8,7 @@ import pytest
 
 from py4vasp import _config, exception, raw
 from py4vasp._calculation.density import Density
+from py4vasp._calculation.dispatch import DictSource
 from py4vasp._calculation.structure import Structure, StructureHandler
 from py4vasp._third_party.view import Isosurface
 from py4vasp._util.bader import BaderAnalysis
@@ -547,6 +548,24 @@ def test_bader_charge_multiple_selections(raw_data):
 
 def test_all_electron_is_selectable(nonpolarized_density):
     assert "all_electron" in nonpolarized_density.selections()["density"]
+
+
+def test_bader_honors_getitem_source(raw_data, Assert):
+    # a source that distinguishes the default (pseudo) from the all_electron data
+    pseudo = raw_data.density("Fe3O4 collinear")
+    all_electron = raw_data.density("all_electron")
+    source = DictSource({"density": pseudo, ("density", "all_electron"): all_electron})
+    density = Density(source)
+
+    from_getitem = density["all_electron"].bader_charge()
+    from_selection = density.bader_charge("all_electron")
+
+    assert from_getitem.keys() == from_selection.keys()
+    for key in from_getitem:
+        Assert.allclose(from_getitem[key], from_selection[key])
+    # and the get-item form must not silently fall back to the pseudo source
+    pseudo_charges = density.bader_charge()
+    assert from_getitem != pseudo_charges
 
 
 def test_all_electron_read_excludes_core(raw_data, Assert):

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -545,6 +545,10 @@ def test_bader_charge_multiple_selections(raw_data):
     assert all(isinstance(value, dict) for value in result.values())
 
 
+def test_all_electron_is_selectable(nonpolarized_density):
+    assert "all_electron" in nonpolarized_density.selections()["density"]
+
+
 def test_all_electron_adds_core_to_scalar(raw_data, Assert):
     raw_density = raw_data.density("all_electron")
     density = Density.from_data(raw_density)

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -522,8 +522,7 @@ def test_bader_charge_conserves_total(raw_data, Assert):
 
     assert list(charges) == structure.to_dict()["names"]
     scalar = density.to_numpy()[0]
-    total = scalar.sum() * structure.volume() / scalar.size
-    Assert.allclose(sum(charges.values()), total)
+    Assert.allclose(sum(charges.values()), scalar.sum() / scalar.size)
 
 
 def test_bader_charge_combined_equals_explicit(raw_data, Assert):

--- a/tests/calculation/test_exciton_density.py
+++ b/tests/calculation/test_exciton_density.py
@@ -119,8 +119,7 @@ def test_bader_charge_conserves_total(raw_data, Assert):
 
     assert list(charges) == structure.to_dict()["names"]
     grid = np.array(raw_density.exciton_charge[0]).T
-    total = grid.sum() * structure.volume() / grid.size
-    Assert.allclose(sum(charges.values()), total)
+    Assert.allclose(sum(charges.values()), grid.sum() / grid.size)
 
 
 def test_factory_methods(raw_data, check_factory_methods):

--- a/tests/calculation/test_exciton_density.py
+++ b/tests/calculation/test_exciton_density.py
@@ -7,7 +7,7 @@ import pytest
 
 from py4vasp import _config, exception, raw
 from py4vasp._calculation.exciton_density import ExcitonDensity
-from py4vasp._calculation.structure import Structure
+from py4vasp._calculation.structure import Structure, StructureHandler
 
 
 @pytest.fixture
@@ -108,6 +108,19 @@ exciton charge density:
     grid: 10, 12, 14
     excitons: 3"""
     assert actual == {"text/plain": expected_text}
+
+
+def test_bader_charge_conserves_total(raw_data, Assert):
+    raw_density = raw_data.exciton_density()
+    density = ExcitonDensity.from_data(raw_density)
+    structure = StructureHandler.from_data(raw_density.structure)
+
+    charges = density.bader_charge()
+
+    assert list(charges) == structure.to_dict()["names"]
+    grid = np.array(raw_density.exciton_charge[0]).T
+    total = grid.sum() * structure.volume() / grid.size
+    Assert.allclose(sum(charges.values()), total)
 
 
 def test_factory_methods(raw_data, check_factory_methods):

--- a/tests/calculation/test_exciton_density.py
+++ b/tests/calculation/test_exciton_density.py
@@ -8,6 +8,7 @@ import pytest
 from py4vasp import _config, exception, raw
 from py4vasp._calculation.exciton_density import ExcitonDensity
 from py4vasp._calculation.structure import Structure, StructureHandler
+from py4vasp._util.bader import BaderAnalysis
 
 
 @pytest.fixture
@@ -114,14 +115,22 @@ def test_bader_charge_conserves_total(raw_data, Assert):
     raw_density = raw_data.exciton_density()
     density = ExcitonDensity.from_data(raw_density)
     structure = StructureHandler.from_data(raw_density.structure)
+    grid = np.array(raw_density.exciton_charge[0]).T
+    # only the charge density defines basins, so supply them externally
+    analysis = BaderAnalysis(structure, grid)
 
-    charges = density.bader_charge()
+    charges = density.bader_charge(bader_analysis=analysis)
 
     assert list(charges) == structure.to_dict()["names"]
-    grid = np.array(raw_density.exciton_charge[0]).T
     Assert.allclose(sum(charges.values()), grid.sum() / grid.size)
+
+
+def test_bader_charge_requires_analysis(raw_data):
+    density = ExcitonDensity.from_data(raw_data.exciton_density())
+    with pytest.raises(exception.IncorrectUsage):
+        density.bader_charge()
 
 
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.exciton_density()
-    check_factory_methods(ExcitonDensity, data)
+    check_factory_methods(ExcitonDensity, data, skip_methods=["bader_charge"])

--- a/tests/calculation/test_nics.py
+++ b/tests/calculation/test_nics.py
@@ -12,8 +12,8 @@ from py4vasp import _config, exception, raw
 from py4vasp._calculation.nics import Nics, NicsHandler
 from py4vasp._calculation.structure import Structure, StructureHandler
 from py4vasp._raw.models import NicsModel
-from py4vasp._util.bader import BaderAnalysis
 from py4vasp._third_party import view
+from py4vasp._util.bader import BaderAnalysis
 
 
 @pytest.fixture(params=("on-a-grid", "at-points"))

--- a/tests/calculation/test_nics.py
+++ b/tests/calculation/test_nics.py
@@ -10,7 +10,7 @@ import pytest
 
 from py4vasp import _config, exception, raw
 from py4vasp._calculation.nics import Nics, NicsHandler
-from py4vasp._calculation.structure import Structure
+from py4vasp._calculation.structure import Structure, StructureHandler
 from py4vasp._raw.models import NicsModel
 from py4vasp._third_party import view
 
@@ -527,6 +527,25 @@ def test_to_database(nics):
     db_data: NicsModel = handler.to_database()
     assert isinstance(db_data, NicsModel)
     assert db_data.method == nics.ref.output["method"]
+
+
+def test_bader_charge_conserves_total(raw_data, Assert):
+    raw_nics = raw_data.nics("on-a-grid")
+    nics = Nics.from_data(raw_nics)
+    structure = StructureHandler.from_data(raw_nics.structure)
+
+    charges = nics.bader_charge()
+
+    assert list(charges) == structure.to_dict()["names"]
+    grid = nics.to_view().grid_scalars[0].quantity[0]
+    total = grid.sum() * structure.volume() / grid.size
+    Assert.allclose(sum(charges.values()), total)
+
+
+def test_bader_charge_in_points_mode_raises(raw_data):
+    nics = Nics.from_data(raw_data.nics("at-points"))
+    with pytest.raises(exception.IncorrectUsage):
+        nics.bader_charge()
 
 
 def test_factory_methods(raw_data, check_factory_methods):

--- a/tests/calculation/test_nics.py
+++ b/tests/calculation/test_nics.py
@@ -538,8 +538,7 @@ def test_bader_charge_conserves_total(raw_data, Assert):
 
     assert list(charges) == structure.to_dict()["names"]
     grid = nics.to_view().grid_scalars[0].quantity[0]
-    total = grid.sum() * structure.volume() / grid.size
-    Assert.allclose(sum(charges.values()), total)
+    Assert.allclose(sum(charges.values()), grid.sum() / grid.size)
 
 
 def test_bader_charge_in_points_mode_raises(raw_data):

--- a/tests/calculation/test_nics.py
+++ b/tests/calculation/test_nics.py
@@ -12,6 +12,7 @@ from py4vasp import _config, exception, raw
 from py4vasp._calculation.nics import Nics, NicsHandler
 from py4vasp._calculation.structure import Structure, StructureHandler
 from py4vasp._raw.models import NicsModel
+from py4vasp._util.bader import BaderAnalysis
 from py4vasp._third_party import view
 
 
@@ -533,23 +534,35 @@ def test_bader_charge_conserves_total(raw_data, Assert):
     raw_nics = raw_data.nics("on-a-grid")
     nics = Nics.from_data(raw_nics)
     structure = StructureHandler.from_data(raw_nics.structure)
+    grid = nics.to_view().grid_scalars[0].quantity[0]
+    # the NICS is a shielding field, not a density, so basins come from elsewhere
+    analysis = BaderAnalysis(structure, grid)
 
-    charges = nics.bader_charge()
+    charges = nics.bader_charge(bader_analysis=analysis)
 
     assert list(charges) == structure.to_dict()["names"]
-    grid = nics.to_view().grid_scalars[0].quantity[0]
     Assert.allclose(sum(charges.values()), grid.sum() / grid.size)
 
 
-def test_bader_charge_in_points_mode_raises(raw_data):
-    nics = Nics.from_data(raw_data.nics("at-points"))
+def test_bader_charge_requires_analysis(raw_data):
+    nics = Nics.from_data(raw_data.nics("on-a-grid"))
     with pytest.raises(exception.IncorrectUsage):
         nics.bader_charge()
 
 
+def test_bader_charge_in_points_mode_raises(raw_data):
+    raw_grid = raw_data.nics("on-a-grid")
+    structure = StructureHandler.from_data(raw_grid.structure)
+    grid = Nics.from_data(raw_grid).to_view().grid_scalars[0].quantity[0]
+    analysis = BaderAnalysis(structure, grid)
+    nics = Nics.from_data(raw_data.nics("at-points"))
+    with pytest.raises(exception.IncorrectUsage):
+        nics.bader_charge(bader_analysis=analysis)
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.nics("on-a-grid")
-    check_factory_methods(Nics, data)
+    check_factory_methods(Nics, data, skip_methods=["bader_charge"])
 
 
 def test_is_available_on_a_grid(nics_on_a_grid):

--- a/tests/calculation/test_partial_density.py
+++ b/tests/calculation/test_partial_density.py
@@ -429,7 +429,9 @@ def test_bader_charge_conserves_total(raw_data, Assert):
 
 
 def test_bader_charge_requires_analysis(raw_data):
-    partial_density = PartialDensity.from_data(raw_data.partial_density("spin_polarized"))
+    partial_density = PartialDensity.from_data(
+        raw_data.partial_density("spin_polarized")
+    )
     with pytest.raises(IncorrectUsage):
         partial_density.bader_charge()
 

--- a/tests/calculation/test_partial_density.py
+++ b/tests/calculation/test_partial_density.py
@@ -413,6 +413,19 @@ def test_interpolation_setting_change(PolarizedNonSplitPartialDensity):
     assert not np.allclose(graph_def.series.data, graph_less_interp_points.series.data)
 
 
+def test_bader_charge_conserves_total(raw_data, Assert):
+    raw_pd = raw_data.partial_density("spin_polarized")
+    partial_density = PartialDensity.from_data(raw_pd)
+    structure = StructureHandler.from_data(raw_pd.structure)
+
+    charges = partial_density.bader_charge()
+
+    assert list(charges) == structure.to_dict()["names"]
+    grid = partial_density.to_numpy("total")
+    total = grid.sum() * structure.volume() / grid.size
+    Assert.allclose(sum(charges.values()), total)
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.partial_density("spin_polarized")
     check_factory_methods(PartialDensity, data)

--- a/tests/calculation/test_partial_density.py
+++ b/tests/calculation/test_partial_density.py
@@ -422,8 +422,7 @@ def test_bader_charge_conserves_total(raw_data, Assert):
 
     assert list(charges) == structure.to_dict()["names"]
     grid = partial_density.to_numpy("total")
-    total = grid.sum() * structure.volume() / grid.size
-    Assert.allclose(sum(charges.values()), total)
+    Assert.allclose(sum(charges.values()), grid.sum() / grid.size)
 
 
 def test_factory_methods(raw_data, check_factory_methods):

--- a/tests/calculation/test_partial_density.py
+++ b/tests/calculation/test_partial_density.py
@@ -9,6 +9,7 @@ import pytest
 from py4vasp import _config
 from py4vasp._calculation.partial_density import PartialDensity
 from py4vasp._calculation.structure import Structure, StructureHandler
+from py4vasp._util.bader import BaderAnalysis
 from py4vasp._util.slicing import plane
 from py4vasp.exception import IncorrectUsage, NoData, NotImplemented
 
@@ -417,14 +418,22 @@ def test_bader_charge_conserves_total(raw_data, Assert):
     raw_pd = raw_data.partial_density("spin_polarized")
     partial_density = PartialDensity.from_data(raw_pd)
     structure = StructureHandler.from_data(raw_pd.structure)
+    grid = partial_density.to_numpy("total")
+    # only the charge density defines basins, so supply them externally
+    analysis = BaderAnalysis(structure, grid)
 
-    charges = partial_density.bader_charge()
+    charges = partial_density.bader_charge(bader_analysis=analysis)
 
     assert list(charges) == structure.to_dict()["names"]
-    grid = partial_density.to_numpy("total")
     Assert.allclose(sum(charges.values()), grid.sum() / grid.size)
+
+
+def test_bader_charge_requires_analysis(raw_data):
+    partial_density = PartialDensity.from_data(raw_data.partial_density("spin_polarized"))
+    with pytest.raises(IncorrectUsage):
+        partial_density.bader_charge()
 
 
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.partial_density("spin_polarized")
-    check_factory_methods(PartialDensity, data)
+    check_factory_methods(PartialDensity, data, skip_methods=["bader_charge"])

--- a/tests/calculation/test_potential.py
+++ b/tests/calculation/test_potential.py
@@ -420,8 +420,7 @@ def test_bader_charge_conserves_total(raw_data, Assert):
 
     assert list(charges) == structure.to_dict()["names"]
     grid = potential.read()["total"]
-    total = grid.sum() * structure.volume() / grid.size
-    Assert.allclose(sum(charges.values()), total)
+    Assert.allclose(sum(charges.values()), grid.sum() / grid.size)
 
 
 def test_bader_charge_uses_external_analysis(raw_data, Assert):

--- a/tests/calculation/test_potential.py
+++ b/tests/calculation/test_potential.py
@@ -7,8 +7,9 @@ import numpy as np
 import pytest
 
 from py4vasp import _config, exception, raw
+from py4vasp._calculation.density import Density
 from py4vasp._calculation.potential import VALID_KINDS, Potential, PotentialHandler
-from py4vasp._calculation.structure import Structure
+from py4vasp._calculation.structure import Structure, StructureHandler
 from py4vasp._raw.models import PotentialModel
 from py4vasp._third_party.view import Isosurface
 from py4vasp._util import slicing
@@ -408,6 +409,36 @@ def test_to_database(reference_potential):
         if (total_potential_magnetization is not None)
         else None
     )
+
+
+def test_bader_charge_conserves_total(raw_data, Assert):
+    raw_potential = raw_data.potential("Sr2TiO4 total")
+    potential = Potential.from_data(raw_potential)
+    structure = StructureHandler.from_data(raw_potential.structure)
+
+    charges = potential.bader_charge()
+
+    assert list(charges) == structure.to_dict()["names"]
+    grid = potential.read()["total"]
+    total = grid.sum() * structure.volume() / grid.size
+    Assert.allclose(sum(charges.values()), total)
+
+
+def test_bader_charge_uses_external_analysis(raw_data, Assert):
+    raw_potential = raw_data.potential("Sr2TiO4 total")
+    potential = Potential.from_data(raw_potential)
+    density = Density.from_data(raw_data.density("Sr2TiO4"))
+    structure = StructureHandler.from_data(raw_potential.structure)
+
+    analysis = density.bader_analysis()
+    charges = potential.bader_charge(bader_analysis=analysis)
+
+    # integrating the potential in the density-defined basins equals doing so
+    # directly through the analysis object
+    manual = analysis.charges(potential.read()["total"])
+    assert charges.keys() == manual.keys()
+    for key in charges:
+        Assert.allclose(charges[key], manual[key])
 
 
 def test_factory_methods(raw_data, check_factory_methods):

--- a/tests/calculation/test_potential.py
+++ b/tests/calculation/test_potential.py
@@ -414,13 +414,20 @@ def test_to_database(reference_potential):
 def test_bader_charge_conserves_total(raw_data, Assert):
     raw_potential = raw_data.potential("Sr2TiO4 total")
     potential = Potential.from_data(raw_potential)
+    density = Density.from_data(raw_data.density("Sr2TiO4"))
     structure = StructureHandler.from_data(raw_potential.structure)
 
-    charges = potential.bader_charge()
+    charges = potential.bader_charge(bader_analysis=density.bader_analysis())
 
     assert list(charges) == structure.to_dict()["names"]
     grid = potential.read()["total"]
     Assert.allclose(sum(charges.values()), grid.sum() / grid.size)
+
+
+def test_bader_charge_requires_analysis(raw_data):
+    potential = Potential.from_data(raw_data.potential("Sr2TiO4 total"))
+    with pytest.raises(exception.IncorrectUsage):
+        potential.bader_charge()
 
 
 def test_bader_charge_uses_external_analysis(raw_data, Assert):
@@ -442,7 +449,7 @@ def test_bader_charge_uses_external_analysis(raw_data, Assert):
 
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.potential("Fe3O4 collinear total")
-    check_factory_methods(Potential, data)
+    check_factory_methods(Potential, data, skip_methods=["bader_charge"])
 
 
 def test_is_available_total_only(raw_data):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,8 @@ class RawDataFactory:
             return _demo.density.Sr2TiO4()
         elif parts[0] == "Fe3O4":
             return _demo.density.Fe3O4(parts[1])
+        elif parts[0] == "all_electron":
+            return _demo.density.all_electron()
         else:
             raise exception.NotImplemented()
 

--- a/tests/third_party/view/test_view.py
+++ b/tests/third_party/view/test_view.py
@@ -184,6 +184,22 @@ def test_view_stores_grid_domains():
     assert view.grid_domains == [grid_domain]
 
 
+def test_grid_domains_rendering_not_implemented():
+    inputs = base_input_view(is_structure=True)
+    grid_domain = view_module.GridDomain(np.zeros((1, 3, 3, 3), dtype=int), "basins", ["A"])
+    view = View(grid_domains=[grid_domain], **inputs)
+    with pytest.raises(exception.NotImplemented):
+        view.to_ngl()
+    with pytest.raises(exception.NotImplemented):
+        view.to_vasp_viewer_config()
+
+
+def test_view_without_grid_domains_renders_config():
+    view = View(**base_input_view(is_structure=True))
+    config = view.to_vasp_viewer_config()
+    assert "atoms_trajectory" in config
+
+
 def test_structure_to_view(view, Assert):
     widget = view.to_ngl()
     for idx_traj in range(len(view.lattice_vectors)):

--- a/tests/third_party/view/test_view.py
+++ b/tests/third_party/view/test_view.py
@@ -12,6 +12,7 @@ import pytest
 
 from py4vasp import exception
 from py4vasp._third_party.view import View
+from py4vasp._third_party.view import view as view_module
 from py4vasp._third_party.view.view import (
     GridQuantity,
     IonArrow,
@@ -160,6 +161,27 @@ def view_arrow(request):
     view.ref = SimpleNamespace()
     view.ref.ion_arrows = ion_arrows
     return view
+
+
+def test_grid_domain_stores_fields():
+    quantity = np.zeros((1, 3, 4, 5), dtype=int)
+    labels = ["Sr_1", "Sr_2", "Ti_1"]
+    grid_domain = view_module.GridDomain(quantity=quantity, label="basins", labels=labels)
+    assert grid_domain.quantity is quantity
+    assert grid_domain.label == "basins"
+    assert grid_domain.labels == labels
+
+
+def test_grid_domains_default_to_none():
+    view = View(**base_input_view(is_structure=True))
+    assert view.grid_domains is None
+
+
+def test_view_stores_grid_domains():
+    inputs = base_input_view(is_structure=True)
+    grid_domain = view_module.GridDomain(np.zeros((1, 3, 4, 5), dtype=int), "basins", ["A"])
+    view = View(grid_domains=[grid_domain], **inputs)
+    assert view.grid_domains == [grid_domain]
 
 
 def test_structure_to_view(view, Assert):

--- a/tests/third_party/view/test_view.py
+++ b/tests/third_party/view/test_view.py
@@ -166,7 +166,9 @@ def view_arrow(request):
 def test_grid_domain_stores_fields():
     quantity = np.zeros((1, 3, 4, 5), dtype=int)
     labels = ["Sr_1", "Sr_2", "Ti_1"]
-    grid_domain = view_module.GridDomain(quantity=quantity, label="basins", labels=labels)
+    grid_domain = view_module.GridDomain(
+        quantity=quantity, label="basins", labels=labels
+    )
     assert grid_domain.quantity is quantity
     assert grid_domain.label == "basins"
     assert grid_domain.labels == labels
@@ -179,14 +181,18 @@ def test_grid_domains_default_to_none():
 
 def test_view_stores_grid_domains():
     inputs = base_input_view(is_structure=True)
-    grid_domain = view_module.GridDomain(np.zeros((1, 3, 4, 5), dtype=int), "basins", ["A"])
+    grid_domain = view_module.GridDomain(
+        np.zeros((1, 3, 4, 5), dtype=int), "basins", ["A"]
+    )
     view = View(grid_domains=[grid_domain], **inputs)
     assert view.grid_domains == [grid_domain]
 
 
 def test_grid_domains_rendering_not_implemented():
     inputs = base_input_view(is_structure=True)
-    grid_domain = view_module.GridDomain(np.zeros((1, 3, 3, 3), dtype=int), "basins", ["A"])
+    grid_domain = view_module.GridDomain(
+        np.zeros((1, 3, 3, 3), dtype=int), "basins", ["A"]
+    )
     view = View(grid_domains=[grid_domain], **inputs)
     with pytest.raises(exception.NotImplemented):
         view.to_ngl()

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -200,6 +200,39 @@ def test_to_view_threshold_hides_low_density(two_atom_bader):
     assert np.all(domain.quantity[0][~hidden] >= 1)
 
 
+def test_charges_sum_to_total_integral(two_atom_bader, Assert):
+    bader_, charge = two_atom_bader.bader, two_atom_bader.charge
+    charges = bader_.charges()
+    volume = 8.0 * 4.0 * 4.0
+    total = charge.sum() * volume / charge.size
+    Assert.allclose(sum(charges.values()), total)
+
+
+def test_charges_keyed_by_atom_names_and_symmetric(two_atom_bader, Assert):
+    charges = two_atom_bader.bader.charges()
+    assert list(charges) == ["Na_1", "Cl_1"]
+    # the two peaks are identical and symmetric, so the charges match
+    Assert.allclose(charges["Na_1"], charges["Cl_1"])
+
+
+def test_charges_of_different_density_in_same_basins(two_atom_bader, Assert):
+    bader_, shape = two_atom_bader.bader, two_atom_bader.shape
+    volume = 8.0 * 4.0 * 4.0
+    charges = bader_.charges(np.ones(shape))
+    # integrating a uniform density recovers the basin volumes, summing to the cell
+    Assert.allclose(sum(charges.values()), volume)
+
+
+def test_charges_shape_mismatch_raises(two_atom_bader):
+    with pytest.raises(exception.IncorrectUsage):
+        two_atom_bader.bader.charges(np.ones((2, 2, 2)))
+
+
+def test_charges_non_3d_raises(two_atom_bader):
+    with pytest.raises(exception.IncorrectUsage):
+        two_atom_bader.bader.charges(np.ones((4, 4)))
+
+
 def test_plot_is_alias_of_to_view(Assert):
     shape = (20, 10, 10)
     lattice_vectors = np.diag((5.0, 4.0, 4.0))

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -259,6 +259,24 @@ def test_charges_of_different_density_in_same_basins(two_atom_bader, Assert):
     Assert.allclose(sum(charges.values()), 1.0)
 
 
+def expected_bader_string(charges):
+    width = max(len(name) for name in charges)
+    lines = [f"    {name:<{width}}   {charge:.4f}" for name, charge in charges.items()]
+    return "Bader charges:\n" + "\n".join(lines)
+
+
+def test_str_matches_formatted_charges(two_atom_bader):
+    analysis = two_atom_bader.bader
+    assert str(analysis) == expected_bader_string(analysis.charges())
+
+
+def test_str_single_atom_exact():
+    shape = (4, 4, 4)
+    lattice_vectors = np.diag((4.0, 4.0, 4.0))
+    analysis = make_bader(lattice_vectors, [(0.0, 0.0, 0.0)], ["H"], np.ones(shape))
+    assert str(analysis) == "Bader charges:\n    H_1   1.0000"
+
+
 def test_charges_shape_mismatch_raises(two_atom_bader):
     with pytest.raises(exception.IncorrectUsage):
         two_atom_bader.bader.charges(np.ones((2, 2, 2)))

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -38,8 +38,8 @@ def label_at(labels, center):
     return labels[grid_point(labels.shape, center)]
 
 
-def make_bader(lattice_vectors, positions, elements, density, snap_to_atoms=True):
-    """Build a BaderAnalysis wrapping a structure with the given geometry."""
+def make_structure(lattice_vectors, positions, elements):
+    """Build a StructureHandler with the given geometry."""
     groups = [(name, len(list(g))) for name, g in itertools.groupby(elements)]
     raw_structure = raw.Structure(
         raw.Stoichiometry(
@@ -49,8 +49,45 @@ def make_bader(lattice_vectors, positions, elements, density, snap_to_atoms=True
         raw.Cell(lattice_vectors=np.asarray(lattice_vectors), scale=raw.VaspData(1.0)),
         positions=np.asarray(positions, dtype=float),
     )
-    structure = StructureHandler.from_data(raw_structure)
+    return StructureHandler.from_data(raw_structure)
+
+
+def make_bader(lattice_vectors, positions, elements, density, snap_to_atoms=True):
+    """Build a BaderAnalysis wrapping a structure with the given geometry."""
+    structure = make_structure(lattice_vectors, positions, elements)
     return bader.BaderAnalysis(structure, density, snap_to_atoms=snap_to_atoms)
+
+
+class ClosableStructure:
+    """Wrap a structure handler to emulate an HDF5 source that closes.
+
+    Any data access after ``closed`` is set raises, mimicking reading a lazily
+    loaded VASP quantity after its file context has been left.
+    """
+
+    def __init__(self, handler):
+        self._handler = handler
+        self.closed = False
+
+    def _access(self, name, *args, **kwargs):
+        if self.closed:
+            raise RuntimeError("Unable to synchronously read data (file closed)")
+        return getattr(self._handler, name)(*args, **kwargs)
+
+    def lattice_vectors(self):
+        return self._access("lattice_vectors")
+
+    def positions(self):
+        return self._access("positions")
+
+    def volume(self):
+        return self._access("volume")
+
+    def to_dict(self, *args, **kwargs):
+        return self._access("to_dict", *args, **kwargs)
+
+    def to_view(self, *args, **kwargs):
+        return self._access("to_view", *args, **kwargs)
 
 
 def test_local_maximum_points_to_itself(Assert):
@@ -203,8 +240,8 @@ def test_to_view_threshold_hides_low_density(two_atom_bader):
 def test_charges_sum_to_total_integral(two_atom_bader, Assert):
     bader_, charge = two_atom_bader.bader, two_atom_bader.charge
     charges = bader_.charges()
-    volume = 8.0 * 4.0 * 4.0
-    total = charge.sum() * volume / charge.size
+    # VASP convention: sum(density) / density.size is the total electron count
+    total = charge.sum() / charge.size
     Assert.allclose(sum(charges.values()), total)
 
 
@@ -217,10 +254,9 @@ def test_charges_keyed_by_atom_names_and_symmetric(two_atom_bader, Assert):
 
 def test_charges_of_different_density_in_same_basins(two_atom_bader, Assert):
     bader_, shape = two_atom_bader.bader, two_atom_bader.shape
-    volume = 8.0 * 4.0 * 4.0
     charges = bader_.charges(np.ones(shape))
-    # integrating a uniform density recovers the basin volumes, summing to the cell
-    Assert.allclose(sum(charges.values()), volume)
+    # a uniform density of one integrates to one electron over the whole grid
+    Assert.allclose(sum(charges.values()), 1.0)
 
 
 def test_charges_shape_mismatch_raises(two_atom_bader):
@@ -231,6 +267,23 @@ def test_charges_shape_mismatch_raises(two_atom_bader):
 def test_charges_non_3d_raises(two_atom_bader):
     with pytest.raises(exception.IncorrectUsage):
         two_atom_bader.bader.charges(np.ones((4, 4)))
+
+
+def test_analysis_reads_no_structure_data_after_construction():
+    # bader_analysis() is returned to the user after the HDF5 file context closed,
+    # so the analysis must capture everything it needs at construction time.
+    shape = (24, 12, 12)
+    lattice_vectors = np.diag((8.0, 4.0, 4.0))
+    atoms = [(0.25, 0.5, 0.5), (0.75, 0.5, 0.5)]
+    charge = gaussian_density(shape, lattice_vectors, atoms)
+    structure = ClosableStructure(make_structure(lattice_vectors, atoms, ["Na", "Cl"]))
+
+    analysis = bader.BaderAnalysis(structure, charge)
+    structure.closed = True  # emulate leaving the file context
+
+    assert list(analysis.charges()) == ["Na_1", "Cl_1"]
+    assert analysis.basins().shape == shape
+    assert len(analysis.to_view().grid_domains) == 1
 
 
 def test_plot_is_alias_of_to_view(Assert):

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -1,9 +1,12 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import itertools
+
 import numpy as np
 import pytest
 
-from py4vasp import exception
+from py4vasp import exception, raw
+from py4vasp._calculation.structure import StructureHandler
 from py4vasp._util import bader
 
 
@@ -32,6 +35,20 @@ def grid_point(shape, center):
 
 def label_at(labels, center):
     return labels[grid_point(labels.shape, center)]
+
+
+def make_bader(lattice_vectors, positions, elements):
+    """Build a Bader instance wrapping a structure with the given geometry."""
+    groups = [(name, len(list(g))) for name, g in itertools.groupby(elements)]
+    raw_structure = raw.Structure(
+        raw.Stoichiometry(
+            number_ion_types=[count for _, count in groups],
+            ion_types=[name for name, _ in groups],
+        ),
+        raw.Cell(lattice_vectors=np.asarray(lattice_vectors), scale=raw.VaspData(1.0)),
+        positions=np.asarray(positions, dtype=float),
+    )
+    return bader.Bader(StructureHandler.from_data(raw_structure))
 
 
 def test_local_maximum_points_to_itself(Assert):
@@ -73,8 +90,9 @@ def test_single_peak_is_one_basin():
     shape = (20, 18, 16)
     lattice_vectors = np.diag((6.0, 5.0, 4.0))
     charge = gaussian_density(shape, lattice_vectors, [(0.5, 0.5, 0.5)])
+    bader_ = make_bader(lattice_vectors, [(0.5, 0.5, 0.5)], ["H"])
 
-    labels = bader.basins(charge, lattice_vectors)
+    labels = bader_.basins(charge, snap_to_atoms=False)
 
     assert labels.shape == shape
     assert np.issubdtype(labels.dtype, np.integer)
@@ -86,8 +104,9 @@ def test_two_peaks_split_into_two_basins():
     lattice_vectors = np.diag((8.0, 4.0, 4.0))
     left, right = (0.25, 0.5, 0.5), (0.75, 0.5, 0.5)
     charge = gaussian_density(shape, lattice_vectors, [left, right])
+    bader_ = make_bader(lattice_vectors, [(0.0, 0.0, 0.0)], ["H"])
 
-    labels = bader.basins(charge, lattice_vectors)
+    labels = bader_.basins(charge, snap_to_atoms=False)
 
     assert len(np.unique(labels)) == 2
     assert label_at(labels, left) != label_at(labels, right)
@@ -103,11 +122,12 @@ def test_displaced_peak_assigns_to_nearest_atom():
     lattice_vectors = np.diag((8.0, 4.0, 4.0))
     # atom 0 is on the right, atom 1 on the left, so the correct labeling differs
     # from the arbitrary enumeration of the maxima and requires the snapping.
-    atoms = np.array([(0.75, 0.5, 0.5), (0.25, 0.5, 0.5)])
+    atoms = [(0.75, 0.5, 0.5), (0.25, 0.5, 0.5)]
     peaks = [(0.30, 0.5, 0.5), (0.70, 0.5, 0.5)]
     charge = gaussian_density(shape, lattice_vectors, peaks)
+    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"])
 
-    labels = bader.basins(charge, lattice_vectors, atoms)
+    labels = bader_.basins(charge, snap_to_atoms=True)
 
     assert set(np.unique(labels)) <= {0, 1}
     assert label_at(labels, atoms[0]) == 0
@@ -119,15 +139,16 @@ def test_displaced_peak_assigns_to_nearest_atom():
 def test_interstitial_maximum_merges_into_nearest_atom():
     shape = (30, 12, 12)
     lattice_vectors = np.diag((9.0, 4.0, 4.0))
-    atoms = np.array([(0.2, 0.5, 0.5), (0.8, 0.5, 0.5)])
+    atoms = [(0.2, 0.5, 0.5), (0.8, 0.5, 0.5)]
     charge = gaussian_density(
-        shape, lattice_vectors, list(atoms), width=0.9
+        shape, lattice_vectors, atoms, width=0.9
     ) + 0.6 * gaussian_density(shape, lattice_vectors, [(0.45, 0.5, 0.5)], width=0.4)
+    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"])
 
-    # without atoms the interstitial peak is a basin of its own
-    assert len(np.unique(bader.basins(charge, lattice_vectors))) == 3
+    # without snapping the interstitial peak is a basin of its own
+    assert len(np.unique(bader_.basins(charge, snap_to_atoms=False))) == 3
 
-    labels = bader.basins(charge, lattice_vectors, atoms)
+    labels = bader_.basins(charge, snap_to_atoms=True)
 
     assert set(np.unique(labels)) == {0, 1}
     # the interstitial peak at 0.45 is closest to atom 0 at 0.2
@@ -135,12 +156,6 @@ def test_interstitial_maximum_merges_into_nearest_atom():
 
 
 def test_incorrect_charge_dimension_raises():
+    bader_ = make_bader(np.diag((1.0, 1.0, 1.0)), [(0.0, 0.0, 0.0)], ["H"])
     with pytest.raises(exception.IncorrectUsage):
-        bader.basins(np.zeros((4, 4)), np.diag((1.0, 1.0, 1.0)))
-
-
-def test_incorrect_positions_shape_raises():
-    charge = np.zeros((4, 4, 4))
-    lattice_vectors = np.diag((1.0, 1.0, 1.0))
-    with pytest.raises(exception.IncorrectUsage):
-        bader.basins(charge, lattice_vectors, np.zeros((2, 2)))
+        bader_.basins(np.zeros((4, 4)), snap_to_atoms=False)

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -1,7 +1,9 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import numpy as np
+import pytest
 
+from py4vasp import exception
 from py4vasp._util import bader
 
 
@@ -92,3 +94,53 @@ def test_two_peaks_split_into_two_basins():
     # points nearer a peak belong to that peak's basin
     assert label_at(labels, (0.1, 0.5, 0.5)) == label_at(labels, left)
     assert label_at(labels, (0.9, 0.5, 0.5)) == label_at(labels, right)
+
+
+def test_displaced_peak_assigns_to_nearest_atom():
+    # the density peaks are displaced inwards from the atoms, mimicking a pseudo
+    # density that is not peaked at the nuclei.
+    shape = (24, 12, 12)
+    lattice_vectors = np.diag((8.0, 4.0, 4.0))
+    # atom 0 is on the right, atom 1 on the left, so the correct labeling differs
+    # from the arbitrary enumeration of the maxima and requires the snapping.
+    atoms = np.array([(0.75, 0.5, 0.5), (0.25, 0.5, 0.5)])
+    peaks = [(0.30, 0.5, 0.5), (0.70, 0.5, 0.5)]
+    charge = gaussian_density(shape, lattice_vectors, peaks)
+
+    labels = bader.basins(charge, lattice_vectors, atoms)
+
+    assert set(np.unique(labels)) <= {0, 1}
+    assert label_at(labels, atoms[0]) == 0
+    assert label_at(labels, atoms[1]) == 1
+    assert label_at(labels, (0.1, 0.5, 0.5)) == 1
+    assert label_at(labels, (0.9, 0.5, 0.5)) == 0
+
+
+def test_interstitial_maximum_merges_into_nearest_atom():
+    shape = (30, 12, 12)
+    lattice_vectors = np.diag((9.0, 4.0, 4.0))
+    atoms = np.array([(0.2, 0.5, 0.5), (0.8, 0.5, 0.5)])
+    charge = gaussian_density(
+        shape, lattice_vectors, list(atoms), width=0.9
+    ) + 0.6 * gaussian_density(shape, lattice_vectors, [(0.45, 0.5, 0.5)], width=0.4)
+
+    # without atoms the interstitial peak is a basin of its own
+    assert len(np.unique(bader.basins(charge, lattice_vectors))) == 3
+
+    labels = bader.basins(charge, lattice_vectors, atoms)
+
+    assert set(np.unique(labels)) == {0, 1}
+    # the interstitial peak at 0.45 is closest to atom 0 at 0.2
+    assert label_at(labels, (0.45, 0.5, 0.5)) == 0
+
+
+def test_incorrect_charge_dimension_raises():
+    with pytest.raises(exception.IncorrectUsage):
+        bader.basins(np.zeros((4, 4)), np.diag((1.0, 1.0, 1.0)))
+
+
+def test_incorrect_positions_shape_raises():
+    charge = np.zeros((4, 4, 4))
+    lattice_vectors = np.diag((1.0, 1.0, 1.0))
+    with pytest.raises(exception.IncorrectUsage):
+        bader.basins(charge, lattice_vectors, np.zeros((2, 2)))

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -1,6 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import itertools
+import unittest.mock
 from types import SimpleNamespace
 
 import numpy as np
@@ -226,15 +227,31 @@ def test_to_view_sets_grid_domains(two_atom_bader, Assert):
     assert set(np.unique(domain.quantity)) == {1, 2}
 
 
-def test_to_view_threshold_hides_low_density(two_atom_bader):
-    bader_, charge = two_atom_bader.bader, two_atom_bader.charge
-    threshold = 0.5 * charge.max()
+def test_to_view_threshold_is_fraction_of_maximum():
+    shape = (24, 12, 12)
+    lattice_vectors = np.diag((8.0, 4.0, 4.0))
+    atoms = [(0.25, 0.5, 0.5), (0.75, 0.5, 0.5)]
+    # scale the density so an absolute cutoff and a fraction-of-max cutoff differ
+    charge = 100.0 * gaussian_density(shape, lattice_vectors, atoms)
+    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"], charge)
 
-    domain = bader_.to_view(threshold=threshold).grid_domains[0]
+    # the threshold is a fraction of the maximum density, so it is independent of
+    # the grid sampling and of the total number of electrons
+    domain = bader_.to_view(threshold=0.5).grid_domains[0]
 
-    hidden = charge < threshold
+    hidden = charge < 0.5 * charge.max()
     assert np.all(domain.quantity[0][hidden] == 0)
     assert np.all(domain.quantity[0][~hidden] >= 1)
+    # the fraction-of-max cutoff is not the same as an absolute cutoff of 0.5
+    assert hidden.sum() != np.count_nonzero(charge < 0.5)
+
+
+def test_repr_pretty_renders_string(two_atom_bader):
+    printer = unittest.mock.MagicMock()
+
+    two_atom_bader.bader._repr_pretty_(printer, cycle=False)
+
+    printer.text.assert_called_once_with(str(two_atom_bader.bader))
 
 
 def test_charges_sum_to_total_integral(two_atom_bader, Assert):

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -294,6 +294,24 @@ def test_str_single_atom_exact():
     assert str(analysis) == "Bader charges:\n    H_1   1.0000"
 
 
+def test_reference_defines_basins_but_not_charges(Assert):
+    shape = (24, 12, 12)
+    lattice_vectors = np.diag((8.0, 4.0, 4.0))
+    atoms = [(0.25, 0.5, 0.5), (0.75, 0.5, 0.5)]
+    # the integrand density peaks in the middle, the reference peaks on the atoms
+    integrand = gaussian_density(shape, lattice_vectors, [(0.5, 0.5, 0.5)])
+    reference = gaussian_density(shape, lattice_vectors, atoms)
+    structure = make_structure(lattice_vectors, atoms, ["Na", "Cl"])
+
+    analysis = bader.BaderAnalysis(structure, integrand, reference=reference)
+
+    # the basins follow the reference density, not the integrand
+    expected = bader.BaderAnalysis(structure, reference).basins()
+    Assert.allclose(analysis.basins(), expected)
+    # charges integrate the integrand density
+    Assert.allclose(sum(analysis.charges().values()), integrand.sum() / integrand.size)
+
+
 def test_charges_shape_mismatch_raises(two_atom_bader):
     with pytest.raises(exception.IncorrectUsage):
         two_atom_bader.bader.charges(np.ones((2, 2, 2)))

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -38,8 +38,8 @@ def label_at(labels, center):
     return labels[grid_point(labels.shape, center)]
 
 
-def make_bader(lattice_vectors, positions, elements):
-    """Build a Bader instance wrapping a structure with the given geometry."""
+def make_bader(lattice_vectors, positions, elements, density, snap_to_atoms=True):
+    """Build a BaderAnalysis wrapping a structure with the given geometry."""
     groups = [(name, len(list(g))) for name, g in itertools.groupby(elements)]
     raw_structure = raw.Structure(
         raw.Stoichiometry(
@@ -49,7 +49,8 @@ def make_bader(lattice_vectors, positions, elements):
         raw.Cell(lattice_vectors=np.asarray(lattice_vectors), scale=raw.VaspData(1.0)),
         positions=np.asarray(positions, dtype=float),
     )
-    return bader.Bader(StructureHandler.from_data(raw_structure))
+    structure = StructureHandler.from_data(raw_structure)
+    return bader.BaderAnalysis(structure, density, snap_to_atoms=snap_to_atoms)
 
 
 def test_local_maximum_points_to_itself(Assert):
@@ -91,9 +92,9 @@ def test_single_peak_is_one_basin():
     shape = (20, 18, 16)
     lattice_vectors = np.diag((6.0, 5.0, 4.0))
     charge = gaussian_density(shape, lattice_vectors, [(0.5, 0.5, 0.5)])
-    bader_ = make_bader(lattice_vectors, [(0.5, 0.5, 0.5)], ["H"])
+    bader_ = make_bader(lattice_vectors, [(0.5, 0.5, 0.5)], ["H"], charge, False)
 
-    labels = bader_.basins(charge, snap_to_atoms=False)
+    labels = bader_.basins()
 
     assert labels.shape == shape
     assert np.issubdtype(labels.dtype, np.integer)
@@ -105,9 +106,9 @@ def test_two_peaks_split_into_two_basins():
     lattice_vectors = np.diag((8.0, 4.0, 4.0))
     left, right = (0.25, 0.5, 0.5), (0.75, 0.5, 0.5)
     charge = gaussian_density(shape, lattice_vectors, [left, right])
-    bader_ = make_bader(lattice_vectors, [(0.0, 0.0, 0.0)], ["H"])
+    bader_ = make_bader(lattice_vectors, [(0.0, 0.0, 0.0)], ["H"], charge, False)
 
-    labels = bader_.basins(charge, snap_to_atoms=False)
+    labels = bader_.basins()
 
     assert len(np.unique(labels)) == 2
     assert label_at(labels, left) != label_at(labels, right)
@@ -126,9 +127,9 @@ def test_displaced_peak_assigns_to_nearest_atom():
     atoms = [(0.75, 0.5, 0.5), (0.25, 0.5, 0.5)]
     peaks = [(0.30, 0.5, 0.5), (0.70, 0.5, 0.5)]
     charge = gaussian_density(shape, lattice_vectors, peaks)
-    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"])
+    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"], charge)
 
-    labels = bader_.basins(charge, snap_to_atoms=True)
+    labels = bader_.basins()
 
     assert set(np.unique(labels)) <= {0, 1}
     assert label_at(labels, atoms[0]) == 0
@@ -144,12 +145,12 @@ def test_interstitial_maximum_merges_into_nearest_atom():
     charge = gaussian_density(
         shape, lattice_vectors, atoms, width=0.9
     ) + 0.6 * gaussian_density(shape, lattice_vectors, [(0.45, 0.5, 0.5)], width=0.4)
-    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"])
 
     # without snapping the interstitial peak is a basin of its own
-    assert len(np.unique(bader_.basins(charge, snap_to_atoms=False))) == 3
+    no_snap = make_bader(lattice_vectors, atoms, ["Na", "Cl"], charge, False)
+    assert len(np.unique(no_snap.basins())) == 3
 
-    labels = bader_.basins(charge, snap_to_atoms=True)
+    labels = make_bader(lattice_vectors, atoms, ["Na", "Cl"], charge).basins()
 
     assert set(np.unique(labels)) == {0, 1}
     # the interstitial peak at 0.45 is closest to atom 0 at 0.2
@@ -157,9 +158,8 @@ def test_interstitial_maximum_merges_into_nearest_atom():
 
 
 def test_incorrect_charge_dimension_raises():
-    bader_ = make_bader(np.diag((1.0, 1.0, 1.0)), [(0.0, 0.0, 0.0)], ["H"])
     with pytest.raises(exception.IncorrectUsage):
-        bader_.basins(np.zeros((4, 4)), snap_to_atoms=False)
+        make_bader(np.diag((1.0, 1.0, 1.0)), [(0.0, 0.0, 0.0)], ["H"], np.zeros((4, 4)))
 
 
 @pytest.fixture
@@ -168,14 +168,14 @@ def two_atom_bader():
     lattice_vectors = np.diag((8.0, 4.0, 4.0))
     atoms = [(0.25, 0.5, 0.5), (0.75, 0.5, 0.5)]
     charge = gaussian_density(shape, lattice_vectors, atoms)
-    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"])
+    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"], charge)
     return SimpleNamespace(bader=bader_, charge=charge, shape=shape)
 
 
 def test_to_view_sets_grid_domains(two_atom_bader, Assert):
-    bader_, charge, shape = two_atom_bader.bader, two_atom_bader.charge, two_atom_bader.shape
+    bader_, shape = two_atom_bader.bader, two_atom_bader.shape
 
-    view = bader_.to_view(charge)
+    view = bader_.to_view()
 
     assert len(view.grid_domains) == 1
     domain = view.grid_domains[0]
@@ -184,7 +184,7 @@ def test_to_view_sets_grid_domains(two_atom_bader, Assert):
     assert list(domain.labels) == ["Na_1", "Cl_1"]
     # with the default threshold nothing is hidden and ids are the snapped
     # basins shifted to 1..n_atoms
-    expected = bader_.basins(charge, snap_to_atoms=True) + 1
+    expected = bader_.basins() + 1
     Assert.allclose(domain.quantity[0], expected)
     assert set(np.unique(domain.quantity)) == {1, 2}
 
@@ -193,7 +193,7 @@ def test_to_view_threshold_hides_low_density(two_atom_bader):
     bader_, charge = two_atom_bader.bader, two_atom_bader.charge
     threshold = 0.5 * charge.max()
 
-    domain = bader_.to_view(charge, threshold=threshold).grid_domains[0]
+    domain = bader_.to_view(threshold=threshold).grid_domains[0]
 
     hidden = charge < threshold
     assert np.all(domain.quantity[0][hidden] == 0)
@@ -205,9 +205,9 @@ def test_plot_is_alias_of_to_view(Assert):
     lattice_vectors = np.diag((5.0, 4.0, 4.0))
     atoms = [(0.5, 0.5, 0.5)]
     charge = gaussian_density(shape, lattice_vectors, atoms)
-    bader_ = make_bader(lattice_vectors, atoms, ["H"])
+    bader_ = make_bader(lattice_vectors, atoms, ["H"], charge)
 
-    from_plot = bader_.plot(charge).grid_domains[0]
-    from_view = bader_.to_view(charge).grid_domains[0]
-
-    Assert.allclose(from_plot.quantity, from_view.quantity)
+    Assert.allclose(
+        bader_.plot().grid_domains[0].quantity,
+        bader_.to_view().grid_domains[0].quantity,
+    )

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -1,0 +1,44 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import numpy as np
+
+from py4vasp._util import bader
+
+
+def flat_index(shape, *multi_index):
+    return np.ravel_multi_index(multi_index, shape)
+
+
+def test_local_maximum_points_to_itself(Assert):
+    # single peak in the corner of a 3x3x3 grid; with periodic boundaries every
+    # other point is a direct (possibly diagonal) neighbor of the peak.
+    charge = np.zeros((3, 3, 3))
+    charge[0, 0, 0] = 1.0
+    lattice_vectors = np.diag((3.0, 3.0, 3.0))
+
+    pointers = bader._ascent_pointers(charge, lattice_vectors)
+
+    peak = flat_index(charge.shape, 0, 0, 0)
+    assert pointers[peak] == peak
+    # a point on the opposite corner reaches the peak by wrapping around
+    corner = flat_index(charge.shape, 2, 2, 2)
+    assert pointers[corner] == peak
+    # every non-peak point ascends to the single maximum
+    expected = np.full(charge.size, peak)
+    expected[peak] = peak
+    Assert.allclose(pointers, expected)
+
+
+def test_metric_weights_gradient_by_distance():
+    # anisotropic cell: a step along a is much longer than a step along b, so an
+    # equal density difference is a steeper ascent along b.
+    charge = np.zeros((3, 3, 3))
+    charge[2, 1, 1] = 1.0  # +a neighbor of (1, 1, 1)
+    charge[1, 2, 1] = 1.0  # +b neighbor of (1, 1, 1)
+    lattice_vectors = np.diag((30.0, 3.0, 3.0))
+
+    pointers = bader._ascent_pointers(charge, lattice_vectors)
+
+    source = flat_index(charge.shape, 1, 1, 1)
+    steeper_neighbor = flat_index(charge.shape, 1, 2, 1)
+    assert pointers[source] == steeper_neighbor

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -9,6 +9,29 @@ def flat_index(shape, *multi_index):
     return np.ravel_multi_index(multi_index, shape)
 
 
+def gaussian_density(shape, lattice_vectors, centers, width=1.0):
+    """Sum of periodic Gaussian peaks at the given fractional centers."""
+    lengths = np.linalg.norm(lattice_vectors, axis=1)
+    axes = [np.arange(n) / n for n in shape]
+    charge = np.zeros(shape)
+    for center in centers:
+        distance2 = np.zeros(shape)
+        grids = np.meshgrid(*axes, indexing="ij")
+        for grid, frac_center, length in zip(grids, center, lengths):
+            delta = (grid - frac_center + 0.5) % 1.0 - 0.5
+            distance2 = distance2 + (delta * length) ** 2
+        charge = charge + np.exp(-distance2 / (2 * width**2))
+    return charge
+
+
+def grid_point(shape, center):
+    return tuple(int(round(c * n)) % n for c, n in zip(center, shape))
+
+
+def label_at(labels, center):
+    return labels[grid_point(labels.shape, center)]
+
+
 def test_local_maximum_points_to_itself(Assert):
     # single peak in the corner of a 3x3x3 grid; with periodic boundaries every
     # other point is a direct (possibly diagonal) neighbor of the peak.
@@ -42,3 +65,30 @@ def test_metric_weights_gradient_by_distance():
     source = flat_index(charge.shape, 1, 1, 1)
     steeper_neighbor = flat_index(charge.shape, 1, 2, 1)
     assert pointers[source] == steeper_neighbor
+
+
+def test_single_peak_is_one_basin():
+    shape = (20, 18, 16)
+    lattice_vectors = np.diag((6.0, 5.0, 4.0))
+    charge = gaussian_density(shape, lattice_vectors, [(0.5, 0.5, 0.5)])
+
+    labels = bader.basins(charge, lattice_vectors)
+
+    assert labels.shape == shape
+    assert np.issubdtype(labels.dtype, np.integer)
+    assert np.array_equal(np.unique(labels), [0])
+
+
+def test_two_peaks_split_into_two_basins():
+    shape = (24, 12, 12)
+    lattice_vectors = np.diag((8.0, 4.0, 4.0))
+    left, right = (0.25, 0.5, 0.5), (0.75, 0.5, 0.5)
+    charge = gaussian_density(shape, lattice_vectors, [left, right])
+
+    labels = bader.basins(charge, lattice_vectors)
+
+    assert len(np.unique(labels)) == 2
+    assert label_at(labels, left) != label_at(labels, right)
+    # points nearer a peak belong to that peak's basin
+    assert label_at(labels, (0.1, 0.5, 0.5)) == label_at(labels, left)
+    assert label_at(labels, (0.9, 0.5, 0.5)) == label_at(labels, right)

--- a/tests/util/test_bader.py
+++ b/tests/util/test_bader.py
@@ -1,6 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import itertools
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -159,3 +160,54 @@ def test_incorrect_charge_dimension_raises():
     bader_ = make_bader(np.diag((1.0, 1.0, 1.0)), [(0.0, 0.0, 0.0)], ["H"])
     with pytest.raises(exception.IncorrectUsage):
         bader_.basins(np.zeros((4, 4)), snap_to_atoms=False)
+
+
+@pytest.fixture
+def two_atom_bader():
+    shape = (24, 12, 12)
+    lattice_vectors = np.diag((8.0, 4.0, 4.0))
+    atoms = [(0.25, 0.5, 0.5), (0.75, 0.5, 0.5)]
+    charge = gaussian_density(shape, lattice_vectors, atoms)
+    bader_ = make_bader(lattice_vectors, atoms, ["Na", "Cl"])
+    return SimpleNamespace(bader=bader_, charge=charge, shape=shape)
+
+
+def test_to_view_sets_grid_domains(two_atom_bader, Assert):
+    bader_, charge, shape = two_atom_bader.bader, two_atom_bader.charge, two_atom_bader.shape
+
+    view = bader_.to_view(charge)
+
+    assert len(view.grid_domains) == 1
+    domain = view.grid_domains[0]
+    assert domain.quantity.shape == (1, *shape)
+    assert np.issubdtype(domain.quantity.dtype, np.integer)
+    assert list(domain.labels) == ["Na_1", "Cl_1"]
+    # with the default threshold nothing is hidden and ids are the snapped
+    # basins shifted to 1..n_atoms
+    expected = bader_.basins(charge, snap_to_atoms=True) + 1
+    Assert.allclose(domain.quantity[0], expected)
+    assert set(np.unique(domain.quantity)) == {1, 2}
+
+
+def test_to_view_threshold_hides_low_density(two_atom_bader):
+    bader_, charge = two_atom_bader.bader, two_atom_bader.charge
+    threshold = 0.5 * charge.max()
+
+    domain = bader_.to_view(charge, threshold=threshold).grid_domains[0]
+
+    hidden = charge < threshold
+    assert np.all(domain.quantity[0][hidden] == 0)
+    assert np.all(domain.quantity[0][~hidden] >= 1)
+
+
+def test_plot_is_alias_of_to_view(Assert):
+    shape = (20, 10, 10)
+    lattice_vectors = np.diag((5.0, 4.0, 4.0))
+    atoms = [(0.5, 0.5, 0.5)]
+    charge = gaussian_density(shape, lattice_vectors, atoms)
+    bader_ = make_bader(lattice_vectors, atoms, ["H"])
+
+    from_plot = bader_.plot(charge).grid_domains[0]
+    from_view = bader_.to_view(charge).grid_domains[0]
+
+    Assert.allclose(from_plot.quantity, from_view.quantity)


### PR DESCRIPTION
Adds a grid-based Bader (QTAIM) charge analysis for real-space grid quantities.

- New `BaderAnalysis` class (`_util/bader.py`): on-grid steepest-ascent
  partitioning of a density into atomic basins (26-neighbor distance-weighted
  gradient, pointer-jumping to maxima, nearest-atom snapping), with `basins()`,
  `charges(density=None)`, `to_view()`/`plot()`, and `__str__`/`_repr_pretty_`.
- `calc.density.bader_analysis(selection)` builds basins; `bader_charge(...,
  bader_analysis=...)` integrates any grid quantity (density, potential,
  exciton_density, partial_density, nics) within basins supplied by the density.
  Basins are a property of the charge-density topology, so only the density
  defines them and every `bader_charge` takes the basins as an argument.
- Selectable `all_electron` density source with an optional `core` field, used
  only to place the basins (too coarsely sampled to integrate).
- New `view.GridDomain` / `View.grid_domains`; rendering raises `NotImplemented`
  for now.
