### PR TITLE
Fix/restore print on quantity classes

### DIFF
--- a/docs/architecture/calculation.rst
+++ b/docs/architecture/calculation.rst
@@ -338,8 +338,75 @@ Parses multi-selection         (done by ``_parse_selections``)
 Opens data (context manager)   (done by ``_dispatch``)
 Constructs Handler from raw    (done by ``_dispatch``)
 Transform logic                                              ✓
+Formats the text output                                      ✓ (``__str__``)
+Exposes the text output        ✓ (``__str__``, ``print``,
+                               ``_repr_pretty_``)
+Reports its sources            ✓ (``selections``)
 Testable without I/O                                         ✓ (via ``from_data``)
 =============================  ============================  ==========================
+
+
+The mandatory public surface
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The old ``base.Refinery`` gave every quantity ``print``, ``selections``,
+``_repr_pretty_`` and a ``path`` property by inheritance. With composition there
+is no base class, so **each dispatcher has to declare them itself** — only
+``from_path``, ``from_file``, ``__repr__``, ``path``, ``_path`` and
+``is_available`` are injected by the ``@quantity`` decorator.
+
+A dispatcher must therefore define all of the following, and
+``tests/calculation/test_print.py`` fails for a quantity that forgets one:
+
+.. code-block:: python
+
+   @quantity("band")
+   class Band:
+       def read(self, selection=None) -> dict: ...
+       def to_dict(self, selection=None) -> dict: ...
+
+       def __str__(self, selection=None) -> str:
+           # the handler formats the text, the dispatcher merges it across sources
+           return merge_strings(
+               self._source, self._quantity_name, selection,
+               self._handler_factory, BandHandler.__str__,
+           )
+
+       def print(self, selection: str | None = None) -> None:
+           """Print a string representation of this quantity.
+
+           Parameters
+           ----------
+           selection : str | None
+               Select which source of the quantity is printed. If you select
+               multiple sources, py4vasp prints one block per source.
+           """
+           print(self.__str__(selection))
+
+       def _repr_pretty_(self, p, cycle):
+           p.text(str(self) if not cycle else "...")
+
+       def selections(self):
+           from py4vasp._raw import definition as raw_module
+
+           return {
+               self._quantity_name: list(raw_module.selections(self._quantity_name))
+           }
+
+Two things are easy to get wrong here:
+
+* ``__str__`` takes an optional ``selection`` even though dunders normally do
+  not, because ``print`` forwards its own selection to it.
+* ``_repr_pretty_`` belongs on the **dispatcher**, not only on the handler. A
+  test that builds the handler with ``BandHandler.from_data`` and checks
+  ``format_(handler)`` passes while the public class has no Jupyter
+  representation at all. Assert on the dispatcher.
+
+Because ``selections`` only reads the schema and never opens the data file, it
+does not satisfy the one-access-per-method contract that
+``check_factory_methods`` verifies; pass ``skip_methods=["selections"]`` in the
+quantity's ``test_factory_methods`` unless the quantity's ``selections``
+genuinely reads data (as ``Dos`` and ``Band`` do).
 
 
 Step Indexing

--- a/docs/architecture/calculation.rst
+++ b/docs/architecture/calculation.rst
@@ -384,7 +384,7 @@ A dispatcher must therefore define all of the following, and
            print(self.__str__(selection))
 
        def _repr_pretty_(self, p, cycle):
-           p.text(str(self) if not cycle else "...")
+           p.text(str(self))
 
        def selections(self):
            from py4vasp._raw import definition as raw_module
@@ -402,11 +402,31 @@ Two things are easy to get wrong here:
   ``format_(handler)`` passes while the public class has no Jupyter
   representation at all. Assert on the dispatcher.
 
-Because ``selections`` only reads the schema and never opens the data file, it
-does not satisfy the one-access-per-method contract that
-``check_factory_methods`` verifies; pass ``skip_methods=["selections"]`` in the
-quantity's ``test_factory_methods`` unless the quantity's ``selections``
-genuinely reads data (as ``Dos`` and ``Band`` do).
+A quantity whose ``selections`` also offers choices of its own (atoms, orbitals,
+components, ...) lets its handler report those and merges the schema sources over
+them, as ``Band``, ``Dos``, ``Energy`` and ``LocalMoment`` do:
+
+.. code-block:: python
+
+   def selections(self, selection=None) -> dict:
+       from py4vasp._raw import definition as raw_module
+
+       handler_selections = merge_default(
+           self._source, self._quantity_name, selection,
+           self._handler_factory, BandHandler.selections,
+       )
+       sources = list(raw_module.selections(self._quantity_name))
+       return {self._quantity_name: sources, **handler_selections}
+
+Dropping that source entry is easy to miss, because the quantity keeps returning
+a plausible-looking dictionary of its other choices. ``NeighborList`` is the one
+deliberate exception to the ``{quantity: sources}`` shape: it reports a flat list
+of the atom-type pairs that partition its neighbor table.
+
+Because a schema-only ``selections`` never opens the data file, it does not
+satisfy the one-access-per-method contract that ``check_factory_methods``
+verifies; pass ``skip_methods=["selections"]`` in the quantity's
+``test_factory_methods`` unless its ``selections`` genuinely reads data.
 
 
 Step Indexing

--- a/src/py4vasp/_calculation/_CONTCAR.py
+++ b/src/py4vasp/_calculation/_CONTCAR.py
@@ -89,7 +89,7 @@ class CONTCAR(view.Mixin):
     CONTCAR might contain additional information about the system such as the ion
     and lattice velocities."""
 
-    def __init__(self, source, quantity_name="_CONTCAR"):
+    def __init__(self, source, quantity_name="CONTCAR"):
         self._source = source
         self._quantity_name = quantity_name
 
@@ -99,6 +99,22 @@ class CONTCAR(view.Mixin):
 
     def _handler_factory(self, raw):
         return CONTCARHandler.from_data(raw)
+
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
 
     def __str__(self, selection=None):
         return merge_strings(

--- a/src/py4vasp/_calculation/_CONTCAR.py
+++ b/src/py4vasp/_calculation/_CONTCAR.py
@@ -111,7 +111,19 @@ class CONTCAR(view.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/_dispersion.py
+++ b/src/py4vasp/_calculation/_dispersion.py
@@ -122,7 +122,19 @@ class Dispersion:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/_dispersion.py
+++ b/src/py4vasp/_calculation/_dispersion.py
@@ -111,6 +111,22 @@ class Dispersion:
     def _handler_factory(self, raw):
         return DispersionHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/_stoichiometry.py
+++ b/src/py4vasp/_calculation/_stoichiometry.py
@@ -192,6 +192,22 @@ class Stoichiometry:
     def _handler_factory(self, raw):
         return StoichiometryHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/_stoichiometry.py
+++ b/src/py4vasp/_calculation/_stoichiometry.py
@@ -203,7 +203,19 @@ class Stoichiometry:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/band.py
+++ b/src/py4vasp/_calculation/band.py
@@ -33,7 +33,6 @@ from py4vasp._util import (
 )
 
 pd = import_.optional("pandas")
-pretty = import_.optional("IPython.lib.pretty")
 
 _OCCUPATION_CUTOFF = 1e-2
 

--- a/src/py4vasp/_calculation/band.py
+++ b/src/py4vasp/_calculation/band.py
@@ -372,6 +372,17 @@ class Band(graph.Mixin):
             )
         return True
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/bandgap.py
+++ b/src/py4vasp/_calculation/bandgap.py
@@ -467,7 +467,19 @@ class Bandgap(graph.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/bandgap.py
+++ b/src/py4vasp/_calculation/bandgap.py
@@ -456,6 +456,22 @@ class Bandgap(graph.Mixin):
             BandgapHandler.to_graph,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection: str | None = None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/born_effective_charge.py
+++ b/src/py4vasp/_calculation/born_effective_charge.py
@@ -123,6 +123,25 @@ class BornEffectiveCharge:
         """Create a BornEffectiveCharge dispatcher from raw data."""
         return cls(source=DataSource(raw_born_effective_charge))
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self) if not cycle else "...")
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/born_effective_charge.py
+++ b/src/py4vasp/_calculation/born_effective_charge.py
@@ -134,13 +134,25 @@ class BornEffectiveCharge:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
 
     def _repr_pretty_(self, p, cycle):
-        p.text(str(self) if not cycle else "...")
+        p.text(str(self))
 
     def __str__(self, selection=None) -> str:
         return merge_strings(

--- a/src/py4vasp/_calculation/current_density.py
+++ b/src/py4vasp/_calculation/current_density.py
@@ -208,6 +208,22 @@ class CurrentDensity:
             return False
         return is_available_raw(self._quantity_name, raw_data, selection=selection)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/current_density.py
+++ b/src/py4vasp/_calculation/current_density.py
@@ -22,8 +22,6 @@ from py4vasp._third_party import graph
 from py4vasp._util import check, documentation, import_, slicing
 from py4vasp._util.density import SliceArguments, Visualizer
 
-pretty = import_.optional("IPython.lib.pretty")
-
 _COMMON_PARAMETERS = f"""selection : str | None = None
     Selects which of the possible available currents is used. Check the
     `selections` method for all available choices.
@@ -53,7 +51,7 @@ class CurrentDensityHandler:
         key = self._raw_current_density.valid_indices[-1]
         grid = self._raw_current_density[key].current_density.shape[1:]
         return f"""current density:
-    structure: {pretty.pretty(stoichiometry)}
+    structure: {stoichiometry}
     grid: {grid[2]}, {grid[1]}, {grid[0]}
     selections: {", ".join(str(index) for index in self._raw_current_density.valid_indices)}"""
 

--- a/src/py4vasp/_calculation/current_density.py
+++ b/src/py4vasp/_calculation/current_density.py
@@ -219,7 +219,19 @@ class CurrentDensity:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -22,8 +22,6 @@ from py4vasp._third_party import graph, view
 from py4vasp._util import check, documentation, import_, index, select, slicing
 from py4vasp._util.density import SliceArguments, Visualizer
 
