### PR TITLE
Chore: Split the TDD skill into a planning and an execution skill

### DIFF
--- a/.claude/skills/plan-py4vasp/SKILL.md
+++ b/.claude/skills/plan-py4vasp/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: plan-py4vasp
+description: >-
+  Plan a py4vasp change as an ordered list of test-first chunks — that chunk
+  list *is* the plan. Use it BEFORE writing any implementation plan for
+  py4vasp: a new feature, quantity, class or method, a refactor, or a bug fix —
+  and equally when the user only asks design questions ("are there other things
+  to consider?", "how would you implement X?", "what would it take to add X?"),
+  because the answer still has to land as a plan. Correct to use in plan mode:
+  it only reads code and writes the plan, it never edits source and never
+  commits. Each chunk is one method or behavior with its tests named up front;
+  carrying out a chunk is then handed to the tdd-py4vasp skill, one chunk at a
+  time.
+---
+
+# Planning a py4vasp change
+
+A py4vasp plan is **an ordered list of chunks** — not a description of the
+finished code with the tests bolted on at the end. A **chunk** is normally
+**one method of one class** (or one narrow behavior): small enough that its
+tests, its implementation and its commit stay reviewable together.
+
+This skill produces that list and **stops**. Each chunk is then carried out by
+the **tdd-py4vasp** skill (RED → GREEN → refactor → commit), one at a time.
+
+All paths below are relative to the repo/worktree root.
+
+## 1. Read before you plan
+
+Never plan from the request alone. Establish four things first:
+
+- **Does it exist already?** Grep for the method/quantity name across
+  `src/py4vasp` and `tests`. Partial implementations and near-duplicates are
+  common and change the chunking completely.
+- **The sibling to copy.** Find the closest existing quantity or method and
+  read *both* its implementation and its test.
+  `src/py4vasp/_calculation/symmetry.py` + `tests/calculation/test_symmetry.py`
+  is a good default pair.
+- **The seams.** How does data actually reach the class — `raw.access`,
+  a `FileSource`, a dispatcher, `@quantity` injection? Name the exact file and
+  line the new code hangs off.
+- **What the request leaves open.** Collect the genuine design questions and
+  put your recommended default next to each, so the user can answer with
+  "defaults, except 3".
+
+## 2. Cut the work into chunks
+
+- One method or one narrow behavior each. If a chunk needs the word "and" to
+  describe it, split it.
+- Each chunk must be **independently committable and revertible** — green
+  suite at every chunk boundary.
+- **Order pure logic before wiring.** Chunks that touch only a helper module
+  are testable without any public API change; put them first so feedback is
+  fast and early commits are safe.
+- Error and edge-case behavior is its own chunk when the errors carry real
+  logic (ambiguity, validation, rejection), not an afterthought inside another
+  chunk.
+- The docstring + runnable doctest is part of the chunk that adds the public
+  method, never a separate "docs at the end" chunk.
+- Aim for 3–7 chunks. More than that and the request probably needs splitting
+  into two rounds; fewer than two and you likely do not need a plan at all —
+  go straight to **tdd-py4vasp**.
+
+## 3. Write each chunk in this shape
+
+Numbered, and for every chunk state all four:
+
+```
+N. <behavior, one line>
+   Test:  tests/<path>::<test name(s)>  — what the assertion actually checks
+   Code:  src/py4vasp/<path>  — the method/class added or changed
+   Also:  any second place that must change for the test to be writable
+```
+
+That `Also:` line is where py4vasp plans usually go wrong — see the facts
+below. If a chunk has no `Test:` line you have not finished planning it.
+
+## 4. The shape to avoid
+
+Do **not** produce a plan that describes the implementation in full and then
+carries a trailing `## Tests` section listing the test files to add. That is an
+implement-then-test plan; it reads fine and it silently discards TDD, because
+by the time anyone reaches the test section the code is already written. The
+tests belong *inside* each chunk, named before its implementation.
+
+Equally: no chunk whose description is "write the tests" or "add test
+coverage". Coverage is a property of every chunk, not a phase.
+
+## 5. Present the plan, then stop
+
+Put the chunk list in the todo list, present it, and **wait for sign-off before
+any code is written.**
+
+If **plan mode** is active, this chunk list *is* the plan you hand to
+`ExitPlanMode` — ordered chunks with tests named, plus the design decisions and
+open questions. Approval of the plan is the sign-off. Do not describe the
+tdd-py4vasp loop as a final step of the plan; it is how each chunk gets done.
+
+## 6. Hand the chunks over
+
+Once approved, execute **one chunk at a time** with the **tdd-py4vasp** skill,
+starting at chunk 1 and returning to it for each subsequent chunk. Do not batch
+several chunks into one pass, and do not run the full suite between chunks —
+that happens once, after the last chunk lands.
+
+## Planning-time py4vasp facts that change the plan
+
+These are the ones that alter the chunk list, so check them while planning
+rather than discovering them mid-implementation:
+
+- **A new raw quantity costs two extra places.** Besides the calculation class
+  you must add a producer under `src/py4vasp/_demo/` and register a method on
+  `RawDataFactory` in `tests/conftest.py`, or `raw_data.<quantity>()` does not
+  exist and the chunk's test cannot even be written. That belongs on the
+  chunk's `Also:` line.
+- **Construction and fixtures.** Calculation classes are built with
+  `SomeClass.from_data(raw_data.<quantity>("Sr2TiO4"))`. `tests/conftest.py`
+  supplies `raw_data`, `Assert` (`Assert.allclose` for arrays/dataclasses),
+  `format_` and `check_factory_methods`.
+- **The standard method set.** A new quantity is expected to bring `read`/
+  `to_dict` (plus `test_to_dict_is_alias_of_read`), `print`/`_repr_`, and
+  `test_factory_methods(raw_data, check_factory_methods)`. Plan a chunk for
+  each rather than one "add the quantity" chunk.
+- **Public methods need a numpy-style docstring with a runnable doctest.**
+  `tests/test_doctest.py` collects and *executes* docstring examples from
+  `_calculation`, injecting `path` and `py4vasp` as globals — so the example
+  must be able to build its own data. A doctest that cannot run is a failing
+  test, not a comment.
+- **Exceptions come from `py4vasp.exception`**, and user-facing selections go
+  through `select.Tree` / `index.Selector`. Decide which exception type each
+  error chunk raises while planning; `review-py4vasp` enforces this later.
+- **Optional dependencies** get guarded with `pytest.importorskip("spglib")`
+  in the test, as existing tests do. Note it on the chunk.
+- **Docs.** New public methods usually need adding to the relevant file under
+  `docs/`; fold it into the chunk that introduces the method.
+
+## Out of scope for this skill
+
+No edits to `src/` or `tests/`, no commits, no running the test suite. The
+verification commands belong *in* the plan as text, to be run by tdd-py4vasp
+when the chunk is executed. If you find yourself wanting to write code to
+answer a design question, write a throwaway probe in the scratchpad instead and
+say so in the plan.
+
+## Human path
+
+There is no app to launch — this is a workflow skill. The plan is a message (or
+a plan file); nothing is installed or run to produce it.

--- a/.claude/skills/plan-py4vasp/SKILL.md
+++ b/.claude/skills/plan-py4vasp/SKILL.md
@@ -3,10 +3,13 @@ name: plan-py4vasp
 description: >-
   Plan a py4vasp change as an ordered list of test-first chunks — that chunk
   list *is* the plan. Use it BEFORE writing any implementation plan for
-  py4vasp: a new feature, quantity, class or method, a refactor, or a bug fix —
-  and equally when the user only asks design questions ("are there other things
-  to consider?", "how would you implement X?", "what would it take to add X?"),
-  because the answer still has to land as a plan. Correct to use in plan mode:
+  py4vasp: a new feature, quantity, class or method, a refactor, or a bug fix.
+  Load it as soon as a py4vasp code change is under discussion — before
+  answering, not after — including when the user only asks design questions
+  ("are there other things to consider?", "how would you implement X?", "what
+  would it take to add X?"). Answering those IS the first half of planning, and
+  the answer has to close with the chunk list or with what must be settled
+  before the work can be chunked. Correct to use in plan mode:
   it only reads code and writes the plan, it never edits source and never
   commits. Each chunk is one method or behavior with its tests named up front;
   carrying out a chunk is then handed to the tdd-py4vasp skill, one chunk at a
@@ -42,6 +45,23 @@ Never plan from the request alone. Establish four things first:
 - **What the request leaves open.** Collect the genuine design questions and
   put your recommended default next to each, so the user can answer with
   "defaults, except 3".
+
+## Questions are half of planning
+
+A request phrased as a question — "are there other things to consider?", "what
+would it take?", "query me on the open questions" — is still a planning turn.
+Answer the questions, with your recommended default beside each, and then
+**close with the chunking anyway**:
+
+- If the open questions do not change the shape of the work, give the chunk
+  list outright and mark which chunks the answers would affect.
+- If they *do* change the shape (they decide whether a helper module exists at
+  all, say), give the chunk list for the part that is already settled and name
+  the specific answers you need before the rest can be chunked.
+
+What you must not do is answer the questions and stop there. That is how a
+change ends up planned implementation-first later, in a turn where nobody
+remembers to chunk it.
 
 ## 2. Cut the work into chunks
 

--- a/.claude/skills/tdd-py4vasp/SKILL.md
+++ b/.claude/skills/tdd-py4vasp/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: tdd-py4vasp
 description: >-
-  Test-driven development workflow for py4vasp. Use when adding or changing a
-  feature, quantity, class, or method in py4vasp and you want tests written
-  first. Triggers: "TDD", "test-driven", "write the tests first", "add a method
-  with tests", "implement <quantity>", "red-green-refactor". Splits work into
-  one-method chunks, watches each test fail, implements to green, refactors,
-  and commits one chunk at a time.
+  The default development workflow for any code change in py4vasp — adding or
+  changing a feature, quantity, class, method, or fixing a bug. Use it by
+  default, not only when tests or "TDD" are mentioned: unless the user says
+  otherwise, py4vasp changes are developed test-first. Load it BEFORE designing
+  or writing an implementation plan as well — the ordered, one-method-per-chunk
+  breakdown it prescribes *is* the plan, so a plan drafted without it comes out
+  in the wrong shape. Explicit triggers: "TDD", "test-driven", "write the tests
+  first", "red-green-refactor", "implement <quantity>", "add a method", "plan
+  the implementation of <feature>". Each chunk runs RED (watch the test fail) →
+  GREEN → refactor → one local commit.
 ---
 
 # Test-driven development for py4vasp
@@ -26,6 +30,9 @@ below are relative to the repo/worktree root.
 Break the request into an ordered list of chunks, each ≈ one method/behavior.
 Record it in the todo list, present it to the user, and **wait for their
 sign-off before writing any code.** Do not start chunk 1 until they approve.
+If **plan mode** is active, this chunk list *is* the plan: the plan you hand to
+`ExitPlanMode` must be the ordered chunks with the test(s) named for each one,
+not an implement-then-test outline. Approving the plan is the sign-off.
 Keep chunks small — one method/behavior each, so every commit stays reviewable.
 
 Then, for **each** chunk in turn:

--- a/.claude/skills/tdd-py4vasp/SKILL.md
+++ b/.claude/skills/tdd-py4vasp/SKILL.md
@@ -1,43 +1,51 @@
 ---
 name: tdd-py4vasp
 description: >-
-  The default development workflow for any code change in py4vasp — adding or
-  changing a feature, quantity, class, method, or fixing a bug. Use it by
-  default, not only when tests or "TDD" are mentioned: unless the user says
-  otherwise, py4vasp changes are developed test-first. Load it BEFORE designing
-  or writing an implementation plan as well — the ordered, one-method-per-chunk
-  breakdown it prescribes *is* the plan, so a plan drafted without it comes out
-  in the wrong shape. Explicit triggers: "TDD", "test-driven", "write the tests
-  first", "red-green-refactor", "implement <quantity>", "add a method", "plan
-  the implementation of <feature>". Each chunk runs RED (watch the test fail) →
-  GREEN → refactor → one local commit.
+  Carry out ONE chunk of a py4vasp change test-first: RED (watch the test fail
+  for the right reason) → GREEN → refactor → one local commit. Use it for each
+  chunk of an approved chunk list, and for any change small enough to be a
+  single chunk on its own — one method, one narrow behavior, a focused bug fix.
+  If the work turns out bigger than one method or behavior, or there is no chunk
+  list yet, it stops and chunks the work with the plan-py4vasp skill first
+  rather than coding ahead. Triggers: "TDD", "test-driven", "write the tests
+  first", "red-green-refactor", "next chunk", "chunk N", "add a method to
+  <class>", "fix <bug>".
 ---
 
-# Test-driven development for py4vasp
+# Test-driven development for py4vasp — one chunk
 
-Build py4vasp features test-first, one small chunk at a time. A **chunk** is
-normally **one method of one class** (or one narrow behavior). You write its
-tests, watch them fail for the right reason, implement until they pass, refactor
-away duplication, and commit — then and only then move to the next chunk.
+Carry **one chunk** from failing test to commit. A **chunk** is normally **one
+method of one class** (or one narrow behavior): you write its tests, watch them
+fail for the right reason, implement until they pass, refactor away
+duplication, and commit. Then you stop — the next chunk is a fresh pass.
 
 Tests are run with the wrapper `.claude/skills/tdd-py4vasp/run_tests.py`, which
 imports py4vasp from *this* checkout's `src` (see [Gotchas](#gotchas)). All paths
 below are relative to the repo/worktree root.
 
-## The loop (follow in order)
+## 0. Scope check — what is this chunk? (do this first)
 
-### 0. Plan, then STOP for approval
-Break the request into an ordered list of chunks, each ≈ one method/behavior.
-Record it in the todo list, present it to the user, and **wait for their
-sign-off before writing any code.** Do not start chunk 1 until they approve.
-If **plan mode** is active, this chunk list *is* the plan: the plan you hand to
-`ExitPlanMode` must be the ordered chunks with the test(s) named for each one,
-not an implement-then-test outline. Approving the plan is the sign-off.
-Keep chunks small — one method/behavior each, so every commit stays reviewable.
+Decide which of three situations you are in **before writing anything**:
 
-Then, for **each** chunk in turn:
+- **An approved chunk list exists.** Take the next unstarted chunk and only
+  that one. Its test names are already written down; honor them.
+- **The request is itself one chunk** — one method, one narrow behavior, a
+  focused bug fix with a single reproducing test. Treat the request as chunk 1
+  of 1 and continue to step 1.
+- **The work is bigger than one chunk** — several methods, a new quantity
+  end-to-end, more than one class, error handling with real logic of its own,
+  or you cannot name the chunk's test in one line. **Stop. Do not start
+  coding.** Chunk the work with the **plan-py4vasp** skill, get the chunk list
+  signed off, then come back here for chunk 1.
 
-### 1. RED — write the test(s) and watch them fail
+That last branch is the fallback that matters: a chunk you cannot describe in
+one sentence is a plan you have not written yet. Reaching for it is cheap;
+discovering it four files into an implementation is not.
+
+Then, for the chunk you settled on:
+
+## 1. RED — write the test(s) and watch them fail
+
 Write the test(s) for this chunk only, following the conventions below. Run
 just those tests and confirm they **fail for the right reason** — a real
 `AssertionError` or the missing-method `AttributeError`, *not* a typo, bad
@@ -52,21 +60,25 @@ Run only the tests you expect to fail. If your change may have side effects
 elsewhere, add those specific untouched tests to the same run to watch them
 stay green — but do **not** run the full suite here.
 
-### 2. GREEN — implement the minimum to pass
+## 2. GREEN — implement the minimum to pass
+
 Write the simplest implementation that makes the RED tests pass. Re-run the same
-selection until green.
+selection until green. Resist implementing the *next* chunk's behavior because
+it is obvious and nearby — it will arrive without a failing test to justify it.
 
 ```bash
 python .claude/skills/tdd-py4vasp/run_tests.py tests/calculation/test_symmetry.py -q
 ```
 
-### 3. REFACTOR — remove duplication (code AND tests)
+## 3. REFACTOR — remove duplication (code AND tests)
+
 With tests green, remove duplication introduced by this chunk **and** against
 existing code the new code now overlaps with. Apply the same to the tests: pull
 shared setup into fixtures and use `@pytest.mark.parametrize` — this codebase is
 fixture-heavy, mirror it. Re-run the chunk's tests to confirm still green.
 
-### 4. COMMIT — one commit per passing chunk
+## 4. COMMIT — one commit for this chunk
+
 Commit the tests + implementation + refactor together, locally, on the current
 branch. Match the repo's message style (`Feat:`, `Fix:`, `Refactor:` prefix):
 
@@ -74,15 +86,18 @@ branch. Match the repo's message style (`Feat:`, `Fix:`, `Refactor:` prefix):
 git add -A && git commit -m "Feat: add Symmetry.multiplicity"
 ```
 
-Do **not** push or open a PR — that is a separate, later step. For a multi-line
-message use `git commit -F <file>` or a heredoc, never `git commit -m @'...'@`
-in the Bash tool (it wraps the message in literal `@`).
+Do **not** push or open a PR — that is a separate, later step
+(`push-py4vasp`). For a multi-line message use `git commit -F <file>` or a
+heredoc, never `git commit -m @'...'@` in the Bash tool (it wraps the message
+in literal `@`).
 
-Only after the commit lands do you start the next chunk at step 1.
+## 5. Stop, and report where the chunk list stands
 
-### 5. After ALL chunks — full suite, then report
-When every chunk is committed, run the whole suite once. Only report the work as
-done to the user if it is green.
+After the commit lands, say which chunk is done and what the next one is. Start
+the next chunk as a fresh pass through this skill — do not roll straight on.
+
+**Only after the last chunk of the list** run the whole suite once, and only
+report the work as done to the user if it is green:
 
 ```bash
 python .claude/skills/tdd-py4vasp/run_tests.py -q
@@ -107,6 +122,11 @@ is a good template. Key patterns:
   calculation class: add a producer under `src/py4vasp/_demo/` and register a
   method on `RawDataFactory` in `tests/conftest.py`, so `raw_data.<quantity>()`
   exists for your test.
+- **Public methods** get a numpy-style docstring with a **runnable** doctest —
+  `tests/test_doctest.py` executes examples from `_calculation` with `path` and
+  `py4vasp` injected as globals, so the example must build its own data.
+- **Exceptions** come from `py4vasp.exception`; user selections go through
+  `select.Tree` / `index.Selector`.
 - **Optional deps:** guard tests needing extras with
   `pytest.importorskip("spglib")` as existing tests do.
 
@@ -122,9 +142,12 @@ is a good template. Key patterns:
   python -c "import py4vasp; print(py4vasp.__file__)"
   ```
 - **Don't run the full suite mid-loop.** It is slow and dilutes the RED signal.
-  Full suite runs once, at the end (step 5).
+  Full suite runs once, after the final chunk (step 5).
 - **A weak RED is a bug.** If the test passes on the first run, or errors before
   its assertion, it isn't testing what you think — fix the test before implementing.
+- **Scope creep is the common failure.** Finishing two chunks in one commit
+  looks efficient and costs you the ability to revert either. One chunk, one
+  commit.
 
 ## Human path
 

--- a/.claude/skills/tdd-py4vasp/SKILL.md
+++ b/.claude/skills/tdd-py4vasp/SKILL.md
@@ -42,6 +42,13 @@ That last branch is the fallback that matters: a chunk you cannot describe in
 one sentence is a plan you have not written yet. Reaching for it is cheap;
 discovering it four files into an implementation is not.
 
+Take it **even when you could plausibly implement the whole thing in one
+pass** — the value of the chunk list is that the user sees the shape of the
+work while changing it is still free. If you genuinely cannot pause for
+sign-off (a non-interactive or delegated run), you still produce the chunk list
+first and state it up front, then work it one chunk at a time with a commit
+each — never a single sweeping commit.
+
 Then, for the chunk you settled on:
 
 ## 1. RED — write the test(s) and watch them fail


### PR DESCRIPTION
## Summary

`tdd-py4vasp` was rarely picked up on its own: across the sessions where it was
in context it fired autonomously once, and every other time it took an explicit
`/tdd-py4vasp` or "use tdd". Two causes, confirmed by replaying prompts against
subagents:

- **Plan mode.** Its reminder says the model must not edit or commit and that this
  "supercedes any other instructions". The old description advertised itself as
  edits + commits, so in a planning turn the skill read as forbidden — even though
  its step 0 was exactly the chunk breakdown that turn needed. The `from_archive`
  plan came out implement-first with a trailing `## Tests` section as a result.
- **Opt-in wording.** "Use when ... *and you want tests written first*" made it
  contingent. Given a feature request, a subagent read the skill, judged it
  applicable, and asked permission instead of using it.

## What changed

**`plan-py4vasp`** (new, read-only) owns the planning half: read before planning,
cut into chunks, write each as `Test:` / `Code:` / `Also:`, and hand chunks to
`tdd-py4vasp` one at a time. Being read-only is the load-bearing part — it no
longer looks forbidden in plan mode, where the chunk list *is* the plan given to
`ExitPlanMode`. It names the shape to avoid explicitly, and carries the
planning-time facts that change the chunk list (a new raw quantity also needs a
`_demo` producer and a `RawDataFactory` method, runnable doctests, exceptions from
`py4vasp.exception`).

**`tdd-py4vasp`** now carries out one chunk, and opens with a scope check that
branches three ways: next chunk off an approved list; a genuinely single-method
request as chunk 1 of 1; or stop and chunk it with `plan-py4vasp` when the work is
bigger than one behavior.

## Validation

Four prompt framings, each replayed to a subagent in its own worktree:

| Prompt | Result |
|---|---|
| Design questions ("are there other things to consider?") | answers the questions *and* closes with a chunk list, tagging which chunks each answer would change |
| "Create an implementation plan for..." | 6 chunks, tests named per chunk, no trailing `## Tests`, hands chunk 1 over |
| "Add a method `number_operations`..." | chunk 1 of 1, genuine `AttributeError` RED, one commit, no planning detour |
| "Implement a `from_archive` constructor..." | chunked and test-first, but did not pause for sign-off |

The first case failed on the first attempt and drove the third commit here. The
last case stays partly unresolved: a subagent has no user to ask and is told to
finish, so it cannot cleanly demonstrate the stop-for-sign-off branch.