### PR TITLE
Fix AttributeError with IPython >= 9.17

### DIFF
--- a/src/py4vasp/_third_party/interactive.py
+++ b/src/py4vasp/_third_party/interactive.py
@@ -9,6 +9,9 @@ from py4vasp import exception
 from py4vasp._util import import_
 
 IPython = import_.optional("IPython")
+# IPython does not import its submodules eagerly, so request them explicitly
+# instead of relying on them being present as attributes of the package.
+ultratb = import_.optional("IPython.core.ultratb")
 _ERROR_VERBOSITY = "not set"
 _ALLOWED_VERBOSITIES = ["Inherit", "Plain", "Minimal"]
 
@@ -59,9 +62,7 @@ def handle_exception(exception):
 def _handle_exception(shell, etype, evalue, tb, tb_offset=0):
     if shell is not None:
         tb_offset = tb_offset or shell.InteractiveTB.tb_offset
-    traceback_formatter = IPython.core.ultratb.FormattedTB(
-        _ERROR_VERBOSITY, tb_offset=tb_offset
-    )
+    traceback_formatter = ultratb.FormattedTB(_ERROR_VERBOSITY, tb_offset=tb_offset)
     frames = traceback.extract_tb(tb, limit=None)
     frames_outside_py4vasp = list(_keep_frames_outside_py4vasp(frames))
     traceback_formatter(etype, evalue, frames_outside_py4vasp)

--- a/tests/third_party/test_interactive.py
+++ b/tests/third_party/test_interactive.py
@@ -16,9 +16,11 @@ from py4vasp._calculation.dos import Dos
 def ipython():
     """Mock IPython for testing purposes."""
     pytest.importorskip("IPython")
-    import IPython
+    # IPython does not import its submodules eagerly, so import this one explicitly
+    # instead of reaching for it as an attribute of the package.
+    from IPython.terminal.interactiveshell import TerminalInteractiveShell
 
-    shell = IPython.terminal.interactiveshell.TerminalInteractiveShell()
+    shell = TerminalInteractiveShell()
     with patch("IPython.get_ipython", return_value=shell):
         yield shell
 


### PR DESCRIPTION
IPython 9.17 stopped eagerly importing its submodules in IPython/__init__.py and added a module-level __getattr__ that raises AttributeError for names like IPython.terminal. CI jobs that resolve dependencies freshly instead of using uv.lock therefore failed with

    AttributeError: module 'IPython' has no attribute 'terminal'

Import the required submodules explicitly instead of reaching for them as attributes of the package: the test fixture imports TerminalInteractiveShell from IPython.terminal.interactiveshell, and interactive.py obtains IPython.core.ultratb through its own lazy import_.optional proxy. The latter only worked so far because IPython.core.interactiveshell pulls in ultratb transitively, which IPython's deprecation warning explicitly advises against relying on.

The proxy stays lazy, so importing py4vasp still leaves IPython out of sys.modules.