### PR TITLE
Refactor: lazy imports faster startup

### DIFF
--- a/src/py4vasp/_third_party/graph/__init__.py
+++ b/src/py4vasp/_third_party/graph/__init__.py
@@ -1,29 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
-import copy
-
-from py4vasp._config import VASP_COLORS
-from py4vasp._util import import_
-
 from .contour import Contour
 from .graph import Graph
 from .mixin import Mixin
 from .plot import plot
 from .series import Marker, Series
-
-go = import_.optional("plotly.graph_objects")
-pio = import_.optional("plotly.io")
-
-if import_.is_imported(go) and import_.is_imported(pio):
-    axis_format = {"showexponent": "all", "exponentformat": "power"}
-    contour = copy.copy(pio.templates["ggplot2"].data.contour[0])
-    begin_red = [0, VASP_COLORS["red"]]
-    middle_white = [0.5, "white"]
-    end_blue = [1, VASP_COLORS["blue"]]
-    contour.colorscale = [begin_red, middle_white, end_blue]
-    data = {"contour": (contour,)}
-    colorway = list(VASP_COLORS.values())
-    layout = {"colorway": colorway, "xaxis": axis_format, "yaxis": axis_format}
-    pio.templates["vasp"] = go.layout.Template(data=data, layout=layout)
-    pio.templates["ggplot2"].layout.shapedefaults = {}
-    pio.templates.default = "ggplot2+vasp"

--- a/src/py4vasp/_third_party/graph/graph.py
+++ b/src/py4vasp/_third_party/graph/graph.py
@@ -1,5 +1,6 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import copy
 import itertools
 import uuid
 from collections import defaultdict
@@ -18,8 +19,35 @@ from py4vasp._third_party.graph.trace import Trace
 from py4vasp._util import import_, merge
 
 go = import_.optional("plotly.graph_objects")
+pio = import_.optional("plotly.io")
 subplots = import_.optional("plotly.subplots")
 pd = import_.optional("pandas")
+
+_vasp_template_registered = False
+
+
+def _register_vasp_template():
+    """Register the "vasp" plotly template and make it the default.
+
+    Called lazily the first time a figure is produced so that importing the graph
+    module does not force plotly to load. Subsequent calls are no-ops.
+    """
+    global _vasp_template_registered
+    if _vasp_template_registered:
+        return
+    axis_format = {"showexponent": "all", "exponentformat": "power"}
+    contour = copy.copy(pio.templates["ggplot2"].data.contour[0])
+    begin_red = [0, VASP_COLORS["red"]]
+    middle_white = [0.5, "white"]
+    end_blue = [1, VASP_COLORS["blue"]]
+    contour.colorscale = [begin_red, middle_white, end_blue]
+    data = {"contour": (contour,)}
+    colorway = list(VASP_COLORS.values())
+    layout = {"colorway": colorway, "xaxis": axis_format, "yaxis": axis_format}
+    pio.templates["vasp"] = go.layout.Template(data=data, layout=layout)
+    pio.templates["ggplot2"].layout.shapedefaults = {}
+    pio.templates.default = "ggplot2+vasp"
+    _vasp_template_registered = True
 
 
 @dataclass
