### PR TITLE
CI: fix conda `defaults` 403 and harden workflows

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -8,6 +8,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-default:
     runs-on: ${{ matrix.os }}
@@ -23,6 +30,9 @@ jobs:
       with:
         auto-update-conda: true
         python-version: "3.11"
+        channels: conda-forge
+        channel-priority: strict
+        conda-remove-defaults: "true"
     - name: Install py4vasp and testing tools
       shell: bash -el {0}
       run: |
@@ -30,12 +40,6 @@ jobs:
         pip install --progress-bar=off .
         pip install --progress-bar=off pytest hypothesis
         pip install --progress-bar=off ipykernel
-    - name: Configure conda channel priority
-      shell: bash -el {0}
-      run: |
-        conda config --set channel_priority strict
-        conda config --remove channels defaults
-        conda config --add channels conda-forge
     - name: Install mdtraj with conda
       shell: bash -el {0}
       run: |

--- a/.github/workflows/publish_full.yml
+++ b/.github/workflows/publish_full.yml
@@ -21,12 +21,9 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-    - name: Configure conda channel priority
-      shell: bash -el {0}
-      run: |
-        conda config --set channel_priority strict
-        conda config --remove channels defaults
-        conda config --add channels conda-forge
+        channels: conda-forge
+        channel-priority: strict
+        conda-remove-defaults: "true"
     - name: Set up uv
       shell: bash -el {0}
       run: |

--- a/.github/workflows/test_core.yml
+++ b/.github/workflows/test_core.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-core:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_full.yml
+++ b/.github/workflows/test_full.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-full:
     runs-on: ${{ matrix.os }}
@@ -21,12 +28,9 @@ jobs:
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
-    - name: Configure conda channel priority
-      shell: bash -el {0}
-      run: |
-        conda config --set channel_priority strict
-        conda config --remove channels defaults
-        conda config --add channels conda-forge
+        channels: conda-forge
+        channel-priority: strict
+        conda-remove-defaults: "true"
     - name: Set up uv
       shell: bash -el {0}
       run: |

--- a/.github/workflows/test_minimal.yml
+++ b/.github/workflows/test_minimal.yml
@@ -14,6 +14,13 @@ on:
   schedule:
     - cron: "0 2 * * 6"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-minimal:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The conda-based jobs failed during setup with `CondaHTTPError: HTTP 403 Forbidden` for `repo.anaconda.com/pkgs/main`. Anaconda's default channels now reject automated access without accepting their Terms of Service. Because setup-miniconda creates the `test` env (`conda create --name test ...`) using the base `defaults` channel *inside the action*, the later standalone "Configure conda channel priority" step ran too late to help.

Fold the channel configuration into the setup-miniconda inputs so the env is built from conda-forge from the first `conda create`, and drop the redundant follow-up step. Applied to test_full, install, and publish_full.

Also harden the PR-triggered workflows: least-privilege `contents: read` token permissions and a cancel-in-progress concurrency group to save runner minutes. Publish workflows are left untouched (per-job `id-token: write`, never cancel a release).