### PR TITLE
Test: add the simulate-user-py4vasp validation gate

### DIFF
--- a/.claude/skills/plan-py4vasp/SKILL.md
+++ b/.claude/skills/plan-py4vasp/SKILL.md
@@ -153,6 +153,13 @@ rather than discovering them mid-implementation:
   in the test, as existing tests do. Note it on the chunk.
 - **Docs.** New public methods usually need adding to the relevant file under
   `docs/`; fold it into the chunk that introduces the method.
+- **A user-interface change owes user-facing documentation.** A new public method
+  or CLI command will be validated by **simulate-user-py4vasp** before it can be
+  pushed: a subagent that may read only the documentation has to work out how to
+  use it. So the chunk that introduces the method carries its documentation — not
+  just its docstring — and `--help` text that stands on its own. Plan the wording
+  of the tolerances, units and conventions the user must know; that is where such
+  a change usually fails.
 
 ## Out of scope for this skill
 

--- a/.claude/skills/push-py4vasp/SKILL.md
+++ b/.claude/skills/push-py4vasp/SKILL.md
@@ -25,13 +25,14 @@ python .claude/skills/push-py4vasp/push_prep.py
 ```
 
 It prints: changed files split into **CODE** (`*.py` under `src/` or `tests/`) vs
-non-code (docs/CI/tooling); whether a review is required; a suggested branch
-name; the PR compare URL; and a draft PR message. Read this first — it drives
-every decision below.
+non-code (docs/CI/tooling); whether a review is required; whether a **user
+simulation** is required (and why); a suggested branch name; the PR compare URL;
+and a draft PR message. Read this first — it drives every decision below.
 
 ## Step 1 — review gate (only if CODE changed)
 
-If the driver reports **no** code changes (only docs/CI/tooling), skip to Step 3.
+If the driver reports **no** code changes (only docs/CI/tooling), skip to Step 2 —
+a docs change still faces the user simulation gate.
 
 If code changed, a py4vasp review must exist for this diff:
 - If you already ran `/review-py4vasp` on this diff earlier in the session and
@@ -45,13 +46,35 @@ If code changed, a py4vasp review must exist for this diff:
 Then **address the findings** — fix the code, or record why a finding is a
 non-issue. Re-run the affected tests (see `/review-py4vasp` for the invocation).
 
-## Step 2 — confirm (hard stop before publishing)
+## Step 2 — user simulation gate (only if the user interface changed)
+
+If the driver reports `USER SIMULATION REQUIRED: NO`, skip to Step 3.
+
+Otherwise somebody who may read only the documentation must have tried this diff.
+The internal gates cannot see a feature that works perfectly and cannot be found,
+or one whose defaults quietly produce the wrong physics:
+
+- If you already ran `/simulate-user-py4vasp` for this diff earlier in the session
+  and its blockers were addressed, skip re-running it.
+- If you **cannot tell** whether a simulation was done, ask the user before
+  dispatching.
+- Otherwise follow the `/simulate-user-py4vasp` skill — it writes the premise and
+  dispatches the subagent itself. Do not hand-roll the dispatch, and **never run it
+  from plan mode** (the subagent inherits plan mode and cannot write an input file,
+  which silently removes most of the surface a user touches).
+
+Then act on the report: blockers and documentation gaps are fixed before the push;
+a documentation gap larger than this change is recorded in `backlog/` as a short
+markdown file; annoyances go into the PR message so the human reviewer inherits
+them.
+
+## Step 3 — confirm (hard stop before publishing)
 
 STOP and ask the user to confirm before formatting and pushing. Pushing
 publishes the branch to `origin` (`vasp-dev/py4vasp`) — do not proceed without
 an explicit go-ahead.
 
-## Step 3 — format
+## Step 4 — format
 
 Apply the project's formatters to `src` and `tests` (no-op if pre-commit already
 ran):
@@ -75,7 +98,7 @@ If either step changed files, commit that:
 git commit -am "Apply black and isort"
 ```
 