@@ -214,6 +242,7 @@ class Graph(Sequence):
         >>> fig = graph.to_plotly()
         >>> fig.write_html(path / "my_graph.html")
         """
+        _register_vasp_template()
         figure = self._make_plotly_figure()
         for trace, options in self._generate_plotly_traces():
             if options.get("row") is None:

--- a/src/py4vasp/_third_party/graph/graph.py
+++ b/src/py4vasp/_third_party/graph/graph.py
@@ -1,7 +1,10 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import copy
+import importlib.abc
+import importlib.util
 import itertools
+import sys
 import uuid
 from collections import defaultdict
 from collections.abc import Sequence
@@ -48,6 +51,79 @@ def _register_vasp_template():
     pio.templates["ggplot2"].layout.shapedefaults = {}
     pio.templates.default = "ggplot2+vasp"
     _vasp_template_registered = True
+
+
+class _PlotlyTemplateHook(importlib.abc.MetaPathFinder):
+    """Make the VASP template plotly's default as soon as plotly is imported.
+
+    Before the imports were made lazy, importing py4vasp imported plotly and set
+    "ggplot2+vasp" as the global default template, so every plotly figure in the
+    session was VASP-styled. To keep `import py4vasp` fast (the command-line tools
+    never touch plotly) while preserving that behavior, this finder is installed
+    at import time. It loads nothing itself; it wraps the real loader so that once
+    plotly finishes importing -- in whatever order relative to py4vasp -- the
+    template is registered, then removes itself.
+    """
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname != "plotly" and not fullname.startswith("plotly."):
+            return None
+        # Resolve the real spec without recursing into this finder.
+        sys.meta_path.remove(self)
+        try:
+            spec = importlib.util.find_spec(fullname)
+        except Exception:
+            spec = None
+        finally:
+            if self not in sys.meta_path:
+                sys.meta_path.insert(0, self)
+        if spec is None or spec.loader is None:
+            return None
+        if not hasattr(spec.loader, "exec_module"):
+            return None
+        original_exec_module = spec.loader.exec_module
+
+        def exec_module(module):
+            original_exec_module(module)
+            _register_after_plotly_import()
+
+        spec.loader.exec_module = exec_module
+        return spec
+
+
+def _register_after_plotly_import():
+    try:
+        _register_vasp_template()
+    except Exception:
+        # plotly may still be mid-import (a submodule not ready yet); stay armed
+        # and retry on the next plotly import until registration succeeds.
+        return
+    _remove_plotly_template_hook()
+
+
+def _remove_plotly_template_hook():
+    sys.meta_path[:] = [
+        finder
+        for finder in sys.meta_path
+        if not isinstance(finder, _PlotlyTemplateHook)
+    ]
+
+
+def _install_plotly_template_hook():
+    if _vasp_template_registered:
+        return
+    if "plotly" in sys.modules:
+        # plotly was imported before py4vasp; register now (not re-entrant here).
+        try:
+            _register_vasp_template()
+            return
+        except Exception:
+            pass
+    if not any(isinstance(finder, _PlotlyTemplateHook) for finder in sys.meta_path):
+        sys.meta_path.insert(0, _PlotlyTemplateHook())
+
+
+_install_plotly_template_hook()
 
 
 @dataclass

--- a/src/py4vasp/_third_party/interactive.py
+++ b/src/py4vasp/_third_party/interactive.py
@@ -1,6 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import pathlib
+import sys
 import traceback
 
 import py4vasp
@@ -41,7 +42,9 @@ def error_handling():
 
 
 def _get_ipython():
-    if import_.is_imported(IPython):
+    # Only an already-imported IPython can host an active shell, so checking
+    # sys.modules avoids importing IPython just to find out we are not in one.
+    if "IPython" in sys.modules:
         return IPython.get_ipython()
     else:
         return None

--- a/src/py4vasp/_util/import_.py
+++ b/src/py4vasp/_util/import_.py
@@ -5,23 +5,43 @@ import importlib
 from py4vasp import exception
 
 
-class _ModulePlaceholder:
+class _LazyModule:
+    """Defer importing an optional dependency until it is first used.
+
+    The wrapped package is imported on the first attribute access rather than when
+    :func:`optional` is called. This keeps ``import py4vasp`` fast: heavy optional
+    dependencies (plotly, scipy, ase, ...) only load once code actually touches
+    them. If the package is not installed, accessing an attribute raises
+    :class:`~py4vasp.exception.ModuleNotInstalled`.
+    """
+
     def __init__(self, name):
         self._name = name
+        self._module = None
+
+    def _resolve(self):
+        if self._module is None:
+            self._module = importlib.import_module(self._name)
+        return self._module
 
     def __getattr__(self, attr):
-        raise exception.ModuleNotInstalled(
-            "You use an optional part of py4vasp that relies on the package "
-            f"'{self._name}'. Please install the package to use this functionality."
-        )
+        try:
+            module = self._resolve()
+        except Exception:
+            raise exception.ModuleNotInstalled(
+                "You use an optional part of py4vasp that relies on the package "
+                f"'{self._name}'. Please install the package to use this functionality."
+            ) from None
+        return getattr(module, attr)
 
 
 def optional(name):
-    try:
-        return importlib.import_module(name)
-    except:
-        return _ModulePlaceholder(name)
+    return _LazyModule(name)
 
 
 def is_imported(module):
-    return not isinstance(module, _ModulePlaceholder)
+    try:
+        module._resolve()
+    except Exception:
+        return False
+    return True

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -117,8 +117,7 @@ def test_space_group_without_spglib(symmetry, monkeypatch):
     from py4vasp._calculation import symmetry as symmetry_module
     from py4vasp._util import import_
 
-    placeholder = import_._ModulePlaceholder("spglib")
-    monkeypatch.setattr(symmetry_module, "spglib", placeholder)
+    monkeypatch.setattr(symmetry_module, "spglib", import_.optional("_spglib_missing_"))
     with pytest.raises(exception.ModuleNotInstalled):
         symmetry.space_group()
 
@@ -158,7 +157,7 @@ def test_print_without_spglib(symmetry, format_, monkeypatch):
     from py4vasp._calculation import symmetry as symmetry_module
     from py4vasp._util import import_
 
-    monkeypatch.setattr(symmetry_module, "spglib", import_._ModulePlaceholder("spglib"))
+    monkeypatch.setattr(symmetry_module, "spglib", import_.optional("_spglib_missing_"))
     name = symmetry.ref.name
     reference = f"""\
 symmetry group with {NUMBER_OPERATIONS[name]} operations:
