### PR TITLE
Fix/test minimal lowest direct

### DIFF
--- a/.github/workflows/test_minimal.yml
+++ b/.github/workflows/test_minimal.yml
@@ -25,6 +25,12 @@ jobs:
   test-minimal:
     runs-on: ubuntu-latest
 
+    # Set for the whole job, not just `uv lock`: `uv sync` and `uv run` re-resolve
+    # the lockfile as well, so a resolution passed only to `uv lock` gets discarded
+    # again before the tests ever run.
+    env:
+      UV_RESOLUTION: lowest-direct
+
     steps:
     - uses: actions/checkout@v5
     - name: Install uv and set the Python version
@@ -35,7 +41,7 @@ jobs:
       run: |
         uv --version
         python --version
-        uv lock --resolution lowest-direct
+        uv lock
         uv sync --no-group doc
         uv version
     - name: Test with pytest

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
     "numpy>=2.0",
-    "h5py>=3.9.0",
+    "h5py>=3.11.0",
 ]
 
 [project.urls]

--- a/core/uv.lock
+++ b/core/uv.lock
@@ -944,7 +944,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "h5py", specifier = ">=3.9.0" },
+    { name = "h5py", specifier = ">=3.11.0" },
     { name = "numpy", specifier = ">=2.0" },
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,16 +22,16 @@ readme = "README.md"
 license = "Apache-2.0"
 dependencies = [
     "numpy>=2.0",
-    "h5py>=3.9.0",
-    "pandas>=2.0",
+    "h5py>=3.11.0",
+    "pandas>=2.2.2",
     "nglview>=3.0.5",
     "ase>=3.23",
     "plotly>=5.23",
     "kaleido>=1.0",
     "ipython>=8.26",
-    "scipy>=1.12.0",
+    "scipy>=1.15.0",
     "click>=8.1.8",
-    "spglib>=2.1",
+    "spglib>=2.5",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2350,15 +2350,15 @@ doc = [
 requires-dist = [
     { name = "ase", specifier = ">=3.23" },
     { name = "click", specifier = ">=8.1.8" },
-    { name = "h5py", specifier = ">=3.9.0" },
+    { name = "h5py", specifier = ">=3.11.0" },
     { name = "ipython", specifier = ">=8.26" },
     { name = "kaleido", specifier = ">=1.0" },
     { name = "nglview", specifier = ">=3.0.5" },
     { name = "numpy", specifier = ">=2.0" },
-    { name = "pandas", specifier = ">=2.0" },
+    { name = "pandas", specifier = ">=2.2.2" },
     { name = "plotly", specifier = ">=5.23" },
-    { name = "scipy", specifier = ">=1.12.0" },
-    { name = "spglib", specifier = ">=2.1" },
+    { name = "scipy", specifier = ">=1.15.0" },
+    { name = "spglib", specifier = ">=2.5" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
CI: make test-minimal actually test the lowest versions

## Summary

`test-minimal` passed `--resolution lowest-direct` to `uv lock` only, but the
following `uv sync` (and `uv run`) re-resolve the lockfile as well, so the pins
were discarded before the tests ever ran:

    after lock: ipython 8.26.0
    after sync: ipython 9.17.1

The job was therefore testing the *newest* versions, and the declared lower
bounds were never guarded — which is why an IPython 9.17 regression showed up
there at all (#317). Setting `UV_RESOLUTION` for the whole job makes every uv
invocation agree.

With the job actually doing its stated job, four bounds turn out to be too low
next to `numpy>=2.0`. Each is raised to the first version that works, and I
checked that one notch below still fails:

| dep | was | now | why |
|---|---|---|---|
| h5py | `>=3.9.0` | `>=3.11.0` | 3.9/3.10 are built against numpy 1.x → `numpy.dtype size changed` on import |
| pandas | `>=2.0` | `>=2.2.2` | same up to 2.1; 2.2.0 and 2.2.1 declare `numpy<2` |
| scipy | `>=1.12.0` | `>=1.15.0` | `interpolate.AAA`, used by `_third_party.numeric`, was added in 1.15 |
| spglib | `>=2.1` | `>=2.5` | `get_symmetry_dataset` returns a plain `dict` before 2.5, while `_calculation.structure` and `_calculation.symmetry` access it by attribute |

`core/pyproject.toml` carried the same `h5py>=3.9.0` next to `numpy>=2.0`, so it
is raised too. There is no `test-minimal` job for core, so nothing in CI would
have caught it.

Both lock files are updated because they record the specifiers in
`requires-dist`; no resolved version changes. I edited just those lines rather
than running `uv lock`, which with my older local uv would have re-added 41
lines of dependency markers that #316 removed.

## Testing

- Fixed job end-to-end: numpy 2.0.0, h5py 3.11.0, pandas 2.2.2, scipy 1.15.0,
  spglib 2.5.0, ipython 8.26.0 → 3248 passed, 90 skipped, 2 xfailed
- `test-core` scenario (`cp core/* .` + `uv sync --locked --all-extras --dev`)
  → 2926 passed, 310 skipped
- Root `uv sync --locked` succeeds, so `test-full` / `install` see no stale lock