-pretty = import_.optional("IPython.lib.pretty")
-
 _DEFAULT = 0
 _INTERNAL = "_density"
 _COMPONENTS = {
@@ -77,7 +75,7 @@ class DensityHandler:
         else:
             name = "Noncollinear"
         return f"""{name} density:
-    structure: {pretty.pretty(stoichiometry)}
+    structure: {stoichiometry}
     grid: {grid[2]}, {grid[1]}, {grid[0]}"""
 
     def to_dict(self) -> dict:

--- a/src/py4vasp/_calculation/density.py
+++ b/src/py4vasp/_calculation/density.py
@@ -385,6 +385,17 @@ class Density(view.Mixin):
             return len(raw_data.charge) in (2, 4)
         return True
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/dielectric_function.py
+++ b/src/py4vasp/_calculation/dielectric_function.py
@@ -338,6 +338,17 @@ class DielectricFunction(graph.Mixin):
             DielectricFunctionHandler.selections,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection: str | None = None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/dielectric_function.py
+++ b/src/py4vasp/_calculation/dielectric_function.py
@@ -279,11 +279,6 @@ class DielectricFunction(graph.Mixin):
         """Create a DielectricFunction dispatcher from raw data (convenience for testing)."""
         return cls(source=DataSource(raw_dielectric_function))
 
-    @property
-    def path(self):
-        """Returns the path from which the output is obtained."""
-        return self._path
-
     def _handler_factory(self, raw_data):
         return DielectricFunctionHandler.from_data(raw_data)
 

--- a/src/py4vasp/_calculation/dielectric_tensor.py
+++ b/src/py4vasp/_calculation/dielectric_tensor.py
@@ -225,7 +225,19 @@ class DielectricTensor:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/dielectric_tensor.py
+++ b/src/py4vasp/_calculation/dielectric_tensor.py
@@ -214,6 +214,22 @@ class DielectricTensor:
         """Convenient alias for :py:meth:`read`. Please read the documentation there."""
         return self.read()
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/dispatch.py
+++ b/src/py4vasp/_calculation/dispatch.py
@@ -80,6 +80,14 @@ def quantity(name, group=None):
         if not isinstance(getattr(cls, "_path", None), property):
             cls._path = property(lambda self: self._source.path or pathlib.Path.cwd())
 
+        # The public path is an alias of _path, which the graph and view mixins write
+        # their output to. Quantities defining their own path property keep it.
+        if not isinstance(getattr(cls, "path", None), property):
+            cls.path = property(
+                lambda self: self._path,
+                doc="Returns the path from which the output is obtained.",
+            )
+
         # Every quantity shares the public is_available (documented once); the
         # per-quantity logic lives in _is_available, which defaults to the mandatory
         # schema check and is overridden by the few quantities needing custom logic.

--- a/src/py4vasp/_calculation/dos.py
+++ b/src/py4vasp/_calculation/dos.py
@@ -22,7 +22,6 @@ from py4vasp._third_party import graph
 from py4vasp._util import check, documentation, import_
 
 pd = import_.optional("pandas")
-pretty = import_.optional("IPython.lib.pretty")
 
 _TO_DATABASE_SUPPRESSED_EXCEPTIONS = (
     exception.Py4VaspError,

--- a/src/py4vasp/_calculation/dos.py
+++ b/src/py4vasp/_calculation/dos.py
@@ -236,6 +236,17 @@ class Dos(graph.Mixin):
     def _handler_factory(self, raw):
         return DosHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/effective_coulomb.py
+++ b/src/py4vasp/_calculation/effective_coulomb.py
@@ -534,6 +534,17 @@ class EffectiveCoulomb(graph.Mixin):
         )
         return {"effective_coulomb": ["default"], **result}
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/effective_coulomb.py
+++ b/src/py4vasp/_calculation/effective_coulomb.py
@@ -406,11 +406,6 @@ class EffectiveCoulomb(graph.Mixin):
         """Create an EffectiveCoulomb dispatcher from raw data (convenience for testing)."""
         return cls(source=DataSource(raw_coulomb))
 
-    @property
-    def path(self):
-        """Returns the path from which the output is obtained."""
-        return self._path
-
     def _handler_factory(self, raw_data):
         return EffectiveCoulombHandler.from_data(raw_data)
 

--- a/src/py4vasp/_calculation/elastic_modulus.py
+++ b/src/py4vasp/_calculation/elastic_modulus.py
@@ -286,7 +286,19 @@ class ElasticModulus:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/elastic_modulus.py
+++ b/src/py4vasp/_calculation/elastic_modulus.py
@@ -275,6 +275,22 @@ class ElasticModulus:
         """Convenient alias for :py:meth:`read`."""
         return self.read()
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/electron_phonon_bandgap.py
+++ b/src/py4vasp/_calculation/electron_phonon_bandgap.py
@@ -177,13 +177,25 @@ class ElectronPhononBandgapHandler(abc.Sequence):
 
     def __getitem__(self, key):
         if 0 <= key < len(self):
-            mask = np.equal(self._raw_data.scattering_approximation, "SERTA")
+            mask = self._serta_mask()
             index_ = np.arange(len(mask))[mask][key]
             return BandgapInstance(self, index_)
         raise IndexError("Index out of range for electron phonon bandgap instance.")
 
     def __len__(self):
-        return sum(np.equal(self._raw_data.scattering_approximation, "SERTA"))
+        return int(np.count_nonzero(self._serta_mask()))
+
+    def _serta_mask(self):
+        """Mask selecting the instances computed in the SERTA approximation.
+
+        The approximations may be stored as bytes and an empty dataset has no dtype
+        that numpy can compare against a string, so convert to strings explicitly.
+        """
+        approximations = [
+            convert.text_to_string(approximation)
+            for approximation in self._raw_data.scattering_approximation
+        ]
+        return np.array(approximations, dtype=str) == "SERTA"
 
 
 @quantity("bandgap", group="electron_phonon")
@@ -214,6 +226,17 @@ class ElectronPhononBandgap(abc.Sequence):
 
     def _handler_factory(self, raw):
         return ElectronPhononBandgapHandler.from_data(raw)
+
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
 
     def __str__(self, selection=None):
         return merge_strings(

--- a/src/py4vasp/_calculation/electron_phonon_chemical_potential.py
+++ b/src/py4vasp/_calculation/electron_phonon_chemical_potential.py
@@ -132,6 +132,22 @@ class ElectronPhononChemicalPotential:
     def _handler_factory(self, raw):
         return ElectronPhononChemicalPotentialHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         """
         Return a formatted string representation of the electron-phonon chemical potential object.

--- a/src/py4vasp/_calculation/electron_phonon_chemical_potential.py
+++ b/src/py4vasp/_calculation/electron_phonon_chemical_potential.py
@@ -143,7 +143,19 @@ class ElectronPhononChemicalPotential:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/electron_phonon_self_energy.py
+++ b/src/py4vasp/_calculation/electron_phonon_self_energy.py
@@ -207,6 +207,17 @@ class ElectronPhononSelfEnergy(abc.Sequence):
     def _handler_factory(self, raw):
         return ElectronPhononSelfEnergyHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/electron_phonon_transport.py
+++ b/src/py4vasp/_calculation/electron_phonon_transport.py
@@ -422,6 +422,10 @@ class ElectronPhononTransportHandler(abc.Sequence):
 
     def _has_spin_data(self):
         """Check if any instance has spin-resolved data."""
+        if len(self) == 0:
+            # a calculation without transport data has no instance to inspect, and
+            # indexing the empty dataset would raise an IndexError
+            return False
         first_instance = TransportInstance(self, 0)
         return first_instance._has_spin()
 

--- a/src/py4vasp/_calculation/electron_phonon_transport.py
+++ b/src/py4vasp/_calculation/electron_phonon_transport.py
@@ -497,6 +497,17 @@ class ElectronPhononTransport(abc.Sequence, graph.Mixin):
     def _handler_factory(self, raw):
         return ElectronPhononTransportHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/electronic_minimization.py
+++ b/src/py4vasp/_calculation/electronic_minimization.py
@@ -436,6 +436,22 @@ class ElectronicMinimization(graph.Mixin):
             ElectronicMinimizationHandler.is_converged,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/electronic_minimization.py
+++ b/src/py4vasp/_calculation/electronic_minimization.py
@@ -447,7 +447,19 @@ class ElectronicMinimization(graph.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/energy.py
+++ b/src/py4vasp/_calculation/energy.py
@@ -161,7 +161,7 @@ class EnergyHandler:
 
     def selections(self) -> dict:
         components = list(self._init_selection_dict().keys())
-        return {"energy": [], "component": components}
+        return {"component": components}
 
     def to_database(self) -> dict:
         default_dict = self._default_dict_all()
@@ -418,13 +418,17 @@ class Energy(graph.Mixin):
         -
             Dictionary containing available selection options with their possible values.
         """
-        return merge_default(
+        from py4vasp._raw import definition as raw_module
+
+        handler_selections = merge_default(
             self._source,
             self._quantity_name,
             selection,
             self._handler_factory,
             EnergyHandler.selections,
         )
+        sources = list(raw_module.selections(self._quantity_name))
+        return {self._quantity_name: sources, **handler_selections}
 
     def print(self, selection: str | None = None) -> None:
         """Print a string representation of this quantity.

--- a/src/py4vasp/_calculation/energy.py
+++ b/src/py4vasp/_calculation/energy.py
@@ -426,6 +426,17 @@ class Energy(graph.Mixin):
             EnergyHandler.selections,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection: str | None = None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/exciton_density.py
+++ b/src/py4vasp/_calculation/exciton_density.py
@@ -148,6 +148,22 @@ class ExcitonDensity(view.Mixin):
     def _handler_factory(self, raw):
         return ExcitonDensityHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/exciton_density.py
+++ b/src/py4vasp/_calculation/exciton_density.py
@@ -159,7 +159,19 @@ class ExcitonDensity(view.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/exciton_eigenvector.py
+++ b/src/py4vasp/_calculation/exciton_eigenvector.py
@@ -107,7 +107,19 @@ class ExcitonEigenvector:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/exciton_eigenvector.py
+++ b/src/py4vasp/_calculation/exciton_eigenvector.py
@@ -96,6 +96,22 @@ class ExcitonEigenvector:
     def _handler_factory(self, raw):
         return ExcitonEigenvectorHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/force.py
+++ b/src/py4vasp/_calculation/force.py
@@ -209,7 +209,19 @@ class Force(view.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/force.py
+++ b/src/py4vasp/_calculation/force.py
@@ -198,6 +198,22 @@ class Force(view.Mixin):
     def _handler_factory(self, raw):
         return ForceHandler.from_data(raw, steps=self._steps)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         "Convert the forces to a format similar to the OUTCAR file."
         return merge_strings(

--- a/src/py4vasp/_calculation/force_constant.py
+++ b/src/py4vasp/_calculation/force_constant.py
@@ -153,6 +153,25 @@ class ForceConstant:
         """Create a ForceConstant dispatcher from raw data (convenience for testing)."""
         return cls(source=DataSource(raw_force_constant))
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self) if not cycle else "...")
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/force_constant.py
+++ b/src/py4vasp/_calculation/force_constant.py
@@ -164,13 +164,25 @@ class ForceConstant:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
 
     def _repr_pretty_(self, p, cycle):
-        p.text(str(self) if not cycle else "...")
+        p.text(str(self))
 
     def __str__(self, selection=None) -> str:
         return merge_strings(

--- a/src/py4vasp/_calculation/internal_strain.py
+++ b/src/py4vasp/_calculation/internal_strain.py
@@ -85,13 +85,25 @@ class InternalStrain:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
 
     def _repr_pretty_(self, p, cycle):
-        p.text(str(self) if not cycle else "...")
+        p.text(str(self))
 
     def __str__(self, selection=None) -> str:
         return merge_strings(

--- a/src/py4vasp/_calculation/internal_strain.py
+++ b/src/py4vasp/_calculation/internal_strain.py
@@ -74,6 +74,25 @@ class InternalStrain:
         """Create an InternalStrain dispatcher from raw data (convenience for testing)."""
         return cls(source=DataSource(raw_internal_strain))
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self) if not cycle else "...")
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/kpoint.py
+++ b/src/py4vasp/_calculation/kpoint.py
@@ -240,6 +240,17 @@ class Kpoint:
             enforce_optional=enforce_optional,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/kpoint.py
+++ b/src/py4vasp/_calculation/kpoint.py
@@ -534,7 +534,19 @@ class Kpoint:
             finish,
         )
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/local_moment.py
+++ b/src/py4vasp/_calculation/local_moment.py
@@ -349,6 +349,17 @@ class LocalMoment(view.Mixin):
             return raw_data.spin_moments.shape[1] != 1
         return True
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/local_moment.py
+++ b/src/py4vasp/_calculation/local_moment.py
@@ -745,13 +745,17 @@ class LocalMoment(view.Mixin):
         )
 
     def selections(self) -> dict:
-        return merge_default(
+        from py4vasp._raw import definition as raw_module
+
+        handler_selections = merge_default(
             self._source,
             self._quantity_name,
             None,
             self._handler_factory,
             LocalMomentHandler.selections,
         )
+        sources = list(raw_module.selections(self._quantity_name))
+        return {self._quantity_name: sources, **handler_selections}
 
     def number_steps(self) -> int:
         """Return the number of local moments in the trajectory."""

--- a/src/py4vasp/_calculation/neighbor_list.py
+++ b/src/py4vasp/_calculation/neighbor_list.py
@@ -401,6 +401,17 @@ class NeighborList:
             cutoff,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/nics.py
+++ b/src/py4vasp/_calculation/nics.py
@@ -289,6 +289,22 @@ class Nics(view.Mixin):
             return on_grid and has_grid
         return has_grid if on_grid else has_points
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/nics.py
+++ b/src/py4vasp/_calculation/nics.py
@@ -22,8 +22,6 @@ from py4vasp._raw.models import NicsModel
 from py4vasp._third_party import graph, view
 from py4vasp._util import check, documentation, import_, index, select, slicing
 
-pretty = import_.optional("IPython.lib.pretty")
-
 _DEFAULT_SELECTION: str = "isotropic"
 
 
@@ -46,7 +44,7 @@ class NicsHandler:
             data_string = self._points_to_string()
         return f"""\
 nucleus-independent chemical shift:
-    structure: {pretty.pretty(stoichiometry)}
+    structure: {stoichiometry}
 {data_string}"""
 
     def to_dict(self) -> dict:

--- a/src/py4vasp/_calculation/nics.py
+++ b/src/py4vasp/_calculation/nics.py
@@ -300,7 +300,19 @@ class Nics(view.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/optics.py
+++ b/src/py4vasp/_calculation/optics.py
@@ -560,6 +560,17 @@ class Optics(graph.Mixin):
             OpticsHandler.selections,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection: str | None = None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/optics.py
+++ b/src/py4vasp/_calculation/optics.py
@@ -328,11 +328,6 @@ class Optics(graph.Mixin):
         """Create an Optics dispatcher from raw data (convenience for testing)."""
         return cls(source=DataSource(raw_dielectric_function))
 
-    @property
-    def path(self):
-        """Returns the path from which the output is obtained."""
-        return self._path
-
     def _handler_factory(self, raw_data):
         return OpticsHandler.from_data(raw_data)
 

--- a/src/py4vasp/_calculation/pair_correlation.py
+++ b/src/py4vasp/_calculation/pair_correlation.py
@@ -267,7 +267,19 @@ class PairCorrelation(graph.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/pair_correlation.py
+++ b/src/py4vasp/_calculation/pair_correlation.py
@@ -52,6 +52,14 @@ class PairCorrelationHandler:
     ) -> "PairCorrelationHandler":
         return cls(raw_pair_correlation, steps)
 
+    def __str__(self) -> str:
+        distances = self._raw_data.distances
+        pairs = ", ".join(self.labels())
+        return f"""\
+pair-correlation function:
+    distances: [{distances[0]:0.2f}, {distances[-1]:0.2f}] {len(distances)} points
+    pairs: {pairs}"""
+
     def to_dict(self, selection=None) -> dict:
         """Read the pair-correlation function and store it in a dictionary."""
         selection = self._default_selection_if_none(selection)
@@ -247,6 +255,22 @@ class PairCorrelation(graph.Mixin):
             self._handler_factory,
             PairCorrelationHandler.labels,
         )
+
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
 
     def __str__(self, selection=None) -> str:
         return merge_strings(

--- a/src/py4vasp/_calculation/pair_correlation.py
+++ b/src/py4vasp/_calculation/pair_correlation.py
@@ -166,11 +166,6 @@ class PairCorrelation(graph.Mixin):
         """Create a PairCorrelation dispatcher from raw data."""
         return cls(source=DataSource(raw_pair_correlation))
 
-    @property
-    def path(self):
-        """Path used for file-export methods."""
-        return self._path
-
     def __getitem__(self, steps) -> "PairCorrelation":
         new = copy.copy(self)
         new._steps = steps

--- a/src/py4vasp/_calculation/partial_density.py
+++ b/src/py4vasp/_calculation/partial_density.py
@@ -419,7 +419,19 @@ class PartialDensity(view.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/partial_density.py
+++ b/src/py4vasp/_calculation/partial_density.py
@@ -408,6 +408,22 @@ class PartialDensity(view.Mixin):
     def _handler_factory(self, raw):
         return PartialDensityHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/phonon_band.py
+++ b/src/py4vasp/_calculation/phonon_band.py
@@ -174,6 +174,17 @@ class PhononBand(graph.Mixin):
     def _handler_factory(self, raw):
         return PhononBandHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/phonon_dos.py
+++ b/src/py4vasp/_calculation/phonon_dos.py
@@ -148,6 +148,17 @@ class PhononDos(graph.Mixin):
     def _handler_factory(self, raw):
         return PhononDosHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/phonon_mode.py
+++ b/src/py4vasp/_calculation/phonon_mode.py
@@ -104,6 +104,22 @@ class PhononMode:
     def _handler_factory(self, raw):
         return PhononModeHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/phonon_mode.py
+++ b/src/py4vasp/_calculation/phonon_mode.py
@@ -115,7 +115,19 @@ class PhononMode:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/piezoelectric_tensor.py
+++ b/src/py4vasp/_calculation/piezoelectric_tensor.py
@@ -286,6 +286,22 @@ class PiezoelectricTensor:
         """Convenient alias for :py:meth:`read`. Please read the documentation there."""
         return self.read()
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/piezoelectric_tensor.py
+++ b/src/py4vasp/_calculation/piezoelectric_tensor.py
@@ -297,7 +297,19 @@ class PiezoelectricTensor:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/polarization.py
+++ b/src/py4vasp/_calculation/polarization.py
@@ -134,7 +134,19 @@ class Polarization:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/polarization.py
+++ b/src/py4vasp/_calculation/polarization.py
@@ -123,6 +123,22 @@ class Polarization:
         """Convenient alias for :py:meth:`read`."""
         return self.read()
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/potential.py
+++ b/src/py4vasp/_calculation/potential.py
@@ -342,7 +342,19 @@ class Potential(view.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/potential.py
+++ b/src/py4vasp/_calculation/potential.py
@@ -331,6 +331,22 @@ class Potential(view.Mixin):
             return _is_collinear(potential) or _is_noncollinear(potential)
         return any(present.values())
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/projector.py
+++ b/src/py4vasp/_calculation/projector.py
@@ -317,6 +317,17 @@ class Projector:
     def _handler_factory(self, raw):
         return ProjectorHandler.from_data(raw)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
     def __str__(self, selection=None):
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/run_info.py
+++ b/src/py4vasp/_calculation/run_info.py
@@ -262,13 +262,25 @@ class RunInfo:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
 
     def _repr_pretty_(self, p, cycle):
-        p.text(str(self) if not cycle else "...")
+        p.text(str(self))
 
     def __str__(self, selection=None) -> str:
         return merge_strings(

--- a/src/py4vasp/_calculation/run_info.py
+++ b/src/py4vasp/_calculation/run_info.py
@@ -80,7 +80,9 @@ class RunInfoHandler:
             return "collinear"
         if data["is_noncollinear"]:
             return "noncollinear"
-        if data["is_collinear"] is None and data["is_noncollinear"] is None:
+        # the two flags fall back to different fields, so one may be known while the
+        # other is not; a single False does not establish a nonpolarized calculation
+        if data["is_collinear"] is None or data["is_noncollinear"] is None:
             return None
         return "nonpolarized"
 

--- a/src/py4vasp/_calculation/run_info.py
+++ b/src/py4vasp/_calculation/run_info.py
@@ -9,12 +9,13 @@ from py4vasp._calculation.dispatch import (
     DataSource,
     _dispatch,
     merge_default,
+    merge_strings,
     merge_to_database,
     quantity,
 )
 from py4vasp._raw.data_wrapper import VaspData
 from py4vasp._raw.models import RunInfoModel
-from py4vasp._util import check
+from py4vasp._util import check, convert
 
 _TO_DATABASE_SUPPRESSED_EXCEPTIONS = (
     exception.Py4VaspError,
@@ -46,6 +47,42 @@ class RunInfoHandler:
             **self._dict_from_contcar(),
             **self._dict_from_phonon_dispersion(),
         }
+
+    def __str__(self) -> str:
+        data = self.to_dict()
+        system = convert.text_to_string(data["system_tag"] or "")
+        header = f"run info for {system}:" if system else "run info:"
+        lines = [header, *self._summary_lines(data)]
+        return "\n".join(lines)
+
+    def _summary_lines(self, data):
+        """Report the quantities VASP wrote, skipping the ones it did not."""
+        version = data["vasp_version"]
+        if version is not None:
+            yield f"    VASP version: {convert.text_to_string(version)}"
+        if data["num_ionic_steps"] is not None:
+            yield f"    ionic steps: {data['num_ionic_steps']}"
+        if data["fermi_energy"] is not None:
+            yield f"    Fermi energy: {data['fermi_energy']:.3f}"
+        spin = self._spin_string(data)
+        if spin is not None:
+            yield f"    spin: {spin}"
+        if data["is_metallic"] is not None:
+            yield f"    metallic: {'yes' if data['is_metallic'] else 'no'}"
+        qpoints = data["phonon_num_qpoints"]
+        modes = data["phonon_num_modes"]
+        if qpoints is not None and modes is not None:
+            yield f"    phonon dispersion: {qpoints} q-points, {modes} modes"
+
+    @staticmethod
+    def _spin_string(data):
+        if data["is_collinear"]:
+            return "collinear"
+        if data["is_noncollinear"]:
+            return "noncollinear"
+        if data["is_collinear"] is None and data["is_noncollinear"] is None:
+            return None
+        return "nonpolarized"
 
     def to_database(self) -> dict:
         """Serialize run info for the database."""
@@ -173,7 +210,9 @@ class RunInfoHandler:
     def _dict_from_phonon_dispersion(self) -> dict:
         phonon_num_qpoints = None
         phonon_num_modes = None
-        with suppress(exception.NoData):
+        # a calculation without phonons has no dispersion at all, so guard against the
+        # missing attribute the same way _dict_from_structure does
+        with suppress(exception.NoData, AttributeError):
             eigenvalues = self._raw_run_info.phonon_dispersion.eigenvalues
             phonon_num_qpoints = eigenvalues.shape[0]
             phonon_num_modes = eigenvalues.shape[1]
@@ -209,6 +248,34 @@ class RunInfo:
     def to_dict(self, selection: str | None = None) -> dict:
         """Convenient alias for :py:meth:`read`."""
         return self.read()
+
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
+    def _repr_pretty_(self, p, cycle):
+        p.text(str(self) if not cycle else "...")
+
+    def __str__(self, selection=None) -> str:
+        return merge_strings(
+            self._source,
+            self._quantity_name,
+            selection,
+            RunInfoHandler.from_data,
+            RunInfoHandler.__str__,
+        )
 
     def _to_database(self) -> dict:
         """Return {quantity[_selection]: handler_result} for database storage."""

--- a/src/py4vasp/_calculation/stress.py
+++ b/src/py4vasp/_calculation/stress.py
@@ -176,7 +176,19 @@ class Stress:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/stress.py
+++ b/src/py4vasp/_calculation/stress.py
@@ -165,6 +165,22 @@ class Stress:
     def _handler_factory(self, raw):
         return StressHandler.from_data(raw, steps=self._steps)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         "Convert the stress to a format similar to the OUTCAR file."
         return merge_strings(

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -825,7 +825,19 @@ class Structure(view.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/structure.py
+++ b/src/py4vasp/_calculation/structure.py
@@ -814,6 +814,22 @@ class Structure(view.Mixin):
         )
         return cls.from_data(structure)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None):
         "Generate a string representing the final structure usable as a POSCAR file."
         return merge_strings(

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -331,11 +331,6 @@ class Symmetry:
         """Create a Symmetry dispatcher from raw data (convenience for testing)."""
         return cls(source=DataSource(raw_symmetry))
 
-    @property
-    def path(self):
-        """Returns the path from which the output is obtained."""
-        return self._path
-
     def _handler_factory(self, raw_data):
         return SymmetryHandler.from_data(raw_data)
 

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -502,6 +502,22 @@ class Symmetry:
             SymmetryHandler.pearson_symbol,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/symmetry.py
+++ b/src/py4vasp/_calculation/symmetry.py
@@ -513,7 +513,19 @@ class Symmetry:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/system.py
+++ b/src/py4vasp/_calculation/system.py
@@ -87,6 +87,22 @@ class System:
         """Convenient alias for :py:meth:`read`. Please read the documentation there."""
         return self.read()
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/system.py
+++ b/src/py4vasp/_calculation/system.py
@@ -98,7 +98,19 @@ class System:
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/velocity.py
+++ b/src/py4vasp/_calculation/velocity.py
@@ -198,6 +198,22 @@ class Velocity(view.Mixin):
     def _handler_factory(self, raw):
         return VelocityHandler.from_data(raw, steps=self._steps)
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/velocity.py
+++ b/src/py4vasp/_calculation/velocity.py
@@ -209,7 +209,19 @@ class Velocity(view.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/workfunction.py
+++ b/src/py4vasp/_calculation/workfunction.py
@@ -178,7 +178,19 @@ class Workfunction(graph.Mixin):
         """
         print(self.__str__(selection))
 
-    def selections(self):
+    def selections(self) -> dict:
+        """Returns possible alternatives for this particular quantity VASP can produce.
+
+        The returned dictionary contains a single item with the name of the quantity
+        mapping to all possible selections. Each of these selections may be passed to
+        the other methods of this quantity to choose which output of VASP is used.
+
+        Returns
+        -------
+        dict
+            The key indicates this quantity and the value lists the possible choices
+            for the selection argument of its other methods.
+        """
         from py4vasp._raw import definition as raw_module
 
         return {self._quantity_name: list(raw_module.selections(self._quantity_name))}

--- a/src/py4vasp/_calculation/workfunction.py
+++ b/src/py4vasp/_calculation/workfunction.py
@@ -167,6 +167,22 @@ class Workfunction(graph.Mixin):
             WorkfunctionHandler.to_graph,
         )
 
+    def print(self, selection: str | None = None) -> None:
+        """Print a string representation of this quantity.
+
+        Parameters
+        ----------
+        selection : str | None
+            Select which source of the quantity is printed. If you select multiple
+            sources, py4vasp prints one block per source.
+        """
+        print(self.__str__(selection))
+
+    def selections(self):
+        from py4vasp._raw import definition as raw_module
+
+        return {self._quantity_name: list(raw_module.selections(self._quantity_name))}
+
     def __str__(self, selection=None) -> str:
         return merge_strings(
             self._source,

--- a/src/py4vasp/_calculation/workfunction.py
+++ b/src/py4vasp/_calculation/workfunction.py
@@ -120,11 +120,6 @@ class Workfunction(graph.Mixin):
         """Create a Workfunction dispatcher from raw data (convenience for testing)."""
         return cls(source=DataSource(raw_workfunction))
 
-    @property
-    def path(self):
-        """Returns the path from which the output is obtained."""
-        return self._path
-
     def _handler_factory(self, raw_data):
         return WorkfunctionHandler.from_data(raw_data)
 

--- a/tests/calculation/test_band.py
+++ b/tests/calculation/test_band.py
@@ -760,6 +760,11 @@ def test_dispatcher_to_database_default(single_band):
     assert isinstance(result["band"]["default"], BandModel)
 
 
+def test_print_writes_to_stdout(multiple_bands, capsys):
+    assert multiple_bands.print() is None
+    assert capsys.readouterr().out == str(multiple_bands) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.band("multiple")
     parameters = {"to_quiver": {"selection": "x~y(band=1)"}}

--- a/tests/calculation/test_bandgap.py
+++ b/tests/calculation/test_bandgap.py
@@ -355,9 +355,18 @@ direct gap:                  0.044108                     0.041885              
 Fermi energy:               11.401754"""
 
 
+def test_print_writes_to_stdout(bandgap, capsys):
+    assert bandgap.print() is None
+    assert capsys.readouterr().out == str(bandgap) + "\n"
+
+
+def test_selections(bandgap):
+    assert bandgap.selections() == {"bandgap": ["default", "kpoint"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     raw_gap = raw_data.bandgap("default")
-    check_factory_methods(Bandgap, raw_gap)
+    check_factory_methods(Bandgap, raw_gap, skip_methods=["selections"])
 
 
 def _check_to_database(_handler, Assert):

--- a/tests/calculation/test_born_effective_charge.py
+++ b/tests/calculation/test_born_effective_charge.py
@@ -26,6 +26,11 @@ def Sr2TiO4(raw_data):
     return handler
 
 
+@pytest.fixture
+def dispatcher(raw_data):
+    return BornEffectiveCharge.from_data(raw_data.born_effective_charge("Sr2TiO4"))
+
+
 def test_Sr2TiO4_read(Sr2TiO4, Assert):
     actual = Sr2TiO4.read()
     reference_structure = Sr2TiO4.ref.structure.to_dict()
@@ -37,9 +42,7 @@ def test_Sr2TiO4_read(Sr2TiO4, Assert):
     Assert.allclose(actual["charge_tensors"], Sr2TiO4.ref.charge_tensors)
 
 
-def test_Sr2TiO4_print(Sr2TiO4, format_):
-    actual, _ = format_(Sr2TiO4)
-    reference = """
+REFERENCE_OUTPUT = """
 BORN EFFECTIVE CHARGES (including local field effects) (in |e|, cumulative output)
 ---------------------------------------------------------------------------------
 ion    1   Sr
@@ -71,12 +74,30 @@ ion    7   O
     2    57.00000    58.00000    59.00000
     3    60.00000    61.00000    62.00000
 """.strip()
-    assert actual == {"text/plain": reference}
+
+
+def test_Sr2TiO4_print(Sr2TiO4, format_):
+    actual, _ = format_(Sr2TiO4)
+    assert actual == {"text/plain": REFERENCE_OUTPUT}
+
+
+def test_print_dispatcher(dispatcher, format_):
+    actual, _ = format_(dispatcher)
+    assert actual == {"text/plain": REFERENCE_OUTPUT}
+
+
+def test_print_writes_to_stdout(dispatcher, capsys):
+    assert dispatcher.print() is None
+    assert capsys.readouterr().out == str(dispatcher) + "\n"
+
+
+def test_selections(dispatcher):
+    assert dispatcher.selections() == {"born_effective_charge": ["default"]}
 
 
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.born_effective_charge("Sr2TiO4")
-    check_factory_methods(BornEffectiveCharge, data)
+    check_factory_methods(BornEffectiveCharge, data, skip_methods=["selections"])
 
 
 def test_to_database(Sr2TiO4):

--- a/tests/calculation/test_contcar.py
+++ b/tests/calculation/test_contcar.py
@@ -118,9 +118,18 @@ def test_print(CONTCAR, format_):
     assert actual == {"text/plain": CONTCAR.ref.string}
 
 
+def test_print_writes_to_stdout(CONTCAR, capsys):
+    assert CONTCAR.print() is None
+    assert capsys.readouterr().out == str(CONTCAR) + "\n"
+
+
+def test_selections(CONTCAR):
+    assert CONTCAR.selections() == {"CONTCAR": ["default", "CONTCAR"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     raw_contcar = raw_data.CONTCAR("Sr2TiO4")
-    check_factory_methods(_CONTCAR, raw_contcar)
+    check_factory_methods(_CONTCAR, raw_contcar, skip_methods=["selections"])
 
 
 def test_to_database(CONTCAR):

--- a/tests/calculation/test_current_density.py
+++ b/tests/calculation/test_current_density.py
@@ -214,9 +214,18 @@ def test_to_database(raw_data, Assert):
     assert db_data.grid_shape == (nx, ny, nz)
 
 
+def test_print_writes_to_stdout(current_density, capsys):
+    assert current_density.print() is None
+    assert capsys.readouterr().out == str(current_density) + "\n"
+
+
+def test_selections(current_density):
+    assert current_density.selections() == {"current_density": ["nmr"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.current_density("x")
-    check_factory_methods(CurrentDensity, data)
+    check_factory_methods(CurrentDensity, data, skip_methods=["selections"])
 
 
 def test_is_available(tmp_path):

--- a/tests/calculation/test_density.py
+++ b/tests/calculation/test_density.py
@@ -632,6 +632,11 @@ def test_all_electron_core_only_defines_basins(raw_data, Assert):
     Assert.allclose(density.bader_analysis().basins(), expected_basins)
 
 
+def test_print_writes_to_stdout(reference_density, capsys):
+    assert reference_density.print() is None
+    assert capsys.readouterr().out == str(reference_density) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.density("Fe3O4 collinear")
     parameters = {"to_contour": {"a": 0.3}}

--- a/tests/calculation/test_dielectric_function.py
+++ b/tests/calculation/test_dielectric_function.py
@@ -453,6 +453,11 @@ def test_to_database_ionic(ionic):
     _check_to_database(ionic)
 
 
+def test_print_writes_to_stdout(electronic, capsys):
+    assert electronic.print() is None
+    assert capsys.readouterr().out == str(electronic) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.dielectric_function("electron")
     check_factory_methods(DielectricFunction, data)

--- a/tests/calculation/test_dielectric_tensor.py
+++ b/tests/calculation/test_dielectric_tensor.py
@@ -155,9 +155,18 @@ Macroscopic static dielectric tensor (dimensionless)
     assert actual == {"text/plain": expected}
 
 
+def test_print_writes_to_stdout(dft_tensor, capsys):
+    assert dft_tensor.print() is None
+    assert capsys.readouterr().out == str(dft_tensor) + "\n"
+
+
+def test_selections(dft_tensor):
+    assert dft_tensor.selections() == {"dielectric_tensor": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.dielectric_tensor("dft with_ion")
-    check_factory_methods(DielectricTensor, data)
+    check_factory_methods(DielectricTensor, data, skip_methods=["selections"])
 
 
 def _check_to_database(tensor, Assert):

--- a/tests/calculation/test_dispatch.py
+++ b/tests/calculation/test_dispatch.py
@@ -1352,4 +1352,5 @@ class TestPathInjected:
 
     def test_path_is_documented(self):
         structure = dict(REGISTERED_CLASSES)["structure"]
-        assert "path" in structure.path.__doc__
+        expected = "Returns the path from which the output is obtained."
+        assert structure.path.__doc__ == expected

--- a/tests/calculation/test_dispatch.py
+++ b/tests/calculation/test_dispatch.py
@@ -1317,3 +1317,39 @@ class TestArchiveSource:
         del source
         gc.collect()
         assert not directory.exists()
+
+
+def _all_registered_classes():
+    """Yield (name, dispatcher class) for every quantity in the registry."""
+    for name, entry in sorted(_REGISTRY.items()):
+        if isinstance(entry, dict):
+            for member, cls in sorted(entry.items()):
+                yield f"{name}.{member}", cls
+        else:
+            yield name, entry
+
+
+REGISTERED_CLASSES = list(_all_registered_classes())
+QUANTITY_CLASSES = [cls for _, cls in REGISTERED_CLASSES]
+QUANTITY_IDS = [name for name, _ in REGISTERED_CLASSES]
+
+
+class TestPathInjected:
+    """The public path property that base.Refinery provided for every quantity."""
+
+    @pytest.mark.parametrize("cls", QUANTITY_CLASSES, ids=QUANTITY_IDS)
+    def test_path_is_a_property(self, cls):
+        assert isinstance(getattr(cls, "path", None), property)
+
+    @pytest.mark.parametrize("cls", QUANTITY_CLASSES, ids=QUANTITY_IDS)
+    def test_path_reports_calculation_directory(self, cls, tmp_path):
+        assert cls.from_path(tmp_path).path == tmp_path.resolve()
+
+    @pytest.mark.parametrize("cls", QUANTITY_CLASSES, ids=QUANTITY_IDS)
+    def test_path_defaults_to_working_directory(self, cls):
+        # in-memory data has no path, so py4vasp writes generated output to the cwd
+        assert cls(source=DataSource(None)).path == pathlib.Path.cwd()
+
+    def test_path_is_documented(self):
+        structure = dict(REGISTERED_CLASSES)["structure"]
+        assert "path" in structure.path.__doc__

--- a/tests/calculation/test_dispersion.py
+++ b/tests/calculation/test_dispersion.py
@@ -112,9 +112,20 @@ def test_print(dispersion, format_):
     assert actual == {"text/plain": reference}
 
 
+def test_print_writes_to_stdout(dispersion, capsys):
+    assert dispersion.print() is None
+    assert capsys.readouterr().out == str(dispersion) + "\n"
+
+
+def test_selections(dispersion):
+    assert dispersion.selections() == {
+        "dispersion": ["default", "kpoints_opt", "kpoints_wan", "phonon"]
+    }
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.dispersion("single_band")
-    check_factory_methods(Dispersion, data)
+    check_factory_methods(Dispersion, data, skip_methods=["selections"])
 
 
 def _check_to_database(dispersion_):

--- a/tests/calculation/test_dos.py
+++ b/tests/calculation/test_dos.py
@@ -342,6 +342,11 @@ projectors:
     assert actual == {"text/plain": reference}
 
 
+def test_print_writes_to_stdout(Sr2TiO4, capsys):
+    assert Sr2TiO4.print() is None
+    assert capsys.readouterr().out == str(Sr2TiO4) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.dos("Sr2TiO4")
     check_factory_methods(Dos, data)

--- a/tests/calculation/test_effective_coulomb.py
+++ b/tests/calculation/test_effective_coulomb.py
@@ -545,6 +545,11 @@ screened Hubbard J =\s+[-\d.]+\s+[-\d.]+"""
     assert re.search(expected_result, actual["text/plain"], re.MULTILINE)
 
 
+def test_print_writes_to_stdout(effective_coulomb, capsys):
+    assert effective_coulomb.print() is None
+    assert capsys.readouterr().out == str(effective_coulomb) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.effective_coulomb("crpa")
     check_factory_methods(EffectiveCoulomb, data)

--- a/tests/calculation/test_elastic_modulus.py
+++ b/tests/calculation/test_elastic_modulus.py
@@ -157,6 +157,15 @@ def test_to_database(elastic_moduli):
             ), f"mismatch in {key}: expected {value}, got {getattr(overview, key)}."
 
 
+def test_print_writes_to_stdout(elastic_modulus, capsys):
+    assert elastic_modulus.print() is None
+    assert capsys.readouterr().out == str(elastic_modulus) + "\n"
+
+
+def test_selections(elastic_modulus):
+    assert elastic_modulus.selections() == {"elastic_modulus": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.elastic_modulus("dft")
-    check_factory_methods(ElasticModulus, data)
+    check_factory_methods(ElasticModulus, data, skip_methods=["selections"])

--- a/tests/calculation/test_electron_phonon_bandgap.py
+++ b/tests/calculation/test_electron_phonon_bandgap.py
@@ -314,7 +314,11 @@ def test_empty_scattering_approximation(raw_band_gap):
     raw_band_gap.scattering_approximation = []
     band_gap = ElectronPhononBandgap.from_data(raw_band_gap)
     assert len(band_gap) == 0
-    assert isinstance(str(band_gap), str)
+    # the instance count comes straight from the mask that used to raise; the rest of
+    # the text lists the randomized demo parameters, so only pin what matters here
+    actual = str(band_gap)
+    assert actual.startswith("Electron-phonon bandgap with 0 instance(s):")
+    assert "scattering_approx: []" in actual
 
 
 def test_factory_methods(raw_data, check_factory_methods):

--- a/tests/calculation/test_electron_phonon_bandgap.py
+++ b/tests/calculation/test_electron_phonon_bandgap.py
@@ -303,6 +303,20 @@ def test_print_instance(band_gap, format_):
     assert actual == {"text/plain": str(instance)}
 
 
+def test_print_writes_to_stdout(band_gap, capsys):
+    assert band_gap.print() is None
+    assert capsys.readouterr().out == str(band_gap) + "\n"
+
+
+def test_empty_scattering_approximation(raw_band_gap):
+    # a calculation without electron-phonon data has no scattering approximations at
+    # all; len() and str() run in display code and must not raise for it
+    raw_band_gap.scattering_approximation = []
+    band_gap = ElectronPhononBandgap.from_data(raw_band_gap)
+    assert len(band_gap) == 0
+    assert isinstance(str(band_gap), str)
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.electron_phonon_band_gap("default")
     parameters = {"select": {"selection": "selfen_carrier_den=0.01"}}

--- a/tests/calculation/test_electron_phonon_chemical_potential.py
+++ b/tests/calculation/test_electron_phonon_chemical_potential.py
@@ -96,6 +96,17 @@ def test_print(chemical_potential, format_):
     assert actual == {"text/plain": str(chemical_potential)}
 
 
+def test_print_writes_to_stdout(chemical_potential, capsys):
+    assert chemical_potential.print() is None
+    assert capsys.readouterr().out == str(chemical_potential) + "\n"
+
+
+def test_selections(chemical_potential):
+    assert chemical_potential.selections() == {
+        "electron_phonon_chemical_potential": ["default"]
+    }
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.electron_phonon_chemical_potential("carrier_den")
-    check_factory_methods(ChemicalPotential, data)
+    check_factory_methods(ChemicalPotential, data, skip_methods=["selections"])

--- a/tests/calculation/test_electron_phonon_self_energy.py
+++ b/tests/calculation/test_electron_phonon_self_energy.py
@@ -305,6 +305,11 @@ def test_print_instance(self_energy, format_):
     assert actual == {"text/plain": str(instance)}
 
 
+def test_print_writes_to_stdout(self_energy, capsys):
+    assert self_energy.print() is None
+    assert capsys.readouterr().out == str(self_energy) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.electron_phonon_self_energy("default")
     parameters = {"select": {"selection": "selfen_approx=SERTA"}}

--- a/tests/calculation/test_electron_phonon_transport.py
+++ b/tests/calculation/test_electron_phonon_transport.py
@@ -483,6 +483,11 @@ def test_print_instance(transport, format_):
     assert actual == {"text/plain": str(instance)}
 
 
+def test_print_writes_to_stdout(transport, capsys):
+    assert transport.print() is None
+    assert capsys.readouterr().out == str(transport) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.electron_phonon_transport("default")
     parameters = {

--- a/tests/calculation/test_electron_phonon_transport.py
+++ b/tests/calculation/test_electron_phonon_transport.py
@@ -488,6 +488,17 @@ def test_print_writes_to_stdout(transport, capsys):
     assert capsys.readouterr().out == str(transport) + "\n"
 
 
+def test_selections_without_transport_data(raw_transport):
+    # a calculation without electron-phonon transport has no instances and no datasets,
+    # exactly as the default demo calculation; selections is metadata and must report
+    # that no spin selection exists instead of indexing the empty dataset
+    raw_transport.valid_indices = []
+    raw_transport.electronic_conductivity = []
+    transport = ElectronPhononTransport.from_data(raw_transport)
+    assert len(transport) == 0
+    assert "spin" not in transport.selections()
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.electron_phonon_transport("default")
     parameters = {

--- a/tests/calculation/test_electronic_minimization.py
+++ b/tests/calculation/test_electronic_minimization.py
@@ -289,6 +289,17 @@ def test_to_database(electronic_minimization, raw_data):
             ), f"{k} has unexpected type {type(v)}: {v}"
 
 
+def test_print_writes_to_stdout(electronic_minimization, capsys):
+    assert electronic_minimization.print() is None
+    assert capsys.readouterr().out == str(electronic_minimization) + "\n"
+
+
+def test_selections(electronic_minimization):
+    assert electronic_minimization.selections() == {
+        "electronic_minimization": ["default"]
+    }
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.electronic_minimization()
-    check_factory_methods(ElectronicMinimization, data)
+    check_factory_methods(ElectronicMinimization, data, skip_methods=["selections"])

--- a/tests/calculation/test_energy.py
+++ b/tests/calculation/test_energy.py
@@ -291,6 +291,11 @@ def test_detect_energy_format_unknown_raises():
         _detect_energy_format({"not_a_real_energy_key"})
 
 
+def test_print_writes_to_stdout(MD_energy, capsys):
+    assert MD_energy.print() is None
+    assert capsys.readouterr().out == str(MD_energy) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.energy("MD")
     check_factory_methods(Energy, data)

--- a/tests/calculation/test_energy.py
+++ b/tests/calculation/test_energy.py
@@ -129,7 +129,7 @@ def check_to_image(MD_energy, filename_argument, expected_filename):
 
 def test_selections(MD_energy, raw_data):
     md_selections = MD_energy.selections()
-    md_selections.pop("energy")
+    assert md_selections.pop("energy") == ["default", "afqmc"]
     components = [
         "ion_electron",
         "TOTEN",
@@ -149,7 +149,7 @@ def test_selections(MD_energy, raw_data):
     assert md_selections == {"component": components}
     #
     relax_selections = Energy.from_data(raw_data.energy("relax")).selections()
-    relax_selections.pop("energy")
+    assert relax_selections.pop("energy") == ["default", "afqmc"]
     components = [
         "free_energy",
         "TOTEN",
@@ -161,7 +161,7 @@ def test_selections(MD_energy, raw_data):
     assert relax_selections == {"component": components}
     #
     afqmc_selections = Energy.from_data(raw_data.energy("afqmc")).selections()
-    afqmc_selections.pop("energy")
+    assert afqmc_selections.pop("energy") == ["default", "afqmc"]
     components = [
         "step",
         "STEP",

--- a/tests/calculation/test_exciton_density.py
+++ b/tests/calculation/test_exciton_density.py
@@ -131,6 +131,17 @@ def test_bader_charge_requires_analysis(raw_data):
         density.bader_charge()
 
 
+def test_print_writes_to_stdout(exciton_density, capsys):
+    assert exciton_density.print() is None
+    assert capsys.readouterr().out == str(exciton_density) + "\n"
+
+
+def test_selections(exciton_density):
+    assert exciton_density.selections() == {"exciton_density": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.exciton_density()
-    check_factory_methods(ExcitonDensity, data, skip_methods=["bader_charge"])
+    check_factory_methods(
+        ExcitonDensity, data, skip_methods=["selections", "bader_charge"]
+    )

--- a/tests/calculation/test_exciton_eigenvector.py
+++ b/tests/calculation/test_exciton_eigenvector.py
@@ -73,6 +73,15 @@ def test_to_database(exciton_eigenvector):
             assert isinstance(getattr(db_data, fld.name), (int, type(None)))
 
 
+def test_print_writes_to_stdout(exciton_eigenvector, capsys):
+    assert exciton_eigenvector.print() is None
+    assert capsys.readouterr().out == str(exciton_eigenvector) + "\n"
+
+
+def test_selections(exciton_eigenvector):
+    assert exciton_eigenvector.selections() == {"exciton_eigenvector": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.exciton_eigenvector("default")
-    check_factory_methods(ExcitonEigenvector, data)
+    check_factory_methods(ExcitonEigenvector, data, skip_methods=["selections"])

--- a/tests/calculation/test_force.py
+++ b/tests/calculation/test_force.py
@@ -138,6 +138,15 @@ def test_to_database(forces):
         )
 
 
+def test_print_writes_to_stdout(Sr2TiO4, capsys):
+    assert Sr2TiO4.print() is None
+    assert capsys.readouterr().out == str(Sr2TiO4) + "\n"
+
+
+def test_selections(Sr2TiO4):
+    assert Sr2TiO4.selections() == {"force": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.force("Fe3O4")
-    check_factory_methods(Force, data)
+    check_factory_methods(Force, data, skip_methods=["selections"])

--- a/tests/calculation/test_force_constant.py
+++ b/tests/calculation/test_force_constant.py
@@ -37,9 +37,23 @@ def test_Sr2TiO4_read(Sr2TiO4, Assert):
         Assert.allclose(actual["selective_dynamics"], Sr2TiO4.ref.selective_dynamics)
 
 
+@pytest.fixture(params=("all atoms", "selective dynamics"))
+def dispatcher(raw_data, request):
+    raw_force_constants = raw_data.force_constant(f"Sr2TiO4 {request.param}")
+    force_constants = ForceConstant.from_data(raw_force_constants)
+    force_constants.ref = types.SimpleNamespace()
+    force_constants.ref.format_output = get_format_output(request.param)
+    return force_constants
+
+
 def test_Sr2TiO4_print(Sr2TiO4):
     actual = str(Sr2TiO4)
     assert actual == Sr2TiO4.ref.format_output["text/plain"]
+
+
+def test_print_dispatcher(dispatcher, format_):
+    actual, _ = format_(dispatcher)
+    assert actual == {"text/plain": dispatcher.ref.format_output["text/plain"]}
 
 
 def get_format_output(selection):
@@ -431,6 +445,15 @@ vibration 10
 """
 
 
+def test_print_writes_to_stdout(dispatcher, capsys):
+    assert dispatcher.print() is None
+    assert capsys.readouterr().out == str(dispatcher) + "\n"
+
+
+def test_selections(dispatcher):
+    assert dispatcher.selections() == {"force_constant": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.force_constant("Sr2TiO4 all atoms")
-    check_factory_methods(ForceConstant, data)
+    check_factory_methods(ForceConstant, data, skip_methods=["selections"])

--- a/tests/calculation/test_internal_strain.py
+++ b/tests/calculation/test_internal_strain.py
@@ -19,6 +19,11 @@ def Sr2TiO4(raw_data):
     return handler
 
 
+@pytest.fixture
+def dispatcher(raw_data):
+    return InternalStrain.from_data(raw_data.internal_strain("Sr2TiO4"))
+
+
 def test_Sr2TiO4_read(Sr2TiO4, Assert):
     actual = Sr2TiO4.to_dict()
     reference_structure = Sr2TiO4.ref.structure.to_dict()
@@ -30,9 +35,7 @@ def test_Sr2TiO4_read(Sr2TiO4, Assert):
     Assert.allclose(actual["internal_strain"], Sr2TiO4.ref.internal_strain)
 
 
-def test_Sr2TiO4_print(Sr2TiO4):
-    actual = str(Sr2TiO4)
-    reference = """
+REFERENCE_OUTPUT = """
 Internal strain tensor (eV/Å):
  ion  displ     X           Y           Z          XY          YZ          ZX
 ---------------------------------------------------------------------------------
@@ -58,9 +61,26 @@ Internal strain tensor (eV/Å):
         y   171.00000   175.00000   179.00000   173.00000   177.00000   175.00000
         z   180.00000   184.00000   188.00000   182.00000   186.00000   184.00000
 """.strip()
-    assert actual == reference
+
+
+def test_Sr2TiO4_print(Sr2TiO4):
+    assert str(Sr2TiO4) == REFERENCE_OUTPUT
+
+
+def test_print_dispatcher(dispatcher, format_):
+    actual, _ = format_(dispatcher)
+    assert actual == {"text/plain": REFERENCE_OUTPUT}
+
+
+def test_print_writes_to_stdout(dispatcher, capsys):
+    assert dispatcher.print() is None
+    assert capsys.readouterr().out == str(dispatcher) + "\n"
+
+
+def test_selections(dispatcher):
+    assert dispatcher.selections() == {"internal_strain": ["default"]}
 
 
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.internal_strain("Sr2TiO4")
-    check_factory_methods(InternalStrain, data)
+    check_factory_methods(InternalStrain, data, skip_methods=["selections"])

--- a/tests/calculation/test_kpoint.py
+++ b/tests/calculation/test_kpoint.py
@@ -323,6 +323,11 @@ def test_to_database_qpoints(qpoints):
     _check_to_database(qpoints)
 
 
+def test_print_writes_to_stdout(explicit_kpoints, capsys):
+    assert explicit_kpoints.print() is None
+    assert capsys.readouterr().out == str(explicit_kpoints) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.kpoint("automatic")
     parameters = {"path_indices": {"start": (0, 0, 0), "finish": (1, 1, 1)}}

--- a/tests/calculation/test_local_moment.py
+++ b/tests/calculation/test_local_moment.py
@@ -272,6 +272,7 @@ def expected_color(selection):
 def test_selections(example_moments):
     actual = example_moments.selections()
     assert actual == {
+        "local_moment": ["default"],
         "orbital_projection": example_moments.ref.projections,
         "component": example_moments.ref.components,
     }

--- a/tests/calculation/test_local_moment.py
+++ b/tests/calculation/test_local_moment.py
@@ -339,6 +339,11 @@ def test_to_database(example_moments):
     )
 
 
+def test_print_writes_to_stdout(collinear_moments, capsys):
+    assert collinear_moments.print() is None
+    assert capsys.readouterr().out == str(collinear_moments) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.local_moment("collinear")
     check_factory_methods(LocalMoment, data)

--- a/tests/calculation/test_neighbor_list.py
+++ b/tests/calculation/test_neighbor_list.py
@@ -312,6 +312,12 @@ def test_print(raw_data, format_):
     assert actual == {"text/plain": expected}
 
 
+def test_print_writes_to_stdout(raw_data, capsys):
+    neighbor_list = NeighborList.from_data(raw_data.structure("SrTiO3"))
+    assert neighbor_list.print() is None
+    assert capsys.readouterr().out == str(neighbor_list) + "\n"
+
+
 def test_str_uses_default_cutoff(raw_data):
     structure = raw_data.structure("SrTiO3")
     neighbor_list = NeighborList.from_data(structure)

--- a/tests/calculation/test_nics.py
+++ b/tests/calculation/test_nics.py
@@ -560,9 +560,18 @@ def test_bader_charge_in_points_mode_raises(raw_data):
         nics.bader_charge(bader_analysis=analysis)
 
 
+def test_print_writes_to_stdout(nics, capsys):
+    assert nics.print() is None
+    assert capsys.readouterr().out == str(nics) + "\n"
+
+
+def test_selections(nics):
+    assert nics.selections() == {"nics": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.nics("on-a-grid")
-    check_factory_methods(Nics, data, skip_methods=["bader_charge"])
+    check_factory_methods(Nics, data, skip_methods=["selections", "bader_charge"])
 
 
 def test_is_available_on_a_grid(nics_on_a_grid):

--- a/tests/calculation/test_optics.py
+++ b/tests/calculation/test_optics.py
@@ -408,6 +408,11 @@ def test_to_database_scalar_dielectric_function_is_skipped(raw_data):
     assert optics._to_database() == {}
 
 
+def test_print_writes_to_stdout(electron, capsys):
+    assert electron.print() is None
+    assert capsys.readouterr().out == str(electron) + "\n"
+
+
 def test_factory_methods_read_dielectric_function(raw_data):
     # Optics owns no data of its own; from_path/from_file must access the dielectric
     # function in the schema rather than a nonexistent "optics" entry.

--- a/tests/calculation/test_pair_correlation.py
+++ b/tests/calculation/test_pair_correlation.py
@@ -143,6 +143,24 @@ def test_to_database_no_first_peak():
     assert db_data.first_peak_height is None
 
 
+def test_print(pair_correlation, format_):
+    actual, _ = format_(pair_correlation)
+    reference = """\
+pair-correlation function:
+    distances: [0.00, 49.00] 50 points
+    pairs: total, Sr~Sr, Sr~Ti, Sr~O, Ti~Ti, Ti~O, O~O"""
+    assert actual == {"text/plain": reference}
+
+
+def test_print_writes_to_stdout(pair_correlation, capsys):
+    assert pair_correlation.print() is None
+    assert capsys.readouterr().out == str(pair_correlation) + "\n"
+
+
+def test_selections(pair_correlation):
+    assert pair_correlation.selections() == {"pair_correlation": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.pair_correlation("Sr2TiO4")
-    check_factory_methods(PairCorrelation, data)
+    check_factory_methods(PairCorrelation, data, skip_methods=["selections"])

--- a/tests/calculation/test_partial_density.py
+++ b/tests/calculation/test_partial_density.py
@@ -436,6 +436,27 @@ def test_bader_charge_requires_analysis(raw_data):
         partial_density.bader_charge()
 
 
+def test_print(NonSplitPartialDensity, format_):
+    actual, _ = format_(NonSplitPartialDensity)
+    reference = """\
+partial charge density of C10:
+        on fine FFT grid: [ 24  24 216]
+        summed over all contributing bands
+        summed over all contributing k-points"""
+    assert actual == {"text/plain": reference}
+
+
+def test_print_writes_to_stdout(AnyPartialDensity, capsys):
+    assert AnyPartialDensity.print() is None
+    assert capsys.readouterr().out == str(AnyPartialDensity) + "\n"
+
+
+def test_selections(AnyPartialDensity):
+    assert AnyPartialDensity.selections() == {"partial_density": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.partial_density("spin_polarized")
-    check_factory_methods(PartialDensity, data, skip_methods=["bader_charge"])
+    check_factory_methods(
+        PartialDensity, data, skip_methods=["selections", "bader_charge"]
+    )

--- a/tests/calculation/test_phonon_band.py
+++ b/tests/calculation/test_phonon_band.py
@@ -227,6 +227,11 @@ def test_raw_data_exposes_primitive_positions(raw_data, Assert):
     assert positions.shape == (number_atoms, 3)
 
 
+def test_print_writes_to_stdout(phonon_band, capsys):
+    assert phonon_band.print() is None
+    assert capsys.readouterr().out == str(phonon_band) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.phonon_band("default")
     check_factory_methods(PhononBand, data)

--- a/tests/calculation/test_phonon_dos.py
+++ b/tests/calculation/test_phonon_dos.py
@@ -115,6 +115,11 @@ def test_to_database(phonon_dos):
     assert db_data.energy_max == float(phonon_dos.ref.energies[-1])
 
 
+def test_print_writes_to_stdout(phonon_dos, capsys):
+    assert phonon_dos.print() is None
+    assert capsys.readouterr().out == str(phonon_dos) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.phonon_dos("default")
     check_factory_methods(PhononDos, data)

--- a/tests/calculation/test_phonon_mode.py
+++ b/tests/calculation/test_phonon_mode.py
@@ -96,6 +96,15 @@ def test_to_database_in_calculation(tmp_path):
     assert "phonon_phonon_mode" not in properties
 
 
+def test_print_writes_to_stdout(phonon_mode, capsys):
+    assert phonon_mode.print() is None
+    assert capsys.readouterr().out == str(phonon_mode) + "\n"
+
+
+def test_selections(phonon_mode):
+    assert phonon_mode.selections() == {"phonon_mode": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.phonon_mode("Sr2TiO4")
-    check_factory_methods(PhononMode, data)
+    check_factory_methods(PhononMode, data, skip_methods=["selections"])

--- a/tests/calculation/test_piezoelectric_tensor.py
+++ b/tests/calculation/test_piezoelectric_tensor.py
@@ -144,6 +144,15 @@ def test_to_database_as_slab(raw_data, piezoelectric_tensor_as_slab):
     _check_to_database(raw_tensor, piezoelectric_tensor_as_slab.ref)
 
 
+def test_print_writes_to_stdout(piezoelectric_tensor, capsys):
+    assert piezoelectric_tensor.print() is None
+    assert capsys.readouterr().out == str(piezoelectric_tensor) + "\n"
+
+
+def test_selections(piezoelectric_tensor):
+    assert piezoelectric_tensor.selections() == {"piezoelectric_tensor": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.piezoelectric_tensor("default")
-    check_factory_methods(PiezoelectricTensor, data)
+    check_factory_methods(PiezoelectricTensor, data, skip_methods=["selections"])

--- a/tests/calculation/test_polarization.py
+++ b/tests/calculation/test_polarization.py
@@ -75,6 +75,15 @@ def test_to_database(raw_data):
     assert db_data.total_dipole_norm == float(np.linalg.norm(total_dipole))
 
 
+def test_print_writes_to_stdout(polarization, capsys):
+    assert polarization.print() is None
+    assert capsys.readouterr().out == str(polarization) + "\n"
+
+
+def test_selections(polarization):
+    assert polarization.selections() == {"polarization": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.polarization("default")
-    check_factory_methods(Polarization, data)
+    check_factory_methods(Polarization, data, skip_methods=["selections"])

--- a/tests/calculation/test_potential.py
+++ b/tests/calculation/test_potential.py
@@ -447,9 +447,18 @@ def test_bader_charge_uses_external_analysis(raw_data, Assert):
         Assert.allclose(charges[key], manual[key])
 
 
+def test_print_writes_to_stdout(reference_potential, capsys):
+    assert reference_potential.print() is None
+    assert capsys.readouterr().out == str(reference_potential) + "\n"
+
+
+def test_selections(reference_potential):
+    assert reference_potential.selections() == {"potential": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.potential("Fe3O4 collinear total")
-    check_factory_methods(Potential, data, skip_methods=["bader_charge"])
+    check_factory_methods(Potential, data, skip_methods=["selections", "bader_charge"])
 
 
 def test_is_available_total_only(raw_data):

--- a/tests/calculation/test_print.py
+++ b/tests/calculation/test_print.py
@@ -39,7 +39,8 @@ def test_every_quantity_defines(cls, method):
 @pytest.mark.parametrize("cls", CLASSES, ids=IDS)
 def test_str_takes_an_optional_selection(cls):
     # print forwards its selection to __str__, so every quantity must accept one
-    parameter = inspect.signature(cls.__str__).parameters["selection"]
+    parameter = inspect.signature(cls.__str__).parameters.get("selection")
+    assert parameter is not None, f"{cls.__name__}.__str__ takes no selection"
     assert parameter.default is None
 
 
@@ -70,3 +71,17 @@ def test_print_writes_the_string_representation(name, demo_calculation, capsys):
         pytest.skip(f"the demo calculation contains no data for {name}")
     assert quantity.print() is None
     assert capsys.readouterr().out == expected + "\n"
+
+
+@pytest.mark.parametrize("name", _public_quantities())
+def test_selections_reports_what_can_be_selected(name, demo_calculation):
+    quantity = _resolve(demo_calculation, name)
+    try:
+        selections = quantity.selections()
+    except (exception.NoData, exception.FileAccessError):
+        pytest.skip(f"the demo calculation contains no data for {name}")
+    # NeighborList deliberately reports a flat list of atom-type pairs; every other
+    # quantity maps its own name (and any further keys) to a list of choices
+    assert selections
+    if isinstance(selections, dict):
+        assert all(isinstance(choices, list) for choices in selections.values())

--- a/tests/calculation/test_print.py
+++ b/tests/calculation/test_print.py
@@ -1,0 +1,72 @@
+# Copyright © VASP Software GmbH,
+# Licensed under the Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+"""Every quantity must offer the uniform surface base.Refinery used to provide.
+
+The Refinery base class gave print, __str__, _repr_pretty_ and selections to all
+quantities at once. Composition replaced it, and the methods were silently lost
+because nothing checked that a dispatcher implements them. These tests are that
+check; they fail for a new quantity that forgets one of them.
+"""
+
+import inspect
+
+import pytest
+
+from py4vasp import _calculation, demo, exception
+from py4vasp._calculation.dispatch import _REGISTRY
+
+
+def _registered_quantities():
+    for name, entry in sorted(_REGISTRY.items()):
+        if isinstance(entry, dict):
+            for member, cls in sorted(entry.items()):
+                yield f"{name}.{member}", cls
+        else:
+            yield name, entry
+
+
+QUANTITIES = list(_registered_quantities())
+CLASSES = [cls for _, cls in QUANTITIES]
+IDS = [name for name, _ in QUANTITIES]
+
+
+@pytest.mark.parametrize("cls", CLASSES, ids=IDS)
+@pytest.mark.parametrize("method", ("print", "__str__", "_repr_pretty_", "selections"))
+def test_every_quantity_defines(cls, method):
+    assert method in cls.__dict__
+
+
+@pytest.mark.parametrize("cls", CLASSES, ids=IDS)
+def test_str_takes_an_optional_selection(cls):
+    # print forwards its selection to __str__, so every quantity must accept one
+    parameter = inspect.signature(cls.__str__).parameters["selection"]
+    assert parameter.default is None
+
+
+def _public_quantities():
+    names = list(_calculation.QUANTITIES)
+    for group, members in _calculation.GROUPS.items():
+        names += [f"{group}.{member}" for member in members]
+    return sorted(names)
+
+
+def _resolve(calculation, name):
+    for part in name.split("."):
+        calculation = getattr(calculation, part)
+    return calculation
+
+
+@pytest.fixture(scope="module")
+def demo_calculation(tmp_path_factory):
+    return demo.calculation(tmp_path_factory.mktemp("demo") / "calculation")
+
+
+@pytest.mark.parametrize("name", _public_quantities())
+def test_print_writes_the_string_representation(name, demo_calculation, capsys):
+    quantity = _resolve(demo_calculation, name)
+    try:
+        expected = str(quantity)
+    except (exception.NoData, exception.FileAccessError):
+        pytest.skip(f"the demo calculation contains no data for {name}")
+    assert quantity.print() is None
+    assert capsys.readouterr().out == expected + "\n"

--- a/tests/calculation/test_print.py
+++ b/tests/calculation/test_print.py
@@ -62,13 +62,23 @@ def demo_calculation(tmp_path_factory):
     return demo.calculation(tmp_path_factory.mktemp("demo") / "calculation")
 
 
+# NeighborList builds its table with a scipy KD-tree, so its text is unavailable in a
+# py4vasp-core install; the rest of the quantities must format themselves with numpy
+# and h5py alone.
+_UNAVAILABLE = (
+    exception.NoData,
+    exception.FileAccessError,
+    exception.ModuleNotInstalled,
+)
+
+
 @pytest.mark.parametrize("name", _public_quantities())
 def test_print_writes_the_string_representation(name, demo_calculation, capsys):
     quantity = _resolve(demo_calculation, name)
     try:
         expected = str(quantity)
-    except (exception.NoData, exception.FileAccessError):
-        pytest.skip(f"the demo calculation contains no data for {name}")
+    except _UNAVAILABLE as error:
+        pytest.skip(f"cannot render {name} here: {type(error).__name__}")
     assert quantity.print() is None
     assert capsys.readouterr().out == expected + "\n"
 
@@ -78,8 +88,10 @@ def test_selections_reports_what_can_be_selected(name, demo_calculation):
     quantity = _resolve(demo_calculation, name)
     try:
         selections = quantity.selections()
-    except (exception.NoData, exception.FileAccessError):
-        pytest.skip(f"the demo calculation contains no data for {name}")
+    except _UNAVAILABLE as error:
+        pytest.skip(
+            f"cannot list the selections of {name} here: {type(error).__name__}"
+        )
     # NeighborList deliberately reports a flat list of atom-type pairs; every other
     # quantity maps its own name (and any further keys) to a list of choices
     assert selections

--- a/tests/calculation/test_projector.py
+++ b/tests/calculation/test_projector.py
@@ -325,6 +325,11 @@ def test_missing_orbitals_print(missing_orbitals, format_):
     assert actual == {"text/plain": "no projectors"}
 
 
+def test_print_writes_to_stdout(Sr2TiO4, capsys):
+    assert Sr2TiO4.print() is None
+    assert capsys.readouterr().out == str(Sr2TiO4) + "\n"
+
+
 def test_factory_methods(raw_data, check_factory_methods, projections):
     data = raw_data.projector("Sr2TiO4")
     parameters = {"project": {"selection": "Sr", "projections": projections}}

--- a/tests/calculation/test_run_info.py
+++ b/tests/calculation/test_run_info.py
@@ -126,6 +126,42 @@ def test_dispatcher_to_database(run_info):
     assert isinstance(result["run_info"]["default"], RunInfoModel)
 
 
+def test_print(run_info, format_):
+    actual, _ = format_(run_info)
+    reference = """\
+run info for Sr2TiO4:
+    VASP version: 99.99.99
+    ionic steps: 4
+    Fermi energy: 0.500
+    spin: nonpolarized
+    metallic: no
+    phonon dispersion: 20 q-points, 21 modes"""
+    assert actual == {"text/plain": reference}
+
+
+def test_print_omits_unknown_quantities(raw_data, format_):
+    raw_run_info = raw_data.run_info("Sr2TiO4")
+    raw_run_info.runtime = None
+    raw_run_info.phonon_dispersion = None
+    actual, _ = format_(RunInfo.from_data(raw_run_info))
+    reference = """\
+run info for Sr2TiO4:
+    ionic steps: 4
+    Fermi energy: 0.500
+    spin: nonpolarized
+    metallic: no"""
+    assert actual == {"text/plain": reference}
+
+
+def test_print_writes_to_stdout(run_info, capsys):
+    assert run_info.print() is None
+    assert capsys.readouterr().out == str(run_info) + "\n"
+
+
+def test_selections(run_info):
+    assert run_info.selections() == {"run_info": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.run_info("Sr2TiO4")
-    check_factory_methods(RunInfo, data)
+    check_factory_methods(RunInfo, data, skip_methods=["selections"])

--- a/tests/calculation/test_run_info.py
+++ b/tests/calculation/test_run_info.py
@@ -153,6 +153,28 @@ run info for Sr2TiO4:
     assert actual == {"text/plain": reference}
 
 
+@pytest.mark.parametrize(
+    "len_dos, expected",
+    [
+        (2, "    spin: collinear"),
+        (4, "    spin: noncollinear"),
+        (1, "    spin: nonpolarized"),
+    ],
+)
+def test_print_reports_the_spin_configuration(raw_data, len_dos, expected):
+    raw_run_info = raw_data.run_info("Sr2TiO4")
+    raw_run_info.len_dos = len_dos
+    assert expected in str(RunInfo.from_data(raw_run_info))
+
+
+def test_print_omits_unknown_spin_configuration(raw_data):
+    raw_run_info = raw_data.run_info("Sr2TiO4")
+    raw_run_info.len_dos = None
+    raw_run_info.band_dispersion_eigenvalues = None
+    raw_run_info.band_projections = None
+    assert "spin:" not in str(RunInfo.from_data(raw_run_info))
+
+
 def test_print_writes_to_stdout(run_info, capsys):
     assert run_info.print() is None
     assert capsys.readouterr().out == str(run_info) + "\n"

--- a/tests/calculation/test_run_info.py
+++ b/tests/calculation/test_run_info.py
@@ -167,6 +167,20 @@ def test_print_reports_the_spin_configuration(raw_data, len_dos, expected):
     assert expected in str(RunInfo.from_data(raw_run_info))
 
 
+@pytest.mark.parametrize(
+    "known_field", ("band_dispersion_eigenvalues", "band_projections")
+)
+def test_print_omits_half_known_spin_configuration(raw_data, known_field):
+    # without a DOS the two flags fall back to different fields, so one of them may be
+    # False while the other is simply unknown; that is not enough to claim nonpolarized
+    raw_run_info = raw_data.run_info("Sr2TiO4")
+    raw_run_info.len_dos = None
+    for field in ("band_dispersion_eigenvalues", "band_projections"):
+        if field != known_field:
+            setattr(raw_run_info, field, None)
+    assert "spin:" not in str(RunInfo.from_data(raw_run_info))
+
+
 def test_print_omits_unknown_spin_configuration(raw_data):
     raw_run_info = raw_data.run_info("Sr2TiO4")
     raw_run_info.len_dos = None

--- a/tests/calculation/test_stoichiometry.py
+++ b/tests/calculation/test_stoichiometry.py
@@ -86,6 +86,14 @@ class Base:
         actual, _ = format_(self.stoichiometry)
         assert actual == self.format_output
 
+    def test_print_writes_to_stdout(self, capsys):
+        assert self.stoichiometry.print() is None
+        assert capsys.readouterr().out == str(self.stoichiometry) + "\n"
+
+    def test_selections(self):
+        expected = {"stoichiometry": ["default", "phonon", "exciton"]}
+        assert self.stoichiometry.selections() == expected
+
     def test_to_database(self):
         handler = StoichiometryHandler.from_data(self.raw_stoichiometry)
         db_data: StoichiometryModel = handler.to_database()
@@ -260,7 +268,7 @@ def test_ion_types_not_required(method, raw_data):
 
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.stoichiometry("Sr2TiO4")
-    check_factory_methods(Stoichiometry, data, skip_methods=["to_mdtraj"])
+    check_factory_methods(Stoichiometry, data, skip_methods=["to_mdtraj", "selections"])
 
 
 def test_stoichiometry_not_collected_standalone(raw_data):

--- a/tests/calculation/test_stress.py
+++ b/tests/calculation/test_stress.py
@@ -125,6 +125,15 @@ def test_to_database(stresses, Assert):
     Assert.allclose(db_data.final_stress_tensor, reduced_final_tensor)
 
 
+def test_print_writes_to_stdout(Sr2TiO4, capsys):
+    assert Sr2TiO4.print() is None
+    assert capsys.readouterr().out == str(Sr2TiO4) + "\n"
+
+
+def test_selections(Sr2TiO4):
+    assert Sr2TiO4.selections() == {"stress": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.stress("Sr2TiO4")
-    check_factory_methods(Stress, data)
+    check_factory_methods(Stress, data, skip_methods=["selections"])

--- a/tests/calculation/test_structure.py
+++ b/tests/calculation/test_structure.py
@@ -666,12 +666,26 @@ def test_to_database_collects_available_sources(tmp_path):
     assert result["structure"]["final"].num_ions == 7
 
 
+def test_print_writes_to_stdout(Sr2TiO4, capsys):
+    assert Sr2TiO4.print() is None
+    assert capsys.readouterr().out == str(Sr2TiO4) + "\n"
+
+
+def test_selections(Sr2TiO4):
+    assert Sr2TiO4.selections() == {
+        "structure": ["default", "final", "exciton", "poscar"]
+    }
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.structure("Sr2TiO4")
     parameters = {"__getitem__": {"steps": slice(None)}}
     # the Sr2TiO4 trajectory carries no symmetry, so the symmetry-derived methods
     # raise NoData; they are exercised on the perovskite fixture instead
+    # the schema-only selections never opens the data file, so it cannot satisfy the
+    # single-access-per-method contract that check_factory_methods verifies
     skip_methods = [
+        "selections",
         "equivalent_atoms",
         "wyckoff_positions",
         "standardized_cell",

--- a/tests/calculation/test_symmetry.py
+++ b/tests/calculation/test_symmetry.py
@@ -222,6 +222,15 @@ def test_to_database_dispatcher(symmetry):
     assert result["symmetry"]["default"] == expected
 
 
+def test_print_writes_to_stdout(symmetry, capsys):
+    assert symmetry.print() is None
+    assert capsys.readouterr().out == str(symmetry) + "\n"
+
+
+def test_selections(symmetry):
+    assert symmetry.selections() == {"symmetry": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     raw_symmetry = raw_data.symmetry("CoO")
-    check_factory_methods(Symmetry, raw_symmetry)
+    check_factory_methods(Symmetry, raw_symmetry, skip_methods=["selections"])

--- a/tests/calculation/test_system.py
+++ b/tests/calculation/test_system.py
@@ -48,5 +48,15 @@ def check_system_print(raw_system, format_):
     assert actual["text/plain"] == text_to_string(raw_system.system)
 
 
+def test_print_writes_to_stdout(string_format, capsys):
+    system = System.from_data(string_format)
+    assert system.print() is None
+    assert capsys.readouterr().out == str(system) + "\n"
+
+
+def test_selections(string_format):
+    assert System.from_data(string_format).selections() == {"system": ["default"]}
+
+
 def test_factory_methods(string_format, check_factory_methods):
-    check_factory_methods(System, string_format)
+    check_factory_methods(System, string_format, skip_methods=["selections"])

--- a/tests/calculation/test_velocity.py
+++ b/tests/calculation/test_velocity.py
@@ -142,6 +142,15 @@ def test_to_database(velocities):
     assert db_data.initial_index_velocity_max == int(np.argmax(initial_norms))
 
 
+def test_print_writes_to_stdout(Sr2TiO4, capsys):
+    assert Sr2TiO4.print() is None
+    assert capsys.readouterr().out == str(Sr2TiO4) + "\n"
+
+
+def test_selections(Sr2TiO4):
+    assert Sr2TiO4.selections() == {"velocity": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     data = raw_data.velocity("Fe3O4")
-    check_factory_methods(Velocity, data)
+    check_factory_methods(Velocity, data, skip_methods=["selections"])

--- a/tests/calculation/test_workfunction.py
+++ b/tests/calculation/test_workfunction.py
@@ -99,6 +99,15 @@ def test_to_database(raw_data):
     assert actual == expected
 
 
+def test_print_writes_to_stdout(workfunction, capsys):
+    assert workfunction.print() is None
+    assert capsys.readouterr().out == str(workfunction) + "\n"
+
+
+def test_selections(workfunction):
+    assert workfunction.selections() == {"workfunction": ["default"]}
+
+
 def test_factory_methods(raw_data, check_factory_methods):
     raw_workfunction = raw_data.workfunction("1")
-    check_factory_methods(Workfunction, raw_workfunction)
+    check_factory_methods(Workfunction, raw_workfunction, skip_methods=["selections"])


### PR DESCRIPTION
## Summary

With the last public release py4vasp still used a base class, `base.Refinery`, to
give every quantity a uniform public surface. The architecture migration (#295)
replaced that inheritance with composition — a public dispatcher plus a private
handler per quantity, wired by the `@quantity` decorator. The decorator injects
`from_path`, `from_file`, `__repr__`, `_path` and `is_available`, but four of
Refinery's methods had no new home, so each dispatcher was supposed to declare
them by hand and most never did:

| method every Refinery had | before | after |
| --- | --- | --- |
| `print()` | 0 / 45 | 45 / 45 |
| `selections()` | 16 / 45 | 45 / 45 |
| public `path` property | 6 / 45 | 45 / 45 |
| `_repr_pretty_` | 41 / 45 | 45 / 45 |
| `__str__` | 44 / 45 | 45 / 45 |

`to_string` and the graph/view mixin methods (`plot`, `to_plotly`, `to_csv`,
`to_image`, `to_frame`, `to_view`, `to_ngl`, `to_vasp_viewer`) are **not**
affected — they are present wherever `to_graph`/`to_view` is, exactly as before.

There is one commit per quantity class, so any single class can be reviewed or
reverted on its own.

## The printed text is unchanged

To confirm the migration had not quietly altered the output too, the
pre-migration code was checked out at `4f74fe0c` and its `__str__` run over its
own `_demo` data, then diffed against this branch:

- 35 quantities byte-identical
- 4 identical in format, only the demo numbers drifted (`effective_coulomb`,
  `electron_phonon.chemical_potential`, `electronic_minimization`,
  `workfunction`) — confirmed by masking every numeral and re-diffing
- `system` verified separately on a live demo calculation
- `neighbor_list`, `optics`, `symmetry` are post-migration additions with no old
  reference

So the per-class tests assert `print()` against the `__str__` text each file
already pins, rather than duplicating 45 reference strings.

## Bugs found along the way

- **`PairCorrelation` printed an object repr.** Its `__str__` dispatched to
  `PairCorrelationHandler.__str__`, which the handler never defined, so
  `object.__str__` ran and printing leaked
  `<PairCorrelationHandler object at 0x…>`. It now reports the distance range,
  the number of sample points and the selectable atom pairs, in the style of `Dos`.
- **`RunInfo` had no `__str__` at all.** It now reports the metadata it already
  collects — VASP version, ionic steps, Fermi energy, spin, whether the system is
  metallic, phonon dispersion size — omitting whatever VASP did not write.
  Writing its test also surfaced that `read()` raised `AttributeError` for a
  calculation without phonons.
- **`str(calculation.electron_phonon.bandgap)` raised.** `__len__` compared the
  raw scattering approximations against `"SERTA"` directly; numpy reads an empty
  dataset as an empty float array, which has no comparison loop against a
  string, so `len()`/`str()`/`print()` raised `_UFuncNoLoopError` on any
  calculation without electron-phonon data.
- **`CONTCAR` could not resolve its own schema entry.** Its constructor default
  for `quantity_name` kept the registry key's leading underscore while
  `@quantity` sets the stripped name, so
  `CONTCAR.from_path(...).read(selection="CONTCAR")` raised `FileAccessError`.

`BornEffectiveCharge`, `ForceConstant` and `InternalStrain` carried
`_repr_pretty_` only on their handlers. Their tests built the handler, which is
precisely why the public classes having no Jupyter representation went
unnoticed; those tests now exercise the dispatcher.

## Also fixed, found while reviewing this branch

- **`Energy.selections()` reported no sources and `LocalMoment.selections()`
  reported none at all** — the same regression class as the rest of this PR.
  Their tests hid it: `test_energy` discarded the value with `pop("energy")`,
  and the matching `pop("local_moment")` had been deleted from
  `test_local_moment` during the migration, so the test encoded the regressed
  shape. Both now assert the sources.
- **`electron_phonon.transport.selections()` raised a bare `IndexError`** on any
  calculation without transport data. In py4vasp a non-`Py4VaspError` means
  "report a bug"; it now reports `NoData` like its siblings.
- **`RunInfo` claimed `spin: nonpolarized` when it only knew half the spin
  state.** `is_collinear` and `is_noncollinear` fall back to different raw
  fields, so a run without a DOS can resolve one to `False` while the other
  stays unknown. Either being unknown now omits the line.

## Preventing a repeat

`tests/calculation/test_print.py` sweeps the registry: every dispatcher must
declare `print`, `__str__`, `_repr_pretty_` and `selections`; `__str__` must
accept the optional `selection` that `print` forwards; and both `print()` and
`selections()` are actually called for every quantity of a demo calculation —
checking mere existence is what let the `selections` bodies above ship broken.
Verified to fail by temporarily deleting `Dos.print`.

`docs/architecture/calculation.rst` gains the matching section — its dispatcher
responsibilities never mentioned these methods, which is how they came to be
dropped.

## Design note

`print`, `selections` and `_repr_pretty_` are written out in each of the 45
dispatchers rather than injected centrally, so every class declares its own
public surface; the registry-wide test keeps them honest. The public `path`
property is the one exception — a pure alias of the already-injected `_path`, so
it lives in the decorator, and the six hand-written duplicates were removed.

## Testing

`3925 passed, 151 skipped, 2 xfailed`. The three failures in
`packages/py4vasp/tests/test_metapackage.py` are pre-existing and environmental
(this checkout's venv has `py4vasp` 0.11.2 installed rather than the
`py4vasp-core` distribution the workspace split introduced); they fail
identically at `745b32ba`.