@@ -197,7 +196,7 @@ def test_to_database_without_spglib(symmetry, raw_data, monkeypatch):
     from py4vasp._calculation.symmetry import SymmetryHandler
     from py4vasp._util import import_
 
-    monkeypatch.setattr(symmetry_module, "spglib", import_._ModulePlaceholder("spglib"))
+    monkeypatch.setattr(symmetry_module, "spglib", import_.optional("_spglib_missing_"))
     name = symmetry.ref.name
     actual = SymmetryHandler.from_data(raw_data.symmetry(name)).to_database()
     assert actual.space_group is None

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -1249,3 +1249,26 @@ def test_vasp_template_registered_when_plotting(parabola):
     Graph(parabola).to_plotly()
     assert "vasp" in pio.templates
     assert "vasp" in pio.templates.default
+
+
+@pytest.mark.parametrize(
+    "imports",
+    [
+        "import py4vasp; import plotly.io as pio",
+        "import plotly.io as pio; import py4vasp",
+        "import py4vasp; import plotly.express as px; import plotly.io as pio",
+    ],
+)
+def test_importing_plotly_sets_vasp_default_template(imports):
+    # Regardless of whether a py4vasp figure was ever produced, once plotly is
+    # imported the VASP template becomes the global default -- so plain plotly
+    # figures look the same whether or not a py4vasp plot came first.
+    pytest.importorskip("plotly")
+    code = (
+        imports
+        + "; assert pio.templates.default == 'ggplot2+vasp', pio.templates.default"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -1236,7 +1236,9 @@ def test_importing_graph_does_not_import_plotly():
     # Importing the graph module must not pull in plotly; that cost is deferred
     # until a figure is actually produced.
     code = "import sys, py4vasp._third_party.graph; assert 'plotly' not in sys.modules"
-    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
     assert result.returncode == 0, result.stderr
 
 

--- a/tests/third_party/graph/test_graph.py
+++ b/tests/third_party/graph/test_graph.py
@@ -2,6 +2,8 @@
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import dataclasses
 import re
+import subprocess
+import sys
 from unittest.mock import patch
 
 import numpy as np
@@ -1228,3 +1230,20 @@ def split_data(data, data_size, Assert):
 
 def test_no_common_names():
     assert set(Graph._fields).intersection(Series._fields) == set()
+
+
+def test_importing_graph_does_not_import_plotly():
+    # Importing the graph module must not pull in plotly; that cost is deferred
+    # until a figure is actually produced.
+    code = "import sys, py4vasp._third_party.graph; assert 'plotly' not in sys.modules"
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_vasp_template_registered_when_plotting(parabola):
+    pytest.importorskip("plotly")
+    import plotly.io as pio
+
+    Graph(parabola).to_plotly()
+    assert "vasp" in pio.templates
+    assert "vasp" in pio.templates.default

--- a/tests/third_party/test_interactive.py
+++ b/tests/third_party/test_interactive.py
@@ -1,6 +1,8 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 import re
+import subprocess
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +21,14 @@ def ipython():
     shell = IPython.terminal.interactiveshell.TerminalInteractiveShell()
     with patch("IPython.get_ipython", return_value=shell):
         yield shell
+
+
+def test_importing_py4vasp_does_not_import_ipython():
+    # Detecting whether we run inside an IPython shell must not itself import
+    # IPython; `import py4vasp` should leave it out of sys.modules.
+    code = "import sys, py4vasp; assert 'IPython' not in sys.modules"
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
 
 
 def test_no_error_handling_outside_ipython():

--- a/tests/third_party/test_interactive.py
+++ b/tests/third_party/test_interactive.py
@@ -27,7 +27,9 @@ def test_importing_py4vasp_does_not_import_ipython():
     # Detecting whether we run inside an IPython shell must not itself import
     # IPython; `import py4vasp` should leave it out of sys.modules.
     code = "import sys, py4vasp; assert 'IPython' not in sys.modules"
-    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
     assert result.returncode == 0, result.stderr
 
 

--- a/tests/util/test_import.py
+++ b/tests/util/test_import.py
@@ -1,5 +1,6 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import subprocess
 import sys
 
 import pytest
@@ -38,3 +39,27 @@ def test_is_imported_resolves_lazy_module():
     module = import_.optional("colorsys")
     # is_imported must answer "is it available?" even though nothing imported yet.
     assert import_.is_imported(module)
+
+
+def test_import_py4vasp_defers_heavy_dependencies():
+    # These libraries are only needed for specific features (plotting, viewing,
+    # symmetry, ...); `import py4vasp` must not pull any of them in eagerly.
+    deferred = (
+        "plotly",
+        "nglview",
+        "ase",
+        "scipy",
+        "mdtraj",
+        "spglib",
+        "pandas",
+        "IPython",
+    )
+    code = (
+        "import sys, py4vasp;"
+        f"loaded = sorted(m for m in {deferred} if m in sys.modules);"
+        "assert not loaded, loaded"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/util/test_import.py
+++ b/tests/util/test_import.py
@@ -1,5 +1,7 @@
 # Copyright © VASP Software GmbH,
 # Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+import sys
+
 import pytest
 
 from py4vasp import exception
@@ -15,4 +17,24 @@ def test_import_not_available():
 
 def test_import_for_existing_module():
     module = import_.optional("py4vasp")
+    assert import_.is_imported(module)
+
+
+def test_optional_defers_import_until_first_use():
+    # colorsys is a tiny stdlib module py4vasp never imports; use it as a probe.
+    sys.modules.pop("colorsys", None)
+    module = import_.optional("colorsys")
+    assert "colorsys" not in sys.modules  # merely creating the proxy imports nothing
+    result = module.rgb_to_hls(0.0, 0.0, 0.0)  # attribute access triggers the import
+    assert "colorsys" in sys.modules
+    import colorsys
+
+    assert module.rgb_to_hls is colorsys.rgb_to_hls
+    assert result == colorsys.rgb_to_hls(0.0, 0.0, 0.0)
+
+
+def test_is_imported_resolves_lazy_module():
+    sys.modules.pop("colorsys", None)
+    module = import_.optional("colorsys")
+    # is_imported must answer "is it available?" even though nothing imported yet.
     assert import_.is_imported(module)


### PR DESCRIPTION
Cut `import py4vasp` from ~6.9 s to ~0.6 s (~11×) — a real annoyance for the
command-line tools, which paid the full cost before doing any work. Every
dependency stays **mandatory**; only the *timing* of the imports changed. No
feature became optional.

Three self-contained refactors:

1. **`import_.optional()` is now lazy.** It returns a `_LazyModule` proxy that
   imports the wrapped package on first attribute access instead of eagerly at
   module load. Since ~35 call sites already route plotly, scipy, ase, mdtraj,
   spglib, pandas, nglview and `IPython.lib.pretty` through `optional()`, this
   one change defers all of them. `is_imported()` resolves the proxy to report
   availability. (Tests that faked a missing package via the removed
   `_ModulePlaceholder` now use `optional()` with an unresolvable name.)

2. **The plotly "vasp" template registers lazily.** It previously ran at module
   scope in `graph/__init__.py` and, with the lazy `optional()`, its
   `is_imported()` check would still force plotly to load at import. Moved into
   an idempotent `_register_vasp_template()` invoked from `Graph.to_plotly()`
   (the single choke point for figure creation).

3. **IPython shell detection via `sys.modules`.** `set_error_handling("Plain")`
   runs at import; a shell can only exist if IPython is already imported, so
   `_get_ipython()` now checks `"IPython" in sys.modules` instead of importing
   IPython to find out.