-## Step 4 — branch + push
+## Step 5 — branch + push
 
 Create a **fresh descriptive** branch (start from the driver's suggestion, refine
 if it misses the point), then push it and set upstream:
@@ -88,7 +111,7 @@ git switch -c feat/<descriptive-name>
 git push -u origin feat/<descriptive-name>
 ```
 
-## Step 5 — PR link + message
+## Step 6 — PR link + message
 
 Give the user the compare URL and the draft message from Step 0 (the driver
 already built both, using the real branch name if you kept its suggestion — else
@@ -109,10 +132,12 @@ Present the draft PR message in a copy-paste block.
 - **`gh` is not installed** here (only `glab`). Do not reach for `gh pr create`;
   hand over the constructed compare URL instead — the driver builds it from
   `remote.origin.url`.
-- **Non-code = review-skipped, but still formatted + pushed.** A docs/CI/tooling
-  change goes straight from Step 0 to Step 3.
+- **Non-code = review-skipped, but not necessarily gate-free.** A CI/tooling
+  change goes straight from Step 0 to Step 4. A **docs** change skips the code
+  review yet still requires the user simulation — the documentation is precisely
+  what that gate reads.
 - **The driver is read-only.** `push_prep.py` never pushes, commits, or edits;
-  re-run it freely. The only publishing action is `git push` in Step 4.
+  re-run it freely. The only publishing action is `git push` in Step 5.
 - **Worktree note:** run inside the worktree you actually changed; the driver
   reports the checkout path so you can confirm.
 

--- a/.claude/skills/push-py4vasp/push_prep.py
+++ b/.claude/skills/push-py4vasp/push_prep.py
@@ -10,6 +10,8 @@ It prints the decisions the push workflow needs:
   1. Changed files, classified into CODE (*.py under src/ or tests/) vs
      non-code (docs / CI / tooling).
   2. Whether a code review is required (any code changes present).
+  3. Whether a user simulation is required (the diff touches the user
+     interface: a public method of a quantity class, the CLI, or docs/).
   3. A suggested descriptive branch name derived from the commit subjects.
   4. The GitHub PR "compare" URL for origin.
   5. A draft PR message (title + summary bullets) to copy/paste.
@@ -57,6 +59,32 @@ def classify(files):
     for f in files:
         (code if is_code(f) else noncode).append(f)
     return code, noncode
+
+
+def public_methods_in_diff(root, base):
+    """Public methods whose signature is added or changed under _calculation."""
+    diff = git(root, "diff", "-U0", base, "HEAD", "--", "src/py4vasp/_calculation")
+    diff += "\n" + git(root, "diff", "-U0", "--", "src/py4vasp/_calculation")
+    diff += "\n" + git(root, "diff", "-U0", "--cached", "--", "src/py4vasp/_calculation")
+    methods, path = {}, None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[len("+++ b/") :]
+        elif path and (match := re.match(r"[+-]\s+def ([a-z][A-Za-z0-9_]*)\(", line)):
+            methods.setdefault(path, set()).add(match.group(1))
+    return {path: sorted(names) for path, names in methods.items()}
+
+
+def user_interface_reasons(root, base, files):
+    """Why a user simulation is required; an empty list means it is not."""
+    reasons = []
+    if "src/py4vasp/cli.py" in files:
+        reasons.append("src/py4vasp/cli.py changed - the command line interface")
+    if documentation := [f for f in files if f.startswith("docs/")]:
+        reasons.append(f"documentation changed - {', '.join(documentation)}")
+    for path, names in public_methods_in_diff(root, base).items():
+        reasons.append(f"public method(s) in {path} - {', '.join(names)}")
+    return reasons
 
 
 def commit_subjects(root, base):
@@ -123,15 +151,25 @@ def main():
     else:
         print("NO - only docs/CI/tooling changed. Skip the review; go straight to push.")
 
-    print("\n" + "=" * 60 + "\n3. SUGGESTED BRANCH NAME\n" + "=" * 60)
+    print("\n" + "=" * 60 + "\n3. USER SIMULATION REQUIRED?\n" + "=" * 60)
+    reasons = user_interface_reasons(root, base, files)
+    if reasons:
+        print("USER SIMULATION REQUIRED: YES - the diff touches the user interface:")
+        print(*("\n  " + reason for reason in reasons))
+        print("\nDispatch /simulate-user-py4vasp to a subagent unless a simulation was")
+        print("already run for this diff (ask the user if unsure). NOT from plan mode.")
+    else:
+        print("USER SIMULATION REQUIRED: NO - no public method, CLI, or docs change.")
+
+    print("\n" + "=" * 60 + "\n4. SUGGESTED BRANCH NAME\n" + "=" * 60)
     print(f"  {branch}")
     print("  (Derive a fresh descriptive name; refine this if it misses the point.)")
 
-    print("\n" + "=" * 60 + "\n4. PR COMPARE URL (origin)\n" + "=" * 60)
+    print("\n" + "=" * 60 + "\n5. PR COMPARE URL (origin)\n" + "=" * 60)
     print(f"  {compare_url}")
     print("  (Replace the branch segment if you push under a different name.)")
 
-    print("\n" + "=" * 60 + "\n5. DRAFT PR MESSAGE\n" + "=" * 60)
+    print("\n" + "=" * 60 + "\n6. DRAFT PR MESSAGE\n" + "=" * 60)
     title = subjects[0] if subjects else branch
     print(f"Title: {title}\n")
     print("## Summary")

--- a/.claude/skills/simulate-user-py4vasp/SKILL.md
+++ b/.claude/skills/simulate-user-py4vasp/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: simulate-user-py4vasp
+description: >-
+  Validate a py4vasp change from the outside by dispatching a subagent to
+  role-play a user who may read only the documentation, never the source. Use
+  before pushing or opening a MR for anything that touches the user interface —
+  a public method of a quantity class, a CLI command, or the docs — and whenever
+  asked to "simulate a user", "test this like a user would", or "check the
+  usability" of a py4vasp feature. Returns ranked findings, a verdict on whether
+  a documentation-only user can succeed, and the agent's confessions.
+---
+
+# Simulating a py4vasp user
+
+`plan-py4vasp`, `tdd-py4vasp` and `review-py4vasp` all judge a change from the
+**inside**: code, tests, coverage, house rules. A change can pass every one of
+them and still be unusable, because none of them asks the only question a user
+asks — *can I work out how to do this from the documentation?*
+
+This skill answers that by dispatching a subagent that role-plays a user with
+**no access to the source**. It is a validation gate, not an exploration: you
+write the premise, dispatch it, verify it stayed inside the rules, and act on
+what it reports. All paths are relative to the repo/worktree root.
+
+## When it is required
+
+Whenever the diff touches the **user interface**:
+
+- a public method (no leading underscore) added to or changed on a quantity class
+  under `src/py4vasp/_calculation/`
+- any change to `src/py4vasp/cli.py`
+- any change under `docs/`
+
+A change confined to private helpers, the raw schema, the demo data or the tests
+does not need it. `push-py4vasp` treats this as a blocking gate and its driver
+prints `USER SIMULATION REQUIRED: YES/NO`, so the decision is a fact rather than
+a judgement.
+
+## Step 0 — do NOT run this from plan mode
+
+**Check first.** A subagent inherits plan mode from the session that dispatches
+it, and a simulated user in plan mode cannot write a POSCAR, cannot use
+`-o/--output`, and cannot read an input file from disk — i.e. it cannot exercise
+the surface a real user touches most. In the trial run that produced this skill
+the agent tried to work around the restriction with a process substitution, which
+is not something any user would do, and the resulting traceback leaked source
+code to it.
+
+If plan mode is on, say so and stop. Run the simulation from normal mode.
+
+## Step 1 — write the premise (without naming the API)
+
+The agent must *discover* the feature, because discoverability is the thing under
+test. Give it exactly what a colleague would have said in one sentence — the
+capability, never the command or method names:
+
+> A colleague mentioned that the latest py4vasp can **create KPOINTS files for
+> you** — both for a band structure along the high-symmetry path and for a regular
+> k-mesh — and that it works from the command line as well as from Python.
+
+Derive that sentence from the MR description, not from the diff. If you catch
+yourself writing `generate_kpath`, delete it.
+
+## Step 2 — dispatch
+
+Use the **Agent** tool with `subagent_type: general-purpose` and the default
+model. Never `fork`: a fork inherits your context, which contains the
+implementation, and the whole exercise collapses. Capability is not what makes a
+simulation unrealistic — *access* is — so do not reach for a weaker model either;
+a capable agent constrained to the documentation writes a far more useful report.
+
+The prompt must contain all six blocks below. Copy them; the wording matters.
+
+**1. The persona.** A computational materials scientist who runs VASP, comfortable
+with the shell and Python, has never seen py4vasp's source and never will. Then
+the premise from Step 1.
+
+**2. The isolation contract.** Allowed, because it is what a real user has:
+`py4vasp --help` and every subcommand's `--help`; `help(obj)` and `obj?` at the
+Python prompt (docstrings *are* user-facing documentation); the sources under
+`docs/`; `README.md`. Forbidden: any file under `src/` or `tests/`; git history,
+diffs, commit messages, branch names; `.claude/`; any plan, issue or notes file.
+And the clause that matters, because this is how leaks actually happen: *if a tool
+result shows you source code — a traceback will — stop reading it and write that
+down in your report.*
+
+**3. Behave like a person, not an agent.** A handful of actions in a natural
+order. No enumerating the package, no reverse-engineering intent from the
+repository. **When the documentation does not answer a question, that is a finding
+to report — not a puzzle to solve by digging.**
+
+**4. The environment.** py4vasp is usually a development checkout here, so spell
+out the invocation and tell the agent to treat it as the real command:
+
+```bash
+export PYTHONPATH=<checkout>/src
+PY=<path to the venv>/bin/python
+$PY -m py4vasp --help          # the command line interface
+$PY -c "import py4vasp; ..."   # the Python interface
+```
+
+Give it a working directory of its own (`/tmp/.../user-trial-<feature>`),
+**explicitly grant it permission to write files there**, and forbid modifying
+anything in the checkout.
+
+**5. The task.** Work out from the documentation how to use the feature and note
+what had to be guessed; write your own input file and use the feature on it; do
+whatever you would normally do to convince yourself the result is right, and say
+whether you *could*; make one or two mistakes a real user plausibly makes and see
+whether the message tells you what to fix; try both interfaces if both exist.
+
+**6. The deliverable.** Five sections, in this order:
+
+- **A. Narrative** — what you did, in order, with the exact commands, including
+  the dead ends.
+- **B. Findings** — each with the command, what you expected, what happened, and
+  what would have helped; ranked *would have stopped me* versus *annoying*;
+  documentation gaps are first-class findings; and for each, **would an ordinary
+  user have noticed this at all?**
+- **C. Verdict** — can a user who only reads the documentation succeed? yes /
+  partly / no, and why.
+- **D. Documentation trail** — every source consulted, in order, and whether it
+  helped.
+- **E. Confessions** — anything you did that a real user could not; any rule you
+  broke; **any false alarm you raised and then retracted**; and every moment you
+  wanted to read the source, and what question drove the urge.
+
+Close with: *do not soften the report to be agreeable; blunt is useful.*
+
+Sections B-"ordinary user", D and E are what turn a report into evidence. The
+trial run's most valuable line was the agent volunteering that an ordinary user
+would *not* have caught its own worst finding, because the only symptom was a
+space-group label nobody checks by eye. D localises the documentation gap to the
+exact channel. E is where the leaked traceback got reported.
+
+## Step 3 — verify the isolation held
+
+Trust the agent, then check. The Agent tool returns an `output_file` — the full
+JSONL transcript. **Do not read it**; it runs to hundreds of KB. Grep the tool
+*inputs* only:
+
+```bash
+grep -o -E '"name":"(Bash|Read|Grep|Glob)","input":\{"[a-z_]+":"[^"]{0,120}' "$TRANSCRIPT" \
+  | grep -o -E '(src/py4vasp/[A-Za-z_./]+|tests/[A-Za-z_./]+|git (log|diff|show|blame))' \
+  | sort | uniq -c
+```
+
+Two traps, both of which caught me while building this:
+
+- The pattern must include the `py4vasp/` segment. A bare `src` also matches the
+  `PYTHONPATH` you supplied yourself, which is legitimate and appears in every
+  command the agent runs.
+- A source path in a tool **result** is a leak, not a violation. Only inputs
+  count. `docs/` hits are expected and fine.
+
+A non-empty result invalidates the run: the findings may come from reading the
+implementation rather than the documentation. Re-dispatch a fresh agent.
+
+## Step 4 — act on the findings
+
+Present the report to the user and classify with them:
+
+- **Blockers** — anything that stopped the simulated user, and anything that
+  produced a silently wrong result. These are fixed before the MR.
+- **Documentation gaps** — fixed before the MR, or, if the gap is bigger than the
+  change (a missing reference page for a whole interface, say), recorded in
+  `backlog/` as a short markdown file.
+- **Annoyances** — fixed if cheap, otherwise recorded in the PR message so the
+  human reviewer inherits them rather than rediscovering them.
+
+Never fix a finding by editing only the report's wording. If the answer is "the
+user should have known", the documentation is the thing that failed.
+
+## Gotchas
+
+- **Plan mode cripples it.** See Step 0. This is the single most likely way to
+  waste a run.
+- **`fork` defeats it.** The fork knows the implementation. Always
+  `general-purpose`.
+- **Naming the API in the premise** removes the discoverability test, which is
+  usually where the real findings are.
+- **A stale installed py4vasp hides the feature.** If the environment has an old
+  release installed, the agent tests *that* and reports the feature as missing.
+  Always pass an explicit `PYTHONPATH` and, if in doubt, have it print
+  `py4vasp.__file__` first.
+- **Docstrings count as documentation.** Do not forbid `help()` — it is exactly
+  what a notebook user reads. What is forbidden is opening the file that contains
+  the docstring.
+- **`dir()` / tab-completion is a grey zone.** The trial agent used it to find a
+  method the docs never mention, and flagged that as borderline itself. Allow it,
+  and treat "I only found this by tab-completion" as a documentation finding.
+- **Budget.** Expect roughly 25-30 tool calls, ~80 k tokens and a few minutes for
+  a two-command feature. Cheap next to the MR it validates.
+
+## Human path
+
+There is no app to launch — this is a workflow skill. The human equivalent is
+handing the branch to a colleague who has not read the code, with the MR summary
+and nothing else, and asking them to use the feature and say where they got
+stuck.


### PR DESCRIPTION
`plan-py4vasp`, `tdd-py4vasp` and `review-py4vasp` all judge a change from the inside —
code, tests, coverage, house rules. Nothing asks whether somebody who only reads the
documentation can use the result.

This adds `simulate-user-py4vasp`: a subagent role-plays a py4vasp user with no access
to the source, and reports where it got stuck. `push-py4vasp` gains a blocking gate
(Step 2) for any diff that touches a public method of a quantity class, `cli.py`, or
`docs/`, and `push_prep.py` decides that as a fact — `USER SIMULATION REQUIRED: YES/NO`
with the reasons — rather than a judgement.

Its substance is what two trial runs on the KPOINTS branch taught: never dispatch from
plan mode (the subagent inherits it, cannot write an input file, and starts inventing
shell tricks no user would); never use `fork` (it inherits the implementation); never
name the API in the premise, because discoverability is the thing under test; ask which
findings an ordinary user would have missed, and ask for retracted false alarms. Plus a
transcript grep that verifies the isolation held, with the two traps that caught me
while writing it.

On the KPOINTS branch it found a silently wrong space group, a `-o` path that hid the
very check the help tells you to make, three raw tracebacks, and an error message
advising a Python argument no CLI flag exposed. None of those were visible to the three
existing gates.