### PR TITLE
Fix is_available misreporting of availability

### DIFF
--- a/src/py4vasp/_calculation/band.py
+++ b/src/py4vasp/_calculation/band.py
@@ -358,13 +358,17 @@ class Band(graph.Mixin):
 
     def _is_available(self, raw_data, selection=None, method=None) -> bool:
         # to_quiver plots the spin texture, which needs the optional projections and
-        # a noncollinear calculation (projections has a leading dimension of 4).
+        # a noncollinear calculation (projections has a leading dimension of 4). It
+        # selects the components via the projector information, so that has to be
+        # present too. The other methods work without any projector data; they only
+        # require it when the user asks for a projection with their selection.
         if not is_available_raw(self._quantity_name, raw_data, selection=selection):
             return False
         if method == "to_quiver":
             return (
                 not check.is_none(raw_data.projections)
                 and len(raw_data.projections) == 4
+                and projector.has_projector_data(raw_data.projectors)
             )
         return True
 

--- a/src/py4vasp/_calculation/current_density.py
+++ b/src/py4vasp/_calculation/current_density.py
@@ -9,6 +9,7 @@ from py4vasp._calculation import _stoichiometry
 from py4vasp._calculation.dispatch import (
     DataSource,
     _dispatch,
+    is_available_raw,
     merge_default,
     merge_strings,
     merge_to_database,
@@ -197,6 +198,15 @@ class CurrentDensity:
 
     def _handler_factory(self, raw):
         return CurrentDensityHandler.from_data(raw)
+
+    def _is_available(self, raw_data, selection=None, method=None) -> bool:
+        # "nmr" is the only source and the quantity defines no default one, so the
+        # methods taking a selection are the only ones that can reach the data;
+        # read and __str__ request the (nonexistent) default source and fail. Drop
+        # this restriction once current_density implements a default selection.
+        if method not in ("to_contour", "to_quiver"):
+            return False
+        return is_available_raw(self._quantity_name, raw_data, selection=selection)
 
     def __str__(self, selection=None):
         return merge_strings(

--- a/src/py4vasp/_calculation/dispatch.py
+++ b/src/py4vasp/_calculation/dispatch.py
@@ -264,6 +264,16 @@ def _dispatch(
     handler_wants_selection, selection_has_default = _method_accepts_selection(method)
     results = {}
     for ctx in contexts:
+        if ctx.remaining_selection is not None and not handler_wants_selection:
+            # without this check, a mistyped source would silently fall back to
+            # the default source and return data the user did not ask for
+            message = (
+                f"The selection '{ctx.remaining_selection}' is not a source of the "
+                f"quantity '{quantity_name.lstrip('_')}' and the method takes no "
+                "further selections. Use `selections` or `is_available` to see "
+                "which sources exist."
+            )
+            raise exception.IncorrectUsage(message)
         with source.access(quantity_name, selection=ctx.selection_name) as raw:
             handler = handler_factory(raw)
             if handler_wants_selection:

--- a/src/py4vasp/_calculation/projector.py
+++ b/src/py4vasp/_calculation/projector.py
@@ -47,6 +47,29 @@ selection : str
 """
 
 
+def has_projector_data(raw_projectors) -> bool:
+    """Check whether VASP wrote the projector information needed for projections.
+
+    VASP only writes the projectors when :tag:`LORBIT` is set. Quantities that link
+    to the projectors then receive a :class:`~py4vasp.raw.Projector` whose fields are
+    all unset (or no projector at all), which is what this detects. Use it to decide
+    whether a projection on atoms and orbitals is possible.
+
+    Parameters
+    ----------
+    raw_projectors
+        The projector data of a quantity, e.g. ``raw_band.projectors``.
+
+    Returns
+    -------
+    bool
+        True if the projector information is present.
+    """
+    if check.is_none(raw_projectors):
+        return False
+    return not check.is_none(raw_projectors.orbital_types)
+
+
 class ProjectorHandler:
     """Handler for projector data."""
 

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -26,6 +26,7 @@ from py4vasp._calculation.dispatch import (
 from py4vasp._calculation.symmetry import _SYMPREC, SymmetryHandler
 from py4vasp._raw.definition import unique_selections as _schema_unique_selections
 from py4vasp._raw.models import StoichiometryModel, StructureModel
+from py4vasp._raw.schema import DEFAULT_SELECTION
 from py4vasp._third_party import view
 from py4vasp._util import check, import_, parse
 
@@ -720,6 +721,12 @@ class Structure(view.Mixin):
         return StructureHandler.from_data(raw, steps=self._steps)
 
     def _is_available(self, raw_data, selection=None, method=None) -> bool:
+        # None of the methods takes a source selection, so the additional schema
+        # sources ("final", "exciton", "poscar") cannot be reached through the public
+        # API. They only serve other quantities that link to them, so report them as
+        # unavailable even when the underlying data exists.
+        if selection not in (None, DEFAULT_SELECTION):
+            return False
         # the symmetry-derived methods need the optional symmetry link that VASP
         # only writes for newer versions; all other methods need only the required
         # structural data.

--- a/src/py4vasp/_raw/data.py
+++ b/src/py4vasp/_raw/data.py
@@ -43,8 +43,8 @@ class Band:
     "Fermi energy obtained by VASP."
     occupations: VaspData
     "The occupations of the different bands."
-    projectors: Projector
-    "Projector information (element, angular momentum, spin)."
+    projectors: Projector = NONE()
+    "If present, projector information (element, angular momentum, spin)."
     projections: VaspData = NONE()
     "If present, orbital projections of the bands."
 
@@ -269,8 +269,8 @@ class Dos:
     "Dos at the energies D(E)."
     fermi_energy: float
     "Fermi energy obtained by VASP."
-    projectors: Projector
-    "Projector information (element, angular momentum, spin)."
+    projectors: Projector = NONE()
+    "If present, projector information (element, angular momentum, spin)."
     projections: VaspData = NONE()
     "If present, orbital projections of the Dos."
 

--- a/src/py4vasp/demo.py
+++ b/src/py4vasp/demo.py
@@ -54,7 +54,12 @@ def _create_path_for_data(path, selection):
 def _generate_calculation_data(h5f, selection, waveh5f=None):
     generator = _DATA_GENERATORS.get(selection)
     if generator is not None:
-        write(h5f, raw.Version(major=99, minor=99, patch=99))
+        version = raw.Version(major=99, minor=99, patch=99)
+        write(h5f, version)
+        if waveh5f is not None:
+            # the wavefile carries its own version because py4vasp checks the version
+            # requirement of a source against the file that source is read from
+            write(waveh5f, version)
         generator(h5f, waveh5f=waveh5f)
     else:
         available = ", ".join(filter(None, key) for key in _DATA_GENERATORS.keys())

--- a/tests/calculation/test_band.py
+++ b/tests/calculation/test_band.py
@@ -776,3 +776,37 @@ def test_is_available_to_quiver(raw_data):
     assert without_projections.is_available("default", method="to_quiver") is False
     # read stays available in every case
     assert noncollinear.is_available("default") is True
+
+
+def test_is_available_to_quiver_requires_projector_data(raw_data):
+    from py4vasp import raw
+
+    # to_quiver selects the spin components through the projector information, so
+    # the projections array alone is not enough
+    raw_band = raw_data.band("noncollinear with_projectors")
+    raw_band.projectors.orbital_types = raw.VaspData(None)
+    without_projector_data = Band.from_data(raw_band)
+    assert without_projector_data.is_available("default", method="to_quiver") is False
+    with pytest.raises(Exception):
+        without_projector_data.to_quiver("x~y")
+
+
+def test_is_available_without_projectors(raw_data):
+    """VASP writes the projectors only when LORBIT is set. Band data without them
+    (e.g. from a phonon calculation) is still usable by every method that does not
+    project onto atoms or orbitals."""
+    # this is the shape a file without the projectors group produces: the linked
+    # Projector exists but its fields are unset
+    without_projectors = Band.from_data(raw_data.band("multiple"))
+    assert without_projectors.is_available("default") is True
+    for method in ("read", "to_graph", "to_frame"):
+        assert without_projectors.is_available("default", method=method) is True
+        assert getattr(without_projectors, method)() is not None
+    # projecting is the only thing that does not work, and it says so
+    assert without_projectors.is_available("default", method="to_quiver") is False
+    with pytest.raises(exception.IncorrectUsage):
+        without_projectors.read("Sr")
+    # the available projections are reported as empty instead of raising
+    assert without_projectors.selections() == {
+        "band": ["default", "kpoints_opt", "kpoints_wan"]
+    }

--- a/tests/calculation/test_band.py
+++ b/tests/calculation/test_band.py
@@ -801,7 +801,8 @@ def test_is_available_without_projectors(raw_data):
     assert without_projectors.is_available("default") is True
     for method in ("read", "to_graph", "to_frame"):
         assert without_projectors.is_available("default", method=method) is True
-        assert getattr(without_projectors, method)() is not None
+    assert without_projectors.read() is not None
+    assert without_projectors.to_graph() is not None
     # projecting is the only thing that does not work, and it says so
     assert without_projectors.is_available("default", method="to_quiver") is False
     with pytest.raises(exception.IncorrectUsage):
@@ -810,3 +811,9 @@ def test_is_available_without_projectors(raw_data):
     assert without_projectors.selections() == {
         "band": ["default", "kpoints_opt", "kpoints_wan"]
     }
+
+
+def test_to_frame_without_projectors(raw_data):
+    pytest.importorskip("pandas")
+    without_projectors = Band.from_data(raw_data.band("multiple"))
+    assert without_projectors.to_frame() is not None

--- a/tests/calculation/test_current_density.py
+++ b/tests/calculation/test_current_density.py
@@ -220,7 +220,16 @@ def test_factory_methods(raw_data, check_factory_methods):
 
 
 def test_is_available(tmp_path):
+    """Only the methods taking a selection can reach the "nmr" source; read and
+    __str__ ask for the default source that current_density does not define."""
     from py4vasp import demo
 
     calc = demo.calculation(tmp_path / "example")
-    assert calc.current_density.is_available("nmr") is True
+    current_density = calc.current_density
+    for method in ("to_contour", "to_quiver"):
+        assert current_density.is_available("nmr", method=method) is True
+        assert getattr(current_density, method)("nmr", a=0) is not None
+    assert current_density.is_available("nmr") is False
+    assert current_density.is_available("nmr", method="read") is False
+    with pytest.raises(exception.Py4VaspError):
+        current_density.read()

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -651,3 +651,14 @@ def test_is_available_to_quiver(raw_data):
     # read / to_view work regardless of the magnetic configuration
     assert nonpolarized.is_available("default") is True
     assert nonpolarized.is_available("default", method="to_view") is True
+
+
+def test_is_available_reports_sources_selected_by_item(tmp_path):
+    """Density selects its source with the [] operator instead of a method argument
+    (``calculation.density["tau"].read()``), so those sources are reachable and must
+    be reported as available."""
+    from py4vasp import demo
+
+    density = demo.calculation(tmp_path / "example").density
+    assert density.is_available(["default", "tau"]) == {"default": True, "tau": True}
+    assert density["tau"].read() is not None

--- a/tests/calculation/test_dispatch.py
+++ b/tests/calculation/test_dispatch.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from py4vasp import raw
+from py4vasp import exception, raw
 from py4vasp._calculation.dispatch import (
     _REGISTRY,
     DataSource,
@@ -356,8 +356,9 @@ class TestDispatch:
         assert received["selection"] == "atom"
 
     def test_selection_not_forwarded_when_handler_has_no_selection_param(self):
-        """If the handler method has no `selection` parameter, dispatch must not
-        forward it — only source routing happens."""
+        """If the handler method has no `selection` parameter, a selection that
+        matches a source routes to it; a leftover selection raises instead of
+        silently falling back to the default source."""
         raw = {"value": 42}
         source = DataSource(raw)
         with patch(
@@ -366,11 +367,19 @@ class TestDispatch:
             result = _dispatch(
                 source,
                 "quantity",
-                "something",
+                "src",
                 _FakeHandler.from_data,
                 _FakeHandler.read,
             )
-        assert result == {"default": {"value": 42}}
+            assert result == {"src": {"value": 42}}
+            with pytest.raises(exception.IncorrectUsage):
+                _dispatch(
+                    source,
+                    "quantity",
+                    "something",
+                    _FakeHandler.from_data,
+                    _FakeHandler.read,
+                )
 
     def test_handler_with_selection_receives_remaining_selection(self):
         """If the handler method accepts `selection`, dispatch auto-forwards

--- a/tests/calculation/test_dispatch.py
+++ b/tests/calculation/test_dispatch.py
@@ -1167,9 +1167,12 @@ class TestIsAvailableSourceResolution:
 
     def test_single_nondefault_source_resolves(self, tmp_path):
         # current_density's only schema source is "nmr" (no "default"); is_available
-        # must resolve it rather than fail on the missing "default" source.
-        calc = self._calc(tmp_path)
-        assert calc.current_density.is_available("nmr") is True
+        # must resolve it rather than fail on the missing "default" source. Only the
+        # methods taking a selection reach that source, so the check uses one of them.
+        current_density = self._calc(tmp_path).current_density
+        assert current_density.is_available("nmr", method="to_contour") is True
         # None resolves the sole "nmr" source rather than the missing "default"
-        assert calc.current_density.is_available() is True
-        assert calc.current_density.is_available(["nmr"]) == {"nmr": True}
+        assert current_density.is_available(method="to_contour") is True
+        assert current_density.is_available(["nmr"], method="to_contour") == {
+            "nmr": True
+        }

--- a/tests/calculation/test_dos.py
+++ b/tests/calculation/test_dos.py
@@ -410,3 +410,19 @@ def test_to_database_Fe3O4(Fe3O4):
 def test_to_database_Ba2PbO4(Ba2PbO4):
     _check_to_database(Ba2PbO4)
     _check_to_database(Ba2PbO4, fermi_energy=Ba2PbO4.ref.fermi_energy + 0.5)
+
+
+def test_is_available_without_projectors(raw_data):
+    """VASP writes the projectors only when LORBIT is set. The DOS without them is
+    still usable by every method that does not project onto atoms or orbitals."""
+    # this is the shape a file without the projectors group produces: the linked
+    # Projector exists but its fields are unset
+    without_projectors = Dos.from_data(raw_data.dos("Sr2TiO4"))
+    assert without_projectors.is_available("default") is True
+    for method in ("read", "to_graph", "to_frame"):
+        assert without_projectors.is_available("default", method=method) is True
+        assert getattr(without_projectors, method)() is not None
+    # projecting is the only thing that does not work, and it says so
+    with pytest.raises(exception.IncorrectUsage):
+        without_projectors.read("Sr")
+    assert without_projectors.selections() == {"dos": ["default", "kpoints_opt"]}

--- a/tests/calculation/test_dos.py
+++ b/tests/calculation/test_dos.py
@@ -421,8 +421,15 @@ def test_is_available_without_projectors(raw_data):
     assert without_projectors.is_available("default") is True
     for method in ("read", "to_graph", "to_frame"):
         assert without_projectors.is_available("default", method=method) is True
-        assert getattr(without_projectors, method)() is not None
+    assert without_projectors.read() is not None
+    assert without_projectors.to_graph() is not None
     # projecting is the only thing that does not work, and it says so
     with pytest.raises(exception.IncorrectUsage):
         without_projectors.read("Sr")
     assert without_projectors.selections() == {"dos": ["default", "kpoints_opt"]}
+
+
+def test_to_frame_without_projectors(raw_data):
+    pytest.importorskip("pandas")
+    without_projectors = Dos.from_data(raw_data.dos("Sr2TiO4"))
+    assert without_projectors.to_frame() is not None

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -749,6 +749,32 @@ def test_is_available_default_and_other_methods(perovskite, raw_data):
     assert without_symmetry.is_available("default", method="to_view") is True
 
 
+def test_is_available_only_reports_selectable_sources(tmp_path):
+    """The extra structure sources exist for other quantities that link to them, but
+    no Structure method takes a source selection. Even with the data present they are
+    therefore reported as unavailable instead of promising access that is not there."""
+    import h5py
+
+    import py4vasp
+    from py4vasp._demo import CONTCAR as contcar_demo
+
+    with h5py.File(tmp_path / "vaspout.h5", "w") as h5f:
+        py4vasp._raw.write.write(h5f, raw.Version(99, 99, 99))
+        py4vasp._raw.write.write(h5f, contcar_demo.Sr2TiO4())
+    (tmp_path / "POSCAR").write_text(REF_POSCAR)
+    structure = py4vasp.Calculation.from_path(tmp_path).structure
+    sources = ["default", "final", "exciton", "poscar"]
+    assert structure.is_available(sources) == {
+        "default": False,  # no intermediate/ion_dynamics data in this file
+        "final": False,
+        "exciton": False,
+        "poscar": False,
+    }
+    # the data of the unselectable sources is present -- the database collection that
+    # accesses the sources internally still picks it up
+    assert set(structure._to_database()["structure"]) == {"final"}
+
+
 def test_wyckoff_positions(perovskite):
     pytest.importorskip("spglib")
     from py4vasp._calculation.structure import Wyckoff


### PR DESCRIPTION
Several methods are currently wrongly reported as available or unavailable. This PR aims to address these issues.

**probably needs discussion**:
- dispatch now throws an error if selection is invalid (rather than falling back to default selection)
- vaspwave.h5 demo now gets version so that we can check it correctly

**relatively straightforward fixes on a quantity basis**:
- projectors property is now Optional for Band and Dos
- structure.is_available now skips reporting availability on non-selectable selections (exciton, poscar, final are all unreachable via selections variable)
- add a density test for density["tau"] producing data as expected
- fix current_density to accurately report availability on a per-method